### PR TITLE
VCST-4893: Add support for payment localization

### DIFF
--- a/src/VirtoCommerce.XCart.Core/Commands/InitializeCartPaymentCommand.cs
+++ b/src/VirtoCommerce.XCart.Core/Commands/InitializeCartPaymentCommand.cs
@@ -7,4 +7,6 @@ public class InitializeCartPaymentCommand : ICommand<InitializeCartPaymentResult
 {
     public string CartId { get; set; }
     public string PaymentId { get; set; }
+    public string StoreId { get; set; }
+    public string CultureName { get; set; }
 }

--- a/src/VirtoCommerce.XCart.Core/Schemas/InputInitializeCartPaymentType.cs
+++ b/src/VirtoCommerce.XCart.Core/Schemas/InputInitializeCartPaymentType.cs
@@ -8,5 +8,7 @@ public class InputInitializeCartPaymentType : InputObjectGraphType
     {
         Field<NonNullGraphType<StringGraphType>>("cartId");
         Field<NonNullGraphType<StringGraphType>>("paymentId").Description("Payment Id");
+        Field<StringGraphType>("storeId").Description("Store Id");
+        Field<StringGraphType>("cultureName").Description("Culture name");
     }
 }

--- a/src/VirtoCommerce.XCart.Core/VirtoCommerce.XCart.Core.csproj
+++ b/src/VirtoCommerce.XCart.Core/VirtoCommerce.XCart.Core.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="VirtoCommerce.FileExperienceApi.Core" Version="3.1000.0" />
     <PackageReference Include="VirtoCommerce.InventoryModule.Core" Version="3.1000.0" />
     <PackageReference Include="VirtoCommerce.MarketingModule.Core" Version="3.1000.0" />
-    <PackageReference Include="VirtoCommerce.PaymentModule.Core" Version="3.1002.0-alpha.272-vcst-4893-payment-localization" />
+    <PackageReference Include="VirtoCommerce.PaymentModule.Core" Version="3.1002.0" />
     <PackageReference Include="VirtoCommerce.PricingModule.Core" Version="3.1000.0" />
     <PackageReference Include="VirtoCommerce.ShippingModule.Core" Version="3.1000.0" />
     <PackageReference Include="VirtoCommerce.Xapi.Core" Version="3.1001.0" />

--- a/src/VirtoCommerce.XCart.Core/VirtoCommerce.XCart.Core.csproj
+++ b/src/VirtoCommerce.XCart.Core/VirtoCommerce.XCart.Core.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="VirtoCommerce.FileExperienceApi.Core" Version="3.1000.0" />
     <PackageReference Include="VirtoCommerce.InventoryModule.Core" Version="3.1000.0" />
     <PackageReference Include="VirtoCommerce.MarketingModule.Core" Version="3.1000.0" />
-    <PackageReference Include="VirtoCommerce.PaymentModule.Core" Version="3.1000.0" />
+    <PackageReference Include="VirtoCommerce.PaymentModule.Core" Version="3.1002.0-alpha.272-vcst-4893-payment-localization" />
     <PackageReference Include="VirtoCommerce.PricingModule.Core" Version="3.1000.0" />
     <PackageReference Include="VirtoCommerce.ShippingModule.Core" Version="3.1000.0" />
     <PackageReference Include="VirtoCommerce.Xapi.Core" Version="3.1001.0" />

--- a/src/VirtoCommerce.XCart.Data/Commands/InitializeCartPaymentCommandHandler.cs
+++ b/src/VirtoCommerce.XCart.Data/Commands/InitializeCartPaymentCommandHandler.cs
@@ -69,7 +69,7 @@ public class InitializeCartPaymentCommandHandler(
         result.Store = cart.Store;
         result.CultureName = !string.IsNullOrEmpty(request.CultureName)
             ? request.CultureName
-            : cart.Cart.LanguageCode;
+            : cart.Store?.DefaultLanguage;
         result.Parameters = new()
         {
             ["CartId"] = request.CartId,

--- a/src/VirtoCommerce.XCart.Data/Commands/InitializeCartPaymentCommandHandler.cs
+++ b/src/VirtoCommerce.XCart.Data/Commands/InitializeCartPaymentCommandHandler.cs
@@ -28,6 +28,12 @@ public class InitializeCartPaymentCommandHandler(
             throw new InvalidOperationException($"Cart '{request.CartId}' not found ");
         }
 
+        if (!string.IsNullOrEmpty(request.StoreId) &&
+            !string.Equals(request.StoreId, cart.Store?.Id, StringComparison.OrdinalIgnoreCase))
+        {
+            throw new InvalidOperationException($"Store '{request.StoreId}' does not match cart store '{cart.Store?.Id}'.");
+        }
+
         var payment = cart.Cart.Payments.FirstOrDefault(x => x.Id == request.PaymentId);
 
         if (payment == null)
@@ -61,6 +67,9 @@ public class InitializeCartPaymentCommandHandler(
         result.PaymentId = payment.Id;
         result.StoreId = cart.Store.Id;
         result.Store = cart.Store;
+        result.CultureName = !string.IsNullOrEmpty(request.CultureName)
+            ? request.CultureName
+            : cart.Store?.DefaultLanguage;
         result.Parameters = new()
         {
             ["CartId"] = request.CartId,

--- a/src/VirtoCommerce.XCart.Data/Commands/InitializeCartPaymentCommandHandler.cs
+++ b/src/VirtoCommerce.XCart.Data/Commands/InitializeCartPaymentCommandHandler.cs
@@ -69,7 +69,7 @@ public class InitializeCartPaymentCommandHandler(
         result.Store = cart.Store;
         result.CultureName = !string.IsNullOrEmpty(request.CultureName)
             ? request.CultureName
-            : cart.Store?.DefaultLanguage;
+            : cart.Cart.LanguageCode;
         result.Parameters = new()
         {
             ["CartId"] = request.CartId,

--- a/src/VirtoCommerce.XCart.Web/module.manifest
+++ b/src/VirtoCommerce.XCart.Web/module.manifest
@@ -11,7 +11,7 @@
     <dependency id="VirtoCommerce.FileExperienceApi" version="3.1000.0" />
     <dependency id="VirtoCommerce.Inventory" version="3.1000.0" />
     <dependency id="VirtoCommerce.Marketing" version="3.1000.0" />
-    <dependency id="VirtoCommerce.Payment" version="3.1002.0-alpha.272-vcst-4893-payment-localization" />
+    <dependency id="VirtoCommerce.Payment" version="3.1002.0" />
     <dependency id="VirtoCommerce.Pricing" version="3.1000.0" />
     <dependency id="VirtoCommerce.Shipping" version="3.1000.0" />
     <dependency id="VirtoCommerce.Xapi" version="3.1001.0" />

--- a/src/VirtoCommerce.XCart.Web/module.manifest
+++ b/src/VirtoCommerce.XCart.Web/module.manifest
@@ -11,7 +11,7 @@
     <dependency id="VirtoCommerce.FileExperienceApi" version="3.1000.0" />
     <dependency id="VirtoCommerce.Inventory" version="3.1000.0" />
     <dependency id="VirtoCommerce.Marketing" version="3.1000.0" />
-    <dependency id="VirtoCommerce.Payment" version="3.1000.0" />
+    <dependency id="VirtoCommerce.Payment" version="3.1002.0-alpha.272-vcst-4893-payment-localization" />
     <dependency id="VirtoCommerce.Pricing" version="3.1000.0" />
     <dependency id="VirtoCommerce.Shipping" version="3.1000.0" />
     <dependency id="VirtoCommerce.Xapi" version="3.1001.0" />


### PR DESCRIPTION
## Description
feat: Adds support for payment localisation

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-4893
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.XCart_3.1006.0-pr-108-4629.zip

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the `initializeCartPayment` mutation contract and request handling by adding store/culture inputs, which can alter payment initialization behavior and introduce new validation failures for existing clients.
> 
> **Overview**
> Adds optional `storeId` and `cultureName` inputs to the `initializeCartPayment` GraphQL mutation/command to support localized payment initialization.
> 
> The handler now validates an explicitly provided `storeId` against the cart’s store and forwards `CultureName` (falling back to the store default language) into `ProcessPaymentRequest` so payment providers can localize their flows.
> 
> Bumps the Payment module dependency to `3.1002.0` in both the core project and module manifest.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4629f132d0e96d8f8ef607bdfbe113910151549a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->