### PR TITLE
VCST-3681: Fix Object reference not set to an instance of an object

### DIFF
--- a/src/VirtoCommerce.XCart.Core/ConfiguredLineItemContainer.cs
+++ b/src/VirtoCommerce.XCart.Core/ConfiguredLineItemContainer.cs
@@ -155,7 +155,7 @@ namespace VirtoCommerce.XCart.Core
 
         public virtual void UpdatePrice(LineItem lineItem)
         {
-            var configurableProductPrice = ConfigurableProduct.Price ?? new Xapi.Core.Models.ProductPrice(Currency);
+            var configurableProductPrice = ConfigurableProduct?.Price ?? new Xapi.Core.Models.ProductPrice(Currency);
             var items = _items.Where(x => x.Item != null).Select(x => x.Item).ToArray();
 
             lineItem.ListPrice = items.Sum(x => x.ListPrice * x.Quantity) + configurableProductPrice.ListPrice.Amount;


### PR DESCRIPTION
## Description
fix: Object reference not set to an instance of an object in cart if Configurable product was removed from catalog.

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-3681
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.XCart_3.927.0-pr-66-d475.zip