### PR TITLE
VCST-3755: Update VirtoCommerce.Cart module version to 3.833.0

### DIFF
--- a/src/VirtoCommerce.XCart.Core/VirtoCommerce.XCart.Core.csproj
+++ b/src/VirtoCommerce.XCart.Core/VirtoCommerce.XCart.Core.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="FluentValidation" Version="11.10.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
     <PackageReference Include="VirtoCommerce.CatalogModule.Core" Version="3.868.0" />
-    <PackageReference Include="VirtoCommerce.CartModule.Core" Version="3.832.0" />
+    <PackageReference Include="VirtoCommerce.CartModule.Core" Version="3.833.0" />
     <PackageReference Include="VirtoCommerce.FileExperienceApi.Core" Version="3.904.0" />
     <PackageReference Include="VirtoCommerce.InventoryModule.Core" Version="3.805.0" />
     <PackageReference Include="VirtoCommerce.MarketingModule.Core" Version="3.820.0" />

--- a/src/VirtoCommerce.XCart.Web/module.manifest
+++ b/src/VirtoCommerce.XCart.Web/module.manifest
@@ -7,7 +7,7 @@
   <platformVersion>3.889.0</platformVersion>
   <dependencies>
     <dependency id="VirtoCommerce.Catalog" version="3.868.0" />
-    <dependency id="VirtoCommerce.Cart" version="3.832.0" />
+    <dependency id="VirtoCommerce.Cart" version="3.833.0" />
     <dependency id="VirtoCommerce.FileExperienceApi" version="3.904.0" />
     <dependency id="VirtoCommerce.Inventory" version="3.805.0" />
     <dependency id="VirtoCommerce.Marketing" version="3.820.0" />


### PR DESCRIPTION
## Description
feat: Update VirtoCommerce.Cart module version to 3.833.0

## References
### QA-test:
### Jira-link:
### Artifact URL:
