### PR TITLE
VCST-1630: add change cart items quantity command

### DIFF
--- a/src/VirtoCommerce.XCart.Core/Commands/ChangeCartItemsQuantityCommand.cs
+++ b/src/VirtoCommerce.XCart.Core/Commands/ChangeCartItemsQuantityCommand.cs
@@ -1,0 +1,11 @@
+using System.Collections.Generic;
+using VirtoCommerce.XCart.Core.Commands.BaseCommands;
+using VirtoCommerce.XCart.Core.Models;
+
+namespace VirtoCommerce.XCart.Core.Commands
+{
+    public class ChangeCartItemsQuantityCommand : CartCommand
+    {
+        public IList<CartItemQuantity> CartItems { get; set; } = new List<CartItemQuantity>();
+    }
+}

--- a/src/VirtoCommerce.XCart.Core/Models/CartItemQuantity.cs
+++ b/src/VirtoCommerce.XCart.Core/Models/CartItemQuantity.cs
@@ -1,0 +1,8 @@
+namespace VirtoCommerce.XCart.Core.Models
+{
+    public class CartItemQuantity
+    {
+        public string LineItemId { get; set; }
+        public int Quantity { get; set; }
+    }
+}

--- a/src/VirtoCommerce.XCart.Core/Schemas/InputCartItemQuantityType.cs
+++ b/src/VirtoCommerce.XCart.Core/Schemas/InputCartItemQuantityType.cs
@@ -1,0 +1,14 @@
+using GraphQL.Types;
+using VirtoCommerce.XCart.Core.Models;
+
+namespace VirtoCommerce.XCart.Core.Schemas
+{
+    public class InputCartItemQuantityType : InputObjectGraphType<CartItemQuantity>
+    {
+        public InputCartItemQuantityType()
+        {
+            Field(x => x.LineItemId, nullable: false).Description("Line item Id");
+            Field(x => x.Quantity, nullable: false).Description("New quantity");
+        }
+    }
+}

--- a/src/VirtoCommerce.XCart.Core/Schemas/InputChangeCartItemsQuantityType.cs
+++ b/src/VirtoCommerce.XCart.Core/Schemas/InputChangeCartItemsQuantityType.cs
@@ -1,0 +1,12 @@
+using GraphQL.Types;
+
+namespace VirtoCommerce.XCart.Core.Schemas
+{
+    public class InputChangeCartItemsQuantityType : InputCartBaseType
+    {
+        public InputChangeCartItemsQuantityType()
+        {
+            Field<NonNullGraphType<ListGraphType<InputCartItemQuantityType>>>("cartItems", "Cart items");
+        }
+    }
+}

--- a/src/VirtoCommerce.XCart.Data/Commands/ChangeCartItemsQuantityCommandHandler.cs
+++ b/src/VirtoCommerce.XCart.Data/Commands/ChangeCartItemsQuantityCommandHandler.cs
@@ -1,0 +1,68 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using VirtoCommerce.XCart.Core;
+using VirtoCommerce.XCart.Core.Commands;
+using VirtoCommerce.XCart.Core.Commands.BaseCommands;
+using VirtoCommerce.XCart.Core.Models;
+using VirtoCommerce.XCart.Core.Services;
+
+namespace VirtoCommerce.XCart.Data.Commands
+{
+    public class ChangeCartItemsQuantityCommandHandler : CartCommandHandler<ChangeCartItemsQuantityCommand>
+    {
+        readonly ICartProductService _cartProductService;
+
+        public ChangeCartItemsQuantityCommandHandler(ICartAggregateRepository cartAggregateRepository, ICartProductService cartProductService)
+            : base(cartAggregateRepository)
+        {
+            _cartProductService = cartProductService;
+        }
+
+        public async override Task<CartAggregate> Handle(ChangeCartItemsQuantityCommand request, CancellationToken cancellationToken)
+        {
+            var cartAggregate = await GetOrCreateCartFromCommandAsync(request);
+
+            var requestItems = request.CartItems.ToList();
+            foreach (var requestItem in request.CartItems.Where(x => x.Quantity == 0))
+            {
+                await cartAggregate.RemoveItemAsync(requestItem.LineItemId);
+                requestItems.Remove(requestItem);
+            }
+
+            var quantityAdjustments = new List<ItemQtyAdjustment>();
+            foreach (var requestItem in requestItems)
+            {
+                var lineItem = cartAggregate.Cart.Items.FirstOrDefault(x => x.Id.Equals(requestItem.LineItemId));
+                if (lineItem != null)
+                {
+                    quantityAdjustments.Add(new ItemQtyAdjustment
+                    {
+                        LineItem = lineItem,
+                        LineItemId = requestItem.LineItemId,
+                        NewQuantity = requestItem.Quantity
+                    });
+                }
+            }
+
+            // load products for line items
+            var productIds = quantityAdjustments.Select(x => x.LineItem.ProductId).ToArray();
+            var productsByIds =
+                (await _cartProductService.GetCartProductsByIdsAsync(cartAggregate, productIds))
+                .ToDictionary(x => x.Id);
+
+            foreach (var adjustment in quantityAdjustments)
+            {
+                if (productsByIds.TryGetValue(adjustment.LineItem.ProductId, out var product))
+                {
+                    adjustment.CartProduct = product;
+
+                    await cartAggregate.ChangeItemQuantityAsync(adjustment);
+                }
+            }
+
+            return await SaveCartAsync(cartAggregate);
+        }
+    }
+}


### PR DESCRIPTION
## Description
```js
mutation changeCartItemsQuantity($command: InputChangeCartItemsQuantityType!) {
  changeCartItemsQuantity(command: $command)
  {
        id
        name
        items {
          id
          name
          quantity
      }
  }
}
```
---
```json
{
    "command": {
        "storeId": "B2B-store",
        "cartId": "123",
        "userId": "456",
        "cartItems": [
            {
                "lineItemId": "78f1b42f-2377-4612-9bb7-84ea3f058cb6",
                "quantity": 5
            },
            {
                "lineItemId": "93eb8c29-0344-40a1-b0f1-8b9e4c4b38c6",
                "quantity": 0
            },
            {
                "lineItemId": "b64f9f1c-2bef-486f-a509-4efe1d9b140c",
                "quantity": 3
            }
        ]
    }
}
```


## References
### QA-test:
### Jira-link:


https://virtocommerce.atlassian.net/browse/VCST-1630
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.XCart_3.804.0-pr-6-ec0a.zip