### PR TITLE
VCST-3003: Adding items to cart in bulk goes wrong with duplicate item code from different catalog

### DIFF
--- a/src/VirtoCommerce.XCart.Data/Commands/AddCartItemsBulkCommandHandler.cs
+++ b/src/VirtoCommerce.XCart.Data/Commands/AddCartItemsBulkCommandHandler.cs
@@ -96,14 +96,6 @@ namespace VirtoCommerce.XCart.Data.Commands
         {
             var productSkus = request.CartItems.Select(x => x.ProductSku).ToList();
 
-            var searchCriteria = new ProductIndexedSearchCriteria
-            {
-                StoreId = request.StoreId,
-                Terms = [new TermFilter { FieldName = "code", Values = productSkus }.ToString()],
-                SearchInVariations = true,
-                ResponseGroup = ItemResponseGroup.ItemInfo.ToString(),
-            };
-
             long totalCount;
             var result = new List<CatalogProduct>();
 
@@ -114,6 +106,7 @@ namespace VirtoCommerce.XCart.Data.Commands
                 Terms = [new TermFilter { FieldName = "code", Values = productSkus }.ToString()],
                 SearchInVariations = true,
                 ResponseGroup = ItemResponseGroup.ItemInfo.ToString(),
+                Take = 20
             };
 
             do


### PR DESCRIPTION
## Description
fix: Resolves adding items to cart in bulk going wrong with duplicate item code from the different catalog. Update product search to use the indexed search service. Refactor `AddCartItemsBulkCommandHandler.cs` to replace the standard product search service with an indexed search service.


## References
### QA-test:
### Jira-link:

https://virtocommerce.atlassian.net/browse/VCST-3003
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.XCart_3.908.0-pr-43-e5ec.zip