### PR TITLE
VCST-2653: enable extended address models mapping via Automapper

### DIFF
--- a/src/VirtoCommerce.XCart.Data/Mapping/CartMappingProfile.cs
+++ b/src/VirtoCommerce.XCart.Data/Mapping/CartMappingProfile.cs
@@ -24,7 +24,7 @@ namespace VirtoCommerce.XCart.Data.Mapping
     {
         public CartMappingProfile()
         {
-            CreateMap<CartModule.Core.Model.Address, TaxModule.Core.Model.Address>();
+            CreateMap<CartModule.Core.Model.Address, TaxModule.Core.Model.Address>().IncludeAllDerived();
 
             CreateMap<GiftReward, GiftItem>();
             CreateMap<GiftItem, LineItem>();
@@ -306,7 +306,8 @@ namespace VirtoCommerce.XCart.Data.Mapping
 
                     if (shipment.DeliveryAddress != null)
                     {
-                        taxEvalcontext.Address = context.Mapper.Map<TaxModule.Core.Model.Address>(shipment.DeliveryAddress);
+                        var taxAddress = AbstractTypeFactory<TaxModule.Core.Model.Address>.TryCreateInstance();
+                        taxEvalcontext.Address = context.Mapper.Map(shipment.DeliveryAddress, taxAddress);
                     }
                 }
 

--- a/tests/VirtoCommerce.XCart.Tests/Mappers/CartMappingProfileTests.cs
+++ b/tests/VirtoCommerce.XCart.Tests/Mappers/CartMappingProfileTests.cs
@@ -1,0 +1,79 @@
+using AutoMapper;
+using FluentAssertions;
+using VirtoCommerce.XCart.Data.Mapping;
+using Xunit;
+using CartAddress = VirtoCommerce.CartModule.Core.Model.Address;
+using TaxAddress = VirtoCommerce.TaxModule.Core.Model.Address;
+
+namespace VirtoCommerce.XCart.Tests.Mappers;
+
+public class CartMappingProfileTests
+{
+    private readonly IMapper _mapper;
+
+    public CartMappingProfileTests()
+    {
+        var configuration = new MapperConfiguration(cfg =>
+        {
+            cfg.AddProfile<CartMappingProfile>();
+            cfg.AddProfile<CartTestDerivedMappingProfile>();
+        });
+
+        _mapper = configuration.CreateMapper();
+    }
+
+    [Fact]
+    public void MappingProfile_Should_ConvertAddresses()
+    {
+        // Arrange
+        var cartAddress = new CartAddress()
+        {
+            Name = nameof(CartAddress),
+        };
+
+        var taxAddress = new TaxAddress();
+
+        // Act
+        _mapper.Map(cartAddress, taxAddress);
+
+        // Assert
+        taxAddress.Name.Should().Be(nameof(CartAddress));
+    }
+
+    [Fact]
+    public void MappingProfile_Should_ConvertExtendedAddresses()
+    {
+        // Arrange
+        var cartAddress = new CartAddress2()
+        {
+            Name = nameof(CartAddress),
+            Extension = nameof(CartAddress2),
+        };
+
+        var taxAddress = new TaxAddress2();
+
+        // Act
+        _mapper.Map((CartAddress)cartAddress, taxAddress);
+
+        // Assert
+        taxAddress.Extension.Should().Be(nameof(CartAddress2));
+    }
+}
+
+public class CartAddress2 : CartAddress
+{
+    public string Extension { get; set; }
+}
+
+public class TaxAddress2 : TaxAddress
+{
+    public string Extension { get; set; }
+}
+
+public class CartTestDerivedMappingProfile : Profile
+{
+    public CartTestDerivedMappingProfile()
+    {
+        CreateMap<CartAddress2, TaxAddress2>();
+    }
+}


### PR DESCRIPTION
## Description
Enables mappings between extended Tax Address and Cart Address models. 

Both Tax Address and Cart Address overrides need to be registered via AbstractTypeFactory:
```c#
  AbstractTypeFactory<CartAddress>.OverrideType<CartAddress, CartAddress2>();
  AbstractTypeFactory<TaxAddress>.OverrideType<TaxAddress, TaxAddress2>();
```

Then create your own mapping profile between these two models:
```c#
public class ExtensionMappingProfile : Profile
  {
      public ExtensionMappingProfile()
      {
          CreateMap<CartAddress2, TaxAddress2>();
      }
  }
```

Don't forget to register your mapping profile. When using `builder.AddSchema(serviceCollection, typeof(AssemblyMarker))` 
XAPI registration method the profile will be registered automatically.


## References
### QA-test:
### Jira-link:

https://virtocommerce.atlassian.net/browse/VCST-2653
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.XCart_3.902.0-pr-32-1a57.zip