### PR TITLE
Calculate cart totals before promotion evaluation

### DIFF
--- a/src/VirtoCommerce.XCart.Core/CartAggregate.cs
+++ b/src/VirtoCommerce.XCart.Core/CartAggregate.cs
@@ -804,6 +804,8 @@ namespace VirtoCommerce.XCart.Core
 
             await UpdateOrganizationName();
 
+            _cartTotalsCalculator.CalculateTotals(Cart);
+
             var promotionEvalResult = await EvaluatePromotionsAsync();
             await this.ApplyRewardsAsync(promotionEvalResult.Rewards);
 

--- a/tests/VirtoCommerce.XCart.Tests/Aggregates/CartAggregateTests.cs
+++ b/tests/VirtoCommerce.XCart.Tests/Aggregates/CartAggregateTests.cs
@@ -820,7 +820,7 @@ namespace VirtoCommerce.XCart.Tests.Aggregates
             var result = await cartAggregate.RecalculateAsync();
 
             // Assert
-            _shoppingCartTotalsCalculatorMock.Verify(x => x.CalculateTotals(It.Is<ShoppingCart>(x => x == cartAggregate.Cart)), Times.Once);
+            _shoppingCartTotalsCalculatorMock.Verify(x => x.CalculateTotals(It.Is<ShoppingCart>(x => x == cartAggregate.Cart)), Times.Exactly(2));
         }
 
         #endregion RecalculateAsync


### PR DESCRIPTION
## Description
In case if present discounts based on the cart total - for example, offering a 10% discount on carts with a total over $1000.

Previously, if a user added a new item that brought the cart total over $1000, the discount evaluation would still reference the previous total, which was under $1000. As a result, the discount would not be re-evaluated and applied upon saving.

## References
### QA-test:
### Jira-link:
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.XCart_3.813.0-pr-18-58d7.zip