### PR TITLE
VCST-3577: GetShortCart Query Unexpectedly Creates a New Cart

### DIFF
--- a/src/VirtoCommerce.XCart.Data/Queries/GetCartQueryBuilder.cs
+++ b/src/VirtoCommerce.XCart.Data/Queries/GetCartQueryBuilder.cs
@@ -3,12 +3,10 @@ using GraphQL;
 using MediatR;
 using Microsoft.AspNetCore.Authorization;
 using VirtoCommerce.CoreModule.Core.Currency;
-using VirtoCommerce.Platform.Core.Common;
 using VirtoCommerce.Xapi.Core.BaseQueries;
 using VirtoCommerce.Xapi.Core.Extensions;
 using VirtoCommerce.Xapi.Core.Services;
 using VirtoCommerce.XCart.Core;
-using VirtoCommerce.XCart.Core.Commands;
 using VirtoCommerce.XCart.Core.Queries;
 using VirtoCommerce.XCart.Core.Schemas;
 using VirtoCommerce.XCart.Data.Authorization;
@@ -58,11 +56,6 @@ namespace VirtoCommerce.XCart.Data.Queries
             else if (string.IsNullOrEmpty(request.CartId))
             {
                 await Authorize(context, request.UserId, cartAuthorizationRequirement);
-
-                var createCartCommand = AbstractTypeFactory<CreateCartCommand>.TryCreateInstance();
-                createCartCommand.CopyFrom(request);
-
-                response = await _mediator.Send(createCartCommand);
             }
 
             return response;
@@ -70,7 +63,10 @@ namespace VirtoCommerce.XCart.Data.Queries
 
         protected override Task AfterMediatorSend(IResolveFieldContext<object> context, GetCartQuery request, CartAggregate response)
         {
-            context.SetExpandedObjectGraph(response);
+            if (response != null)
+            {
+                context.SetExpandedObjectGraph(response);
+            }
             return Task.CompletedTask;
         }
 

--- a/src/VirtoCommerce.XCart.Data/Queries/GetCartQueryBuilder.cs
+++ b/src/VirtoCommerce.XCart.Data/Queries/GetCartQueryBuilder.cs
@@ -17,7 +17,6 @@ namespace VirtoCommerce.XCart.Data.Queries
     {
         protected override string Name => "cart";
 
-        private readonly IMediator _mediator;
         private readonly ICurrencyService _currencyService;
         private readonly IUserManagerCore _userManagerCore;
 
@@ -28,7 +27,6 @@ namespace VirtoCommerce.XCart.Data.Queries
             IUserManagerCore userManagerCore)
             : base(mediator, authorizationService)
         {
-            _mediator = mediator;
             _currencyService = currencyService;
             _userManagerCore = userManagerCore;
         }


### PR DESCRIPTION
## Description
fix: GetShortCart should only read data. If the cart does not exist, it should return null or a controlled response without creating or modifying data.

## References
### QA-test:
### Jira-link:


https://virtocommerce.atlassian.net/browse/VCST-3577
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.XCart_3.925.0-pr-62-a6c7.zip