### PR TITLE
VCST-3284: Make ConfiguredLineItemContainer methods virtual

### DIFF
--- a/src/VirtoCommerce.XCart.Core/ConfiguredLineItemContainer.cs
+++ b/src/VirtoCommerce.XCart.Core/ConfiguredLineItemContainer.cs
@@ -24,7 +24,7 @@ namespace VirtoCommerce.XCart.Core
 
         private readonly List<SectionLineItem> _items = [];
 
-        public LineItem CreateLineItem(CartProduct cartProduct, int quantity)
+        public virtual LineItem CreateLineItem(CartProduct cartProduct, int quantity)
         {
             var lineItem = AbstractTypeFactory<LineItem>.TryCreateInstance();
             lineItem.ProductId = cartProduct.Id;
@@ -56,7 +56,7 @@ namespace VirtoCommerce.XCart.Core
             return lineItem;
         }
 
-        public void AddProductSectionLineItem(CartProduct cartProduct, int quantity, string sectionId)
+        public virtual void AddProductSectionLineItem(CartProduct cartProduct, int quantity, string sectionId)
         {
             var lineItem = CreateLineItem(cartProduct, quantity);
 
@@ -68,7 +68,7 @@ namespace VirtoCommerce.XCart.Core
             });
         }
 
-        public void AddTextSectionLIneItem(string customText, string sectionId)
+        public virtual void AddTextSectionLineItem(string customText, string sectionId)
         {
             _items.Add(new SectionLineItem
             {
@@ -78,7 +78,7 @@ namespace VirtoCommerce.XCart.Core
             });
         }
 
-        public void AddFileSectionLineItem(IList<ConfigurationItemFile> files, string sectionId)
+        public virtual void AddFileSectionLineItem(IList<ConfigurationItemFile> files, string sectionId)
         {
             _items.Add(new SectionLineItem
             {
@@ -88,7 +88,7 @@ namespace VirtoCommerce.XCart.Core
             });
         }
 
-        public ExpConfigurationLineItem CreateConfiguredLineItem(int quantity)
+        public virtual ExpConfigurationLineItem CreateConfiguredLineItem(int quantity)
         {
             var lineItem = AbstractTypeFactory<LineItem>.TryCreateInstance();
 
@@ -153,7 +153,7 @@ namespace VirtoCommerce.XCart.Core
             };
         }
 
-        public void UpdatePrice(LineItem lineItem)
+        public virtual void UpdatePrice(LineItem lineItem)
         {
             var configurableProductPrice = ConfigurableProduct.Price ?? new Xapi.Core.Models.ProductPrice(Currency);
             var items = _items.Where(x => x.Item != null).Select(x => x.Item).ToArray();
@@ -165,7 +165,7 @@ namespace VirtoCommerce.XCart.Core
             lineItem.ExtendedPrice = lineItem.PlacedPrice * lineItem.Quantity;
         }
 
-        public CartProductsRequest GetCartProductsRequest()
+        public virtual CartProductsRequest GetCartProductsRequest()
         {
             var request = AbstractTypeFactory<CartProductsRequest>.TryCreateInstance();
 

--- a/src/VirtoCommerce.XCart.Data/Commands/ChangeCartCurrencyCommandHandler.cs
+++ b/src/VirtoCommerce.XCart.Data/Commands/ChangeCartCurrencyCommandHandler.cs
@@ -133,7 +133,7 @@ namespace VirtoCommerce.XCart.Data.Commands
                     }
                     else if (configurationItem.Type == ConfigurationSectionTypeText)
                     {
-                        container.AddTextSectionLIneItem(configurationItem.CustomText, configurationItem.SectionId);
+                        container.AddTextSectionLineItem(configurationItem.CustomText, configurationItem.SectionId);
                     }
                     else if (configurationItem.Type == ConfigurationSectionTypeFile)
                     {

--- a/src/VirtoCommerce.XCart.Data/Commands/CreateConfiguredLineItemHandler.cs
+++ b/src/VirtoCommerce.XCart.Data/Commands/CreateConfiguredLineItemHandler.cs
@@ -8,6 +8,7 @@ using VirtoCommerce.CartModule.Core.Model;
 using VirtoCommerce.FileExperienceApi.Core.Extensions;
 using VirtoCommerce.FileExperienceApi.Core.Services;
 using VirtoCommerce.Platform.Core.Common;
+using VirtoCommerce.XCart.Core;
 using VirtoCommerce.XCart.Core.Commands;
 using VirtoCommerce.XCart.Core.Extensions;
 using VirtoCommerce.XCart.Core.Models;
@@ -67,7 +68,7 @@ public class CreateConfiguredLineItemHandler : IRequestHandler<CreateConfiguredL
             }
             else if (section.Type == ConfigurationSectionTypeText)
             {
-                container.AddTextSectionLIneItem(section.CustomText, section.SectionId);
+                container.AddTextSectionLineItem(section.CustomText, section.SectionId);
             }
             else if (section.Type == ConfigurationSectionTypeFile)
             {

--- a/src/VirtoCommerce.XCart.Data/Services/ConfiguredLineItemContainerService.cs
+++ b/src/VirtoCommerce.XCart.Data/Services/ConfiguredLineItemContainerService.cs
@@ -27,7 +27,7 @@ public class ConfiguredLineItemContainerService : IConfiguredLineItemContainerSe
         _storeService = storeService;
     }
 
-    public async Task<ConfiguredLineItemContainer> CreateContainerAsync(ICartProductContainerRequest request)
+    public virtual async Task<ConfiguredLineItemContainer> CreateContainerAsync(ICartProductContainerRequest request)
     {
         var storeLoadTask = _storeService.GetByIdAsync(request.StoreId);
         var allCurrenciesLoadTask = _currencyService.GetAllCurrenciesAsync();


### PR DESCRIPTION
## Description
1. Made ConfiguredLineItemContainer methods virtual
2. Made ConfiguredLineItemContainerService methods virtual
3. Fixed some naming in ConfiguredLineItemContainer 

ConfiguredLineItemContainer is created by AbstractTypeFactory. To register your implementation of ConfiguredLineItemContainer use OverrideType method: 

```cs
    public class Module : IModule
    {
        public void PostInitialize(IApplicationBuilder appBuilder)
        {
            //...
            AbstractTypeFactory<ConfiguredLineItemContainer>.OverrideType<ConfiguredLineItemContainer, ConfiguredLineItemContainerExtension>();
            //...
        }
    }
```

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-3284
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.XCart_3.914.0-pr-49-7875.zip