### PR TITLE
adding validation on the ShipmentMethodCode

### DIFF
--- a/src/VirtoCommerce.XCart.Core/Validators/CartShipmentValidator.cs
+++ b/src/VirtoCommerce.XCart.Core/Validators/CartShipmentValidator.cs
@@ -1,6 +1,7 @@
 using System.Linq;
 using FluentValidation;
 using VirtoCommerce.Platform.Core.Common;
+using VirtoCommerce.XCart.Core.Models;
 
 namespace VirtoCommerce.XCart.Core.Validators
 {
@@ -11,6 +12,11 @@ namespace VirtoCommerce.XCart.Core.Validators
             //To support the use case for partial shipment update when user sets the address first.
             RuleFor(x => x).Custom((shipmentContext, context) =>
             {
+                if (string.IsNullOrWhiteSpace(shipmentContext.Shipment.ShipmentMethodCode))
+                {
+                    context.AddFailure(new CartValidationError(shipmentContext.Shipment, "ShipmentMethodCode is Mandatory", "SHIPMENT_METHOD_CODE_IS_MANDATORY"));
+                    return;
+                }
                 var availShippingRates = shipmentContext.AvailShippingRates;
                 var shipment = shipmentContext.Shipment;
                 if (availShippingRates != null && !string.IsNullOrEmpty(shipment.ShipmentMethodCode))


### PR DESCRIPTION
## Description
adding validation on the ShipmentMethodCode to be mandatory sent.

## Issue
On the AddOrUpdateCartShipment mutaion, if the ShipmentMethodCode is not sent, a new shipment with null ShipmentMethodCode is being created which causes a lot of issues.
