### PR TITLE
Feat/cart aggregate validation

### DIFF
--- a/src/VirtoCommerce.XCart.Core/CartAggregate.cs
+++ b/src/VirtoCommerce.XCart.Core/CartAggregate.cs
@@ -187,6 +187,15 @@ namespace VirtoCommerce.XCart.Core
         public bool IsSelectedForCheckout => Store.Settings?.GetValue<bool>(XCartSetting.IsSelectedForCheckout) ?? true;
 
         /// <summary>
+        /// Clears all cached validation results. Called after saving the cart
+        /// so the mutation response and subsequent queries re-validate against the updated state.
+        /// </summary>
+        public void ClearValidationCache()
+        {
+            ValidationErrorsByRuleSet.Clear();
+        }
+
+        /// <summary>
         /// Returns all cached validation errors across all rulesets that have been validated,
         /// combined with <see cref="OperationValidationErrors"/>. Does not trigger validation.
         /// </summary>

--- a/src/VirtoCommerce.XCart.Core/CartAggregate.cs
+++ b/src/VirtoCommerce.XCart.Core/CartAggregate.cs
@@ -56,6 +56,7 @@ namespace VirtoCommerce.XCart.Core
         private readonly IConfigurationItemValidator _configurationItemValidator;
         private readonly IFileUploadService _fileUploadService;
         private readonly ICartSharingService _cartSharingService;
+        private readonly ICartValidationContextFactory _cartValidationContextFactory;
 
         private const char RuleSetSeparator = ',';
 
@@ -70,7 +71,8 @@ namespace VirtoCommerce.XCart.Core
             IGenericPipelineLauncher pipeline,
             IConfigurationItemValidator configurationItemValidator,
             IFileUploadService fileUploadService,
-            ICartSharingService cartSharingService)
+            ICartSharingService cartSharingService,
+            ICartValidationContextFactory cartValidationContextFactory)
         {
             _cartTotalsCalculator = cartTotalsCalculator;
             _marketingEvaluator = marketingEvaluator;
@@ -83,6 +85,7 @@ namespace VirtoCommerce.XCart.Core
             _configurationItemValidator = configurationItemValidator;
             _fileUploadService = fileUploadService;
             _cartSharingService = cartSharingService;
+            _cartValidationContextFactory = cartValidationContextFactory;
         }
 
         public Store Store { get; protected set; }
@@ -847,6 +850,36 @@ namespace VirtoCommerce.XCart.Core
         /// per ruleSet in <see cref="ValidationErrorsByRuleSet"/> — subsequent calls with the same
         /// ruleSet return cached results without re-running validation.
         /// </summary>
+        public virtual async Task<IList<ValidationFailure>> ValidateAsync(string ruleSet)
+        {
+            var key = NormalizeRuleSet(ruleSet);
+
+            if (ValidationErrorsByRuleSet.TryGetValue(key, out var cached))
+            {
+                return cached;
+            }
+
+            if (_cartValidationContextFactory == null)
+            {
+                throw new InvalidOperationException(
+                    $"Cannot validate: {nameof(ICartValidationContextFactory)} is not available. " +
+                    $"Use the {nameof(CartAggregate)} constructor that accepts it.");
+            }
+
+            EnsureCartExists();
+
+            var validationContext = await _cartValidationContextFactory.CreateValidationContextAsync(this);
+            validationContext.CartAggregate = this;
+
+            var rules = ruleSet?.Split(RuleSetSeparator, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+            var result = await AbstractTypeFactory<CartValidator>.TryCreateInstance().ValidateAsync(validationContext, options => options.IncludeRuleSets(rules));
+
+            ValidationErrorsByRuleSet[key] = result.Errors;
+
+            return result.Errors;
+        }
+
+        [Obsolete("Use ValidateAsync(string ruleSet). The context is now created internally.", DiagnosticId = "VC0009", UrlFormat = "https://docs.virtocommerce.org/products/products-virto3-versions/")]
         public virtual async Task<IList<ValidationFailure>> ValidateAsync(CartValidationContext validationContext, string ruleSet)
         {
             ArgumentNullException.ThrowIfNull(validationContext);
@@ -866,6 +899,9 @@ namespace VirtoCommerce.XCart.Core
             var result = await AbstractTypeFactory<CartValidator>.TryCreateInstance().ValidateAsync(validationContext, options => options.IncludeRuleSets(rules));
 
             ValidationErrorsByRuleSet[key] = result.Errors;
+
+            // Backward compatibility: keep obsolete properties in sync 
+            IsValidated = true;
 
             return result.Errors;
         }

--- a/src/VirtoCommerce.XCart.Core/CartAggregate.cs
+++ b/src/VirtoCommerce.XCart.Core/CartAggregate.cs
@@ -56,7 +56,6 @@ namespace VirtoCommerce.XCart.Core
         private readonly IConfigurationItemValidator _configurationItemValidator;
         private readonly IFileUploadService _fileUploadService;
         private readonly ICartSharingService _cartSharingService;
-        private readonly ICartValidationContextFactory _cartValidationContextFactory;
 
         private const char RuleSetSeparator = ',';
 
@@ -71,8 +70,7 @@ namespace VirtoCommerce.XCart.Core
             IGenericPipelineLauncher pipeline,
             IConfigurationItemValidator configurationItemValidator,
             IFileUploadService fileUploadService,
-            ICartSharingService cartSharingService,
-            ICartValidationContextFactory cartValidationContextFactory)
+            ICartSharingService cartSharingService)
         {
             _cartTotalsCalculator = cartTotalsCalculator;
             _marketingEvaluator = marketingEvaluator;
@@ -85,7 +83,6 @@ namespace VirtoCommerce.XCart.Core
             _configurationItemValidator = configurationItemValidator;
             _fileUploadService = fileUploadService;
             _cartSharingService = cartSharingService;
-            _cartValidationContextFactory = cartValidationContextFactory;
         }
 
         public Store Store { get; protected set; }
@@ -852,36 +849,6 @@ namespace VirtoCommerce.XCart.Core
         /// per ruleSet in <see cref="ValidationErrorsByRuleSet"/> — subsequent calls with the same
         /// ruleSet return cached results without re-running validation.
         /// </summary>
-        public virtual async Task<IList<ValidationFailure>> ValidateAsync(string ruleSet)
-        {
-            var key = NormalizeRuleSet(ruleSet);
-
-            if (ValidationErrorsByRuleSet.TryGetValue(key, out var cached))
-            {
-                return cached;
-            }
-
-            if (_cartValidationContextFactory == null)
-            {
-                throw new InvalidOperationException(
-                    $"Cannot validate: {nameof(ICartValidationContextFactory)} is not available. " +
-                    $"Use the {nameof(CartAggregate)} constructor that accepts it.");
-            }
-
-            EnsureCartExists();
-
-            var validationContext = await _cartValidationContextFactory.CreateValidationContextAsync(this);
-            validationContext.CartAggregate = this;
-
-            var rules = ruleSet?.Split(RuleSetSeparator, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
-            var result = await AbstractTypeFactory<CartValidator>.TryCreateInstance().ValidateAsync(validationContext, options => options.IncludeRuleSets(rules));
-
-            ValidationErrorsByRuleSet[key] = result.Errors;
-
-            return result.Errors;
-        }
-
-        [Obsolete("Use ValidateAsync(string ruleSet). The context is now created internally.", DiagnosticId = "VC0009", UrlFormat = "https://docs.virtocommerce.org/products/products-virto3-versions/")]
         public virtual async Task<IList<ValidationFailure>> ValidateAsync(CartValidationContext validationContext, string ruleSet)
         {
             ArgumentNullException.ThrowIfNull(validationContext);
@@ -893,17 +860,14 @@ namespace VirtoCommerce.XCart.Core
                 return cached;
             }
 
+            EnsureCartExists();
+
             validationContext.CartAggregate = this;
 
-            EnsureCartExists();
             var rules = ruleSet?.Split(RuleSetSeparator, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
             var result = await AbstractTypeFactory<CartValidator>.TryCreateInstance().ValidateAsync(validationContext, options => options.IncludeRuleSets(rules));
 
             ValidationErrorsByRuleSet[key] = result.Errors;
-
-            // Backward compatibility: keep obsolete properties in sync
-            CartValidationErrors = result.Errors;
-            IsValidated = true;
 
             return result.Errors;
         }

--- a/src/VirtoCommerce.XCart.Core/CartAggregate.cs
+++ b/src/VirtoCommerce.XCart.Core/CartAggregate.cs
@@ -132,7 +132,7 @@ namespace VirtoCommerce.XCart.Core
         /// FluentValidation RuleSets allow you to group validation rules together which can be executed together as a group. You can set exists rule set name to evaluate default.
         /// <see cref="CartValidator"/>
         /// </summary>
-        public string[] ValidationRuleSet { get; set; } = { "default", "strict" };
+        public string[] ValidationRuleSet { get; set; } = { ModuleConstants.ValidationRuleSets.Default, ModuleConstants.ValidationRuleSets.Strict };
 
         /// <summary>
         /// Per-ruleSet validation results cache. Populated by <see cref="ValidateAsync(CartValidationContext, string)"/>
@@ -1294,7 +1294,7 @@ namespace VirtoCommerce.XCart.Core
         {
             if (string.IsNullOrEmpty(ruleSet))
             {
-                return "default";
+                return ModuleConstants.ValidationRuleSets.Default;
             }
 
             // "*" subsumes all other rulesets — no need to split

--- a/src/VirtoCommerce.XCart.Core/CartAggregate.cs
+++ b/src/VirtoCommerce.XCart.Core/CartAggregate.cs
@@ -58,6 +58,8 @@ namespace VirtoCommerce.XCart.Core
         private readonly ICartSharingService _cartSharingService;
         private readonly ICartValidationContextFactory _cartValidationContextFactory;
 
+        private const char RuleSetSeparator = ',';
+
         [Obsolete("Use the constructor that accepts ICartValidationContextFactory.", DiagnosticId = "VC0009", UrlFormat = "https://docs.virtocommerce.org/products/products-virto3-versions/")]
         public CartAggregate(
             IMarketingPromoEvaluator marketingEvaluator,
@@ -890,7 +892,7 @@ namespace VirtoCommerce.XCart.Core
             var validationContext = await _cartValidationContextFactory.CreateValidationContextAsync(this);
             validationContext.CartAggregate = this;
 
-            var rules = ruleSet?.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+            var rules = ruleSet?.Split(RuleSetSeparator, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
             var result = await AbstractTypeFactory<CartValidator>.TryCreateInstance().ValidateAsync(validationContext, options => options.IncludeRuleSets(rules));
 
             ValidationErrorsByRuleSet[key] = result.Errors;
@@ -913,7 +915,7 @@ namespace VirtoCommerce.XCart.Core
             validationContext.CartAggregate = this;
 
             EnsureCartExists();
-            var rules = ruleSet?.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+            var rules = ruleSet?.Split(RuleSetSeparator, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
             var result = await AbstractTypeFactory<CartValidator>.TryCreateInstance().ValidateAsync(validationContext, options => options.IncludeRuleSets(rules));
 
             ValidationErrorsByRuleSet[key] = result.Errors;
@@ -1314,17 +1316,29 @@ namespace VirtoCommerce.XCart.Core
                 return "default";
             }
 
-            var parts = ruleSet.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
-
-            // "*" subsumes all other rulesets
-            if (parts.Contains("*", StringComparer.OrdinalIgnoreCase))
+            // "*" subsumes all other rulesets — no need to split
+            if (ruleSet.Contains('*'))
             {
                 return "*";
             }
 
+            // Single token (no comma): no normalization needed.
+            // The dictionary comparer is OrdinalIgnoreCase, so case collapses at lookup time.
+            if (ruleSet.IndexOf(RuleSetSeparator) < 0)
+            {
+                return ruleSet;
+            }
+
+            var parts = ruleSet.Split(RuleSetSeparator, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+
+            if (parts.Length == 1)
+            {
+                return parts[0];
+            }
+
             // Sort for consistent cache keys: "shipments,default" == "default,shipments"
             Array.Sort(parts, StringComparer.OrdinalIgnoreCase);
-            return string.Join(",", parts);
+            return string.Join(RuleSetSeparator, parts);
         }
 
         protected virtual async Task<TaxProvider> GetActiveTaxProviderAsync()

--- a/src/VirtoCommerce.XCart.Core/CartAggregate.cs
+++ b/src/VirtoCommerce.XCart.Core/CartAggregate.cs
@@ -144,10 +144,9 @@ namespace VirtoCommerce.XCart.Core
 
         public IList<ValidationFailure> OperationValidationErrors { get; protected set; } = new List<ValidationFailure>();
 
-        [Obsolete("Use GetValidationErrorsAsync(ruleSet) or ValidationErrorsByRuleSet instead.", DiagnosticId = "VC0009", UrlFormat = "https://docs.virtocommerce.org/products/products-virto3-versions/")]
-        public IList<ValidationFailure> CartValidationErrors { get; protected set; } = new List<ValidationFailure>();
+        public IList<ValidationFailure> CartValidationErrors => ValidationErrorsByRuleSet.Values.SelectMany(x => x).ToList();
 
-        [Obsolete("Use GetValidationErrorsAsync(ruleSet). The boolean flag does not track which ruleSet was validated.", DiagnosticId = "VC0009", UrlFormat = "https://docs.virtocommerce.org/products/products-virto3-versions/")]
+        [Obsolete("Use GetValidationErrorsAsync(ruleSet). The boolean flag does not track which ruleSet was validated.", DiagnosticId = "VC0015", UrlFormat = "https://docs.virtocommerce.org/products/products-virto3-versions/")]
         public bool IsValidated { get; private set; }
 
         public IList<ValidationFailure> ValidationWarnings { get; protected set; } = new List<ValidationFailure>();
@@ -181,8 +180,7 @@ namespace VirtoCommerce.XCart.Core
         /// </summary>
         public virtual IList<ValidationFailure> GetValidationErrors()
         {
-            return ValidationErrorsByRuleSet.Values
-                .SelectMany(x => x)
+            return CartValidationErrors
                 .Concat(OperationValidationErrors)
                 .ToList();
         }

--- a/src/VirtoCommerce.XCart.Core/CartAggregate.cs
+++ b/src/VirtoCommerce.XCart.Core/CartAggregate.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
@@ -55,7 +56,9 @@ namespace VirtoCommerce.XCart.Core
         private readonly IConfigurationItemValidator _configurationItemValidator;
         private readonly IFileUploadService _fileUploadService;
         private readonly ICartSharingService _cartSharingService;
+        private readonly ICartValidationContextFactory _cartValidationContextFactory;
 
+        [Obsolete("Use the constructor that accepts ICartValidationContextFactory.", DiagnosticId = "VC0009", UrlFormat = "https://docs.virtocommerce.org/products/products-virto3-versions/")]
         public CartAggregate(
             IMarketingPromoEvaluator marketingEvaluator,
             IShoppingCartTotalsCalculator cartTotalsCalculator,
@@ -68,6 +71,25 @@ namespace VirtoCommerce.XCart.Core
             IConfigurationItemValidator configurationItemValidator,
             IFileUploadService fileUploadService,
             ICartSharingService cartSharingService)
+            : this(marketingEvaluator, cartTotalsCalculator, taxProviderSearchService, cartProductService,
+                dynamicPropertyUpdaterService, mapper, memberService, pipeline,
+                configurationItemValidator, fileUploadService, cartSharingService, null)
+        {
+        }
+
+        public CartAggregate(
+            IMarketingPromoEvaluator marketingEvaluator,
+            IShoppingCartTotalsCalculator cartTotalsCalculator,
+            IOptionalDependency<ITaxProviderSearchService> taxProviderSearchService,
+            ICartProductService cartProductService,
+            IDynamicPropertyUpdaterService dynamicPropertyUpdaterService,
+            IMapper mapper,
+            IMemberService memberService,
+            IGenericPipelineLauncher pipeline,
+            IConfigurationItemValidator configurationItemValidator,
+            IFileUploadService fileUploadService,
+            ICartSharingService cartSharingService,
+            ICartValidationContextFactory cartValidationContextFactory)
         {
             _cartTotalsCalculator = cartTotalsCalculator;
             _marketingEvaluator = marketingEvaluator;
@@ -80,6 +102,7 @@ namespace VirtoCommerce.XCart.Core
             _configurationItemValidator = configurationItemValidator;
             _fileUploadService = fileUploadService;
             _cartSharingService = cartSharingService;
+            _cartValidationContextFactory = cartValidationContextFactory;
         }
 
         public Store Store { get; protected set; }
@@ -128,14 +151,23 @@ namespace VirtoCommerce.XCart.Core
         /// </summary>
         public string[] ValidationRuleSet { get; set; } = { "default", "strict" };
 
-        public bool IsValid => !GetValidationErrors().Any();
+        /// <summary>
+        /// Per-ruleSet validation results cache. Populated by <see cref="ValidateAsync(CartValidationContext, string)"/>
+        /// and <see cref="GetValidationErrorsAsync"/>. Cleared by <see cref="ClearValidationCache"/>.
+        /// </summary>
+        protected ConcurrentDictionary<string, IList<ValidationFailure>> ValidationErrorsByRuleSet { get; } = new(StringComparer.OrdinalIgnoreCase);
+
+        public bool IsValid => ValidationErrorsByRuleSet.IsEmpty || ValidationErrorsByRuleSet.Values.All(x => x.Count == 0);
 
         [Obsolete("Use GetValidationErrors().", DiagnosticId = "VC0009", UrlFormat = "https://docs.virtocommerce.org/products/products-virto3-versions/")]
         public IList<ValidationFailure> ValidationErrors { get; protected set; } = new List<ValidationFailure>();
 
         public IList<ValidationFailure> OperationValidationErrors { get; protected set; } = new List<ValidationFailure>();
+
+        [Obsolete("Use GetValidationErrorsAsync(ruleSet) or ValidationErrorsByRuleSet instead.", DiagnosticId = "VC0009", UrlFormat = "https://docs.virtocommerce.org/products/products-virto3-versions/")]
         public IList<ValidationFailure> CartValidationErrors { get; protected set; } = new List<ValidationFailure>();
 
+        [Obsolete("Use GetValidationErrorsAsync(ruleSet). The boolean flag does not track which ruleSet was validated.", DiagnosticId = "VC0009", UrlFormat = "https://docs.virtocommerce.org/products/products-virto3-versions/")]
         public bool IsValidated { get; private set; }
 
         public IList<ValidationFailure> ValidationWarnings { get; protected set; } = new List<ValidationFailure>();
@@ -154,9 +186,16 @@ namespace VirtoCommerce.XCart.Core
 
         public bool IsSelectedForCheckout => Store.Settings?.GetValue<bool>(XCartSetting.IsSelectedForCheckout) ?? true;
 
+        /// <summary>
+        /// Returns all cached validation errors across all rulesets that have been validated,
+        /// combined with <see cref="OperationValidationErrors"/>. Does not trigger validation.
+        /// </summary>
         public virtual IList<ValidationFailure> GetValidationErrors()
         {
-            return CartValidationErrors.Concat(OperationValidationErrors).ToList();
+            return ValidationErrorsByRuleSet.Values
+                .SelectMany(x => x)
+                .Concat(OperationValidationErrors)
+                .ToList();
         }
 
         public virtual CartAggregate GrabCart(ShoppingCart cart, Store store, Member member, Currency currency)
@@ -816,20 +855,64 @@ namespace VirtoCommerce.XCart.Core
             }
         }
 
+        /// <summary>
+        /// Validates the cart with the specified <paramref name="ruleSet"/>. Results are cached
+        /// per ruleSet in <see cref="ValidationErrorsByRuleSet"/> — subsequent calls with the same
+        /// ruleSet return cached results without re-running validation.
+        /// </summary>
+        public virtual async Task<IList<ValidationFailure>> ValidateAsync(string ruleSet)
+        {
+            var key = NormalizeRuleSet(ruleSet);
+
+            if (ValidationErrorsByRuleSet.TryGetValue(key, out var cached))
+            {
+                return cached;
+            }
+
+            if (_cartValidationContextFactory == null)
+            {
+                throw new InvalidOperationException(
+                    $"Cannot validate: {nameof(ICartValidationContextFactory)} is not available. " +
+                    $"Use the {nameof(CartAggregate)} constructor that accepts it.");
+            }
+
+            EnsureCartExists();
+
+            var validationContext = await _cartValidationContextFactory.CreateValidationContextAsync(this);
+            validationContext.CartAggregate = this;
+
+            var rules = ruleSet?.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+            var result = await AbstractTypeFactory<CartValidator>.TryCreateInstance().ValidateAsync(validationContext, options => options.IncludeRuleSets(rules));
+
+            ValidationErrorsByRuleSet[key] = result.Errors;
+
+            return result.Errors;
+        }
+
+        [Obsolete("Use ValidateAsync(string ruleSet). The context is now created internally.", DiagnosticId = "VC0009", UrlFormat = "https://docs.virtocommerce.org/products/products-virto3-versions/")]
         public virtual async Task<IList<ValidationFailure>> ValidateAsync(CartValidationContext validationContext, string ruleSet)
         {
             ArgumentNullException.ThrowIfNull(validationContext);
+
+            var key = NormalizeRuleSet(ruleSet);
+
+            if (ValidationErrorsByRuleSet.TryGetValue(key, out var cached))
+            {
+                return cached;
+            }
 
             validationContext.CartAggregate = this;
 
             EnsureCartExists();
             var rules = ruleSet?.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
             var result = await AbstractTypeFactory<CartValidator>.TryCreateInstance().ValidateAsync(validationContext, options => options.IncludeRuleSets(rules));
-            if (!result.IsValid)
-            {
-                CartValidationErrors = result.Errors;
-            }
+
+            ValidationErrorsByRuleSet[key] = result.Errors;
+
+            // Backward compatibility: keep obsolete properties in sync
+            CartValidationErrors = result.Errors;
             IsValidated = true;
+
             return result.Errors;
         }
 
@@ -1203,6 +1286,36 @@ namespace VirtoCommerce.XCart.Core
             {
                 throw new OperationCanceledException("Cart not loaded.");
             }
+        }
+
+        /// <summary>
+        /// Normalizes a ruleSet string into a consistent cache key for <see cref="ValidationErrorsByRuleSet"/>.
+        /// Sorts composite rulesets ("shipments,default" → "default,shipments") and collapses "*" variants.
+        /// <para>
+        /// Note: composite keys like "default,shipments" and standalone "default" are cached separately
+        /// even though the composite result is a superset. This is a deliberate design decision —
+        /// resolving subset/superset relationships between rulesets would add complexity
+        /// without meaningful performance benefit in practice.
+        /// </para>
+        /// </summary>
+        private static string NormalizeRuleSet(string ruleSet)
+        {
+            if (string.IsNullOrEmpty(ruleSet))
+            {
+                return "default";
+            }
+
+            var parts = ruleSet.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+
+            // "*" subsumes all other rulesets
+            if (parts.Contains("*", StringComparer.OrdinalIgnoreCase))
+            {
+                return "*";
+            }
+
+            // Sort for consistent cache keys: "shipments,default" == "default,shipments"
+            Array.Sort(parts, StringComparer.OrdinalIgnoreCase);
+            return string.Join(",", parts);
         }
 
         protected virtual async Task<TaxProvider> GetActiveTaxProviderAsync()

--- a/src/VirtoCommerce.XCart.Core/CartAggregate.cs
+++ b/src/VirtoCommerce.XCart.Core/CartAggregate.cs
@@ -60,25 +60,6 @@ namespace VirtoCommerce.XCart.Core
 
         private const char RuleSetSeparator = ',';
 
-        [Obsolete("Use the constructor that accepts ICartValidationContextFactory.", DiagnosticId = "VC0009", UrlFormat = "https://docs.virtocommerce.org/products/products-virto3-versions/")]
-        public CartAggregate(
-            IMarketingPromoEvaluator marketingEvaluator,
-            IShoppingCartTotalsCalculator cartTotalsCalculator,
-            IOptionalDependency<ITaxProviderSearchService> taxProviderSearchService,
-            ICartProductService cartProductService,
-            IDynamicPropertyUpdaterService dynamicPropertyUpdaterService,
-            IMapper mapper,
-            IMemberService memberService,
-            IGenericPipelineLauncher pipeline,
-            IConfigurationItemValidator configurationItemValidator,
-            IFileUploadService fileUploadService,
-            ICartSharingService cartSharingService)
-            : this(marketingEvaluator, cartTotalsCalculator, taxProviderSearchService, cartProductService,
-                dynamicPropertyUpdaterService, mapper, memberService, pipeline,
-                configurationItemValidator, fileUploadService, cartSharingService, null)
-        {
-        }
-
         public CartAggregate(
             IMarketingPromoEvaluator marketingEvaluator,
             IShoppingCartTotalsCalculator cartTotalsCalculator,

--- a/src/VirtoCommerce.XCart.Core/CartAggregate.cs
+++ b/src/VirtoCommerce.XCart.Core/CartAggregate.cs
@@ -147,7 +147,8 @@ namespace VirtoCommerce.XCart.Core
 
         public IList<ValidationFailure> OperationValidationErrors { get; protected set; } = new List<ValidationFailure>();
 
-        public IList<ValidationFailure> CartValidationErrors => ValidationErrorsByRuleSet.Values.SelectMany(x => x).ToList();
+        [Obsolete("Use GetValidationErrorsAsync(ruleSet) or ValidationErrorsByRuleSet instead. This property only contains the last ValidateAsync call's results.", DiagnosticId = "VC0015", UrlFormat = "https://docs.virtocommerce.org/products/products-virto3-versions/")]
+        public IList<ValidationFailure> CartValidationErrors { get; protected set; } = new List<ValidationFailure>();
 
         [Obsolete("Use GetValidationErrorsAsync(ruleSet). The boolean flag does not track which ruleSet was validated.", DiagnosticId = "VC0015", UrlFormat = "https://docs.virtocommerce.org/products/products-virto3-versions/")]
         public bool IsValidated { get; private set; }
@@ -175,6 +176,9 @@ namespace VirtoCommerce.XCart.Core
         public void ClearValidationCache()
         {
             ValidationErrorsByRuleSet.Clear();
+#pragma warning disable VC0015 // Obsolete: maintained for backward compatibility
+            CartValidationErrors = new List<ValidationFailure>();
+#pragma warning restore VC0015
         }
 
         /// <summary>
@@ -183,9 +187,11 @@ namespace VirtoCommerce.XCart.Core
         /// </summary>
         public virtual IList<ValidationFailure> GetValidationErrors()
         {
+#pragma warning disable VC0015 // Obsolete: maintained for backward compatibility
             return CartValidationErrors
                 .Concat(OperationValidationErrors)
                 .ToList();
+#pragma warning restore VC0015
         }
 
         public virtual CartAggregate GrabCart(ShoppingCart cart, Store store, Member member, Currency currency)
@@ -875,6 +881,9 @@ namespace VirtoCommerce.XCart.Core
             var result = await AbstractTypeFactory<CartValidator>.TryCreateInstance().ValidateAsync(validationContext, options => options.IncludeRuleSets(rules));
 
             ValidationErrorsByRuleSet[key] = result.Errors;
+#pragma warning disable VC0015 // Obsolete: maintained for backward compatibility
+            CartValidationErrors = result.Errors;
+#pragma warning restore VC0015
 
             return result.Errors;
         }
@@ -899,8 +908,9 @@ namespace VirtoCommerce.XCart.Core
             var result = await AbstractTypeFactory<CartValidator>.TryCreateInstance().ValidateAsync(validationContext, options => options.IncludeRuleSets(rules));
 
             ValidationErrorsByRuleSet[key] = result.Errors;
+            CartValidationErrors = result.Errors;
 
-            // Backward compatibility: keep obsolete properties in sync 
+            // Backward compatibility: keep obsolete flag in sync
             IsValidated = true;
 
             return result.Errors;
@@ -1891,6 +1901,9 @@ namespace VirtoCommerce.XCart.Core
             // Re-create mutable collections so the clone doesn't share references with the original.
             // MemberwiseClone copies references — writes/clears on one instance would leak to the other.
             result.ValidationErrorsByRuleSet = new ConcurrentDictionary<string, IList<ValidationFailure>>(ValidationErrorsByRuleSet, StringComparer.OrdinalIgnoreCase);
+#pragma warning disable VC0015 // Obsolete: maintained for backward compatibility
+            result.CartValidationErrors = new List<ValidationFailure>(CartValidationErrors);
+#pragma warning restore VC0015
             result.OperationValidationErrors = new List<ValidationFailure>(OperationValidationErrors);
             result.ValidationWarnings = new List<ValidationFailure>(ValidationWarnings);
 

--- a/src/VirtoCommerce.XCart.Core/CartAggregate.cs
+++ b/src/VirtoCommerce.XCart.Core/CartAggregate.cs
@@ -155,7 +155,7 @@ namespace VirtoCommerce.XCart.Core
         /// Per-ruleSet validation results cache. Populated by <see cref="ValidateAsync(CartValidationContext, string)"/>
         /// and <see cref="GetValidationErrorsAsync"/>. Cleared by <see cref="ClearValidationCache"/>.
         /// </summary>
-        protected ConcurrentDictionary<string, IList<ValidationFailure>> ValidationErrorsByRuleSet { get; } = new(StringComparer.OrdinalIgnoreCase);
+        protected ConcurrentDictionary<string, IList<ValidationFailure>> ValidationErrorsByRuleSet { get; private set; } = new(StringComparer.OrdinalIgnoreCase);
 
         public bool IsValid => ValidationErrorsByRuleSet.IsEmpty || ValidationErrorsByRuleSet.Values.All(x => x.Count == 0);
 
@@ -1894,6 +1894,12 @@ namespace VirtoCommerce.XCart.Core
             result.Currency = Currency.CloneTyped();
             result.Member = Member?.CloneTyped();
             result.Store = Store.CloneTyped();
+
+            // Re-create mutable collections so the clone doesn't share references with the original.
+            // MemberwiseClone copies references — writes/clears on one instance would leak to the other.
+            result.ValidationErrorsByRuleSet = new ConcurrentDictionary<string, IList<ValidationFailure>>(ValidationErrorsByRuleSet, StringComparer.OrdinalIgnoreCase);
+            result.OperationValidationErrors = new List<ValidationFailure>(OperationValidationErrors);
+            result.ValidationWarnings = new List<ValidationFailure>(ValidationWarnings);
 
             return result;
         }

--- a/src/VirtoCommerce.XCart.Core/ModuleConstants.cs
+++ b/src/VirtoCommerce.XCart.Core/ModuleConstants.cs
@@ -24,6 +24,17 @@ namespace VirtoCommerce.XCart.Core
 
         public const int LineItemQualityLimit = 999999;
 
+        public static class ValidationRuleSets
+        {
+            public const string Default = "default";
+            public const string Strict = "strict";
+            public const string Items = "items";
+            public const string Shipments = "shipments";
+            public const string Payments = "payments";
+            public const string OrderCreate = "orderCreate";
+            public const string All = "*";
+        }
+
         public static class Settings
         {
             public static class General

--- a/src/VirtoCommerce.XCart.Core/Schemas/CartType.cs
+++ b/src/VirtoCommerce.XCart.Core/Schemas/CartType.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Linq;
 using GraphQL;
 using GraphQL.Types;
@@ -12,21 +11,11 @@ using VirtoCommerce.XCart.Core.Extensions;
 using VirtoCommerce.XCart.Core.Models;
 using VirtoCommerce.XCart.Core.Services;
 using VirtoCommerce.XCart.Core.Specifications;
-using VirtoCommerce.XCart.Core.Validators;
 
 namespace VirtoCommerce.XCart.Core.Schemas
 {
     public class CartType : ExtendableGraphType<CartAggregate>
     {
-        [Obsolete("Use the constructor without ICartValidationContextFactory.", DiagnosticId = "VC0009", UrlFormat = "https://docs.virtocommerce.org/products/products-virto3-versions/")]
-        public CartType(
-            ICartAvailMethodsService cartAvailMethods,
-            IDynamicPropertyResolverService dynamicPropertyResolverService,
-            ICartValidationContextFactory cartValidationContextFactory)
-            : this(cartAvailMethods, dynamicPropertyResolverService)
-        {
-        }
-
         public CartType(
             ICartAvailMethodsService cartAvailMethods,
             IDynamicPropertyResolverService dynamicPropertyResolverService)

--- a/src/VirtoCommerce.XCart.Core/Schemas/CartType.cs
+++ b/src/VirtoCommerce.XCart.Core/Schemas/CartType.cs
@@ -11,6 +11,7 @@ using VirtoCommerce.XCart.Core.Extensions;
 using VirtoCommerce.XCart.Core.Models;
 using VirtoCommerce.XCart.Core.Services;
 using VirtoCommerce.XCart.Core.Specifications;
+using VirtoCommerce.XCart.Core.Validators;
 
 namespace VirtoCommerce.XCart.Core.Schemas
 {
@@ -18,7 +19,8 @@ namespace VirtoCommerce.XCart.Core.Schemas
     {
         public CartType(
             ICartAvailMethodsService cartAvailMethods,
-            IDynamicPropertyResolverService dynamicPropertyResolverService)
+            IDynamicPropertyResolverService dynamicPropertyResolverService,
+            ICartValidationContextFactory cartValidationContextFactory)
         {
             Field(x => x.Cart.Id, nullable: false).Description("Shopping cart ID");
             Field(x => x.Cart.Name, nullable: false).Description("Shopping cart name");
@@ -208,8 +210,9 @@ namespace VirtoCommerce.XCart.Core.Schemas
                 .Arguments(QueryArgumentPresets.GetArgumentsForCartValidator())
                 .ResolveAsync(async context =>
                 {
+                    var cartValidationContext = await cartValidationContextFactory.CreateValidationContextAsync(context.Source);
                     var ruleSet = context.GetArgumentOrValue<string>("ruleSet");
-                    var errors = await context.Source.ValidateAsync(ruleSet);
+                    var errors = await context.Source.ValidateAsync(cartValidationContext, ruleSet);
                     return errors.Concat(context.Source.OperationValidationErrors).OfType<CartValidationError>();
                 });
 

--- a/src/VirtoCommerce.XCart.Core/Schemas/CartType.cs
+++ b/src/VirtoCommerce.XCart.Core/Schemas/CartType.cs
@@ -1,5 +1,5 @@
+using System;
 using System.Linq;
-using System.Threading.Tasks;
 using GraphQL;
 using GraphQL.Types;
 using VirtoCommerce.CartModule.Core.Model;
@@ -18,10 +18,18 @@ namespace VirtoCommerce.XCart.Core.Schemas
 {
     public class CartType : ExtendableGraphType<CartAggregate>
     {
+        [Obsolete("Use the constructor without ICartValidationContextFactory.", DiagnosticId = "VC0009", UrlFormat = "https://docs.virtocommerce.org/products/products-virto3-versions/")]
         public CartType(
             ICartAvailMethodsService cartAvailMethods,
             IDynamicPropertyResolverService dynamicPropertyResolverService,
             ICartValidationContextFactory cartValidationContextFactory)
+            : this(cartAvailMethods, dynamicPropertyResolverService)
+        {
+        }
+
+        public CartType(
+            ICartAvailMethodsService cartAvailMethods,
+            IDynamicPropertyResolverService dynamicPropertyResolverService)
         {
             Field(x => x.Cart.Id, nullable: false).Description("Shopping cart ID");
             Field(x => x.Cart.Name, nullable: false).Description("Shopping cart name");
@@ -212,8 +220,8 @@ namespace VirtoCommerce.XCart.Core.Schemas
                 .ResolveAsync(async context =>
                 {
                     var ruleSet = context.GetArgumentOrValue<string>("ruleSet");
-                    await EnsureThatCartValidatedAsync(context.Source, cartValidationContextFactory, ruleSet);
-                    return context.Source.GetValidationErrors().OfType<CartValidationError>();
+                    var errors = await context.Source.ValidateAsync(ruleSet);
+                    return errors.Concat(context.Source.OperationValidationErrors).OfType<CartValidationError>();
                 });
 
             Field(x => x.Cart.Type, nullable: true).Description("Shopping cart type");
@@ -221,17 +229,6 @@ namespace VirtoCommerce.XCart.Core.Schemas
             Field<NonNullGraphType<ListGraphType<NonNullGraphType<ValidationErrorType>>>>("warnings")
                 .Description("A set of temporary warnings for a cart user")
                 .Resolve(context => context.Source.ValidationWarnings);
-        }
-
-        private static async Task EnsureThatCartValidatedAsync(CartAggregate cartAggr, ICartValidationContextFactory cartValidationContextFactory, string ruleSet)
-        {
-            if (!cartAggr.IsValidated)
-            {
-                var context = await cartValidationContextFactory.CreateValidationContextAsync(cartAggr);
-                //We execute a cart validation only once and by demand, in order to do not introduce  performance issues with fetching data from external services
-                //like shipping and tax rates etc.
-                await cartAggr.ValidateAsync(context, ruleSet);
-            }
         }
     }
 }

--- a/src/VirtoCommerce.XCart.Core/Schemas/CartType.cs
+++ b/src/VirtoCommerce.XCart.Core/Schemas/CartType.cs
@@ -11,7 +11,6 @@ using VirtoCommerce.XCart.Core.Extensions;
 using VirtoCommerce.XCart.Core.Models;
 using VirtoCommerce.XCart.Core.Services;
 using VirtoCommerce.XCart.Core.Specifications;
-using VirtoCommerce.XCart.Core.Validators;
 
 namespace VirtoCommerce.XCart.Core.Schemas
 {
@@ -19,8 +18,7 @@ namespace VirtoCommerce.XCart.Core.Schemas
     {
         public CartType(
             ICartAvailMethodsService cartAvailMethods,
-            IDynamicPropertyResolverService dynamicPropertyResolverService,
-            ICartValidationContextFactory cartValidationContextFactory)
+            IDynamicPropertyResolverService dynamicPropertyResolverService)
         {
             Field(x => x.Cart.Id, nullable: false).Description("Shopping cart ID");
             Field(x => x.Cart.Name, nullable: false).Description("Shopping cart name");
@@ -210,9 +208,8 @@ namespace VirtoCommerce.XCart.Core.Schemas
                 .Arguments(QueryArgumentPresets.GetArgumentsForCartValidator())
                 .ResolveAsync(async context =>
                 {
-                    var cartValidationContext = await cartValidationContextFactory.CreateValidationContextAsync(context.Source);
                     var ruleSet = context.GetArgumentOrValue<string>("ruleSet");
-                    var errors = await context.Source.ValidateAsync(cartValidationContext, ruleSet);
+                    var errors = await context.Source.ValidateAsync(ruleSet);
                     return errors.Concat(context.Source.OperationValidationErrors).OfType<CartValidationError>();
                 });
 

--- a/src/VirtoCommerce.XCart.Core/Validators/CartValidationContextFactory.cs
+++ b/src/VirtoCommerce.XCart.Core/Validators/CartValidationContextFactory.cs
@@ -34,14 +34,13 @@ namespace VirtoCommerce.XCart.Core.Validators
             var configurationsTask = LoadProductConfigurationsAsync(cartAggregate);
             await Task.WhenAll(availPaymentsTask, availShippingRatesTask, cartProductsTask, configurationsTask);
 
-            return new CartValidationContext
-            {
-                CartAggregate = cartAggregate,
-                AllCartProducts = cartProductsTask.Result,
-                AvailPaymentMethods = availPaymentsTask.Result,
-                AvailShippingRates = availShippingRatesTask.Result,
-                ProductConfigurations = configurationsTask.Result,
-            };
+            var context = AbstractTypeFactory<CartValidationContext>.TryCreateInstance();
+            context.CartAggregate = cartAggregate;
+            context.AllCartProducts = cartProductsTask.Result;
+            context.AvailPaymentMethods = availPaymentsTask.Result;
+            context.AvailShippingRates = availShippingRatesTask.Result;
+            context.ProductConfigurations = configurationsTask.Result;
+            return context;
         }
 
         public async Task<CartValidationContext> CreateValidationContextAsync(CartAggregate cartAggregate, IList<CartProduct> products)
@@ -51,14 +50,13 @@ namespace VirtoCommerce.XCart.Core.Validators
             var configurationsTask = LoadProductConfigurationsAsync(cartAggregate);
             await Task.WhenAll(availPaymentsTask, availShippingRatesTask, configurationsTask);
 
-            return new CartValidationContext
-            {
-                CartAggregate = cartAggregate,
-                AllCartProducts = products,
-                AvailPaymentMethods = availPaymentsTask.Result,
-                AvailShippingRates = availShippingRatesTask.Result,
-                ProductConfigurations = configurationsTask.Result,
-            };
+            var context = AbstractTypeFactory<CartValidationContext>.TryCreateInstance();
+            context.CartAggregate = cartAggregate;
+            context.AllCartProducts = products;
+            context.AvailPaymentMethods = availPaymentsTask.Result;
+            context.AvailShippingRates = availShippingRatesTask.Result;
+            context.ProductConfigurations = configurationsTask.Result;
+            return context;
         }
 
         protected virtual async Task<IDictionary<string, ProductConfiguration>> LoadProductConfigurationsAsync(CartAggregate cartAggregate)

--- a/src/VirtoCommerce.XCart.Core/Validators/CartValidator.cs
+++ b/src/VirtoCommerce.XCart.Core/Validators/CartValidator.cs
@@ -21,25 +21,25 @@ namespace VirtoCommerce.XCart.Core.Validators
             RuleFor(x => x.CartAggregate.Cart.Currency).NotEmpty();
             RuleFor(x => x.CartAggregate.Cart.CustomerId).NotEmpty();
 
-            RuleSet("items", () =>
+            RuleSet(ModuleConstants.ValidationRuleSets.Items, () =>
                 RuleFor(x => x).Custom((cartContext, context) =>
                 {
                     ApplyRuleForItems(cartContext, context);
                 }));
 
-            RuleSet("shipments", () =>
+            RuleSet(ModuleConstants.ValidationRuleSets.Shipments, () =>
                 RuleFor(x => x).Custom((cartContext, context) =>
                 {
                     ApplyRuleForShipments(cartContext, context);
                 }));
 
-            RuleSet("payments", () =>
+            RuleSet(ModuleConstants.ValidationRuleSets.Payments, () =>
                 RuleFor(x => x).Custom((cartContext, context) =>
                 {
                     ApplyRuleForPayments(cartContext, context);
                 }));
 
-            RuleSet("orderCreate", () =>
+            RuleSet(ModuleConstants.ValidationRuleSets.OrderCreate, () =>
                 RuleFor(x => x).Custom((cartContext, context) =>
                 {
                     ApplyRuleForOrderCreate(cartContext, context);

--- a/src/VirtoCommerce.XCart.Core/Validators/CartValidator.cs
+++ b/src/VirtoCommerce.XCart.Core/Validators/CartValidator.cs
@@ -16,65 +16,30 @@ public class CartValidator : AbstractValidator<CartValidationContext>
         ShipmentValidator = AbstractTypeFactory<CartShipmentValidator>.TryCreateInstance();
         PaymentValidator = AbstractTypeFactory<CartPaymentValidator>.TryCreateInstance();
 
-        public CartValidator()
-        {
-            LineItemValidator = AbstractTypeFactory<CartLineItemValidator>.TryCreateInstance();
-            ShipmentValidator = AbstractTypeFactory<CartShipmentValidator>.TryCreateInstance();
-            PaymentValidator = AbstractTypeFactory<CartPaymentValidator>.TryCreateInstance();
-
-            RuleFor(x => x.CartAggregate.Cart).NotNull();
-            RuleFor(x => x.CartAggregate.Cart.Name).NotEmpty();
-            RuleFor(x => x.CartAggregate.Cart.Currency).NotEmpty();
-            RuleFor(x => x.CartAggregate.Cart.CustomerId).NotEmpty();
-
-            RuleSet(ModuleConstants.ValidationRuleSets.Items, () =>
-                RuleFor(x => x).Custom((cartContext, context) =>
-                {
-                    ApplyRuleForItems(cartContext, context);
-                }));
-
-            RuleSet(ModuleConstants.ValidationRuleSets.Shipments, () =>
-                RuleFor(x => x).Custom((cartContext, context) =>
-                {
-                    ApplyRuleForShipments(cartContext, context);
-                }));
-
-            RuleSet(ModuleConstants.ValidationRuleSets.Payments, () =>
-                RuleFor(x => x).Custom((cartContext, context) =>
-                {
-                    ApplyRuleForPayments(cartContext, context);
-                }));
-
-            RuleSet(ModuleConstants.ValidationRuleSets.OrderCreate, () =>
-                RuleFor(x => x).Custom((cartContext, context) =>
-                {
-                    ApplyRuleForOrderCreate(cartContext, context);
-                }));
-        }
         RuleFor(x => x.CartAggregate.Cart).NotNull();
         RuleFor(x => x.CartAggregate.Cart.Name).NotEmpty();
         RuleFor(x => x.CartAggregate.Cart.Currency).NotEmpty();
         RuleFor(x => x.CartAggregate.Cart.CustomerId).NotEmpty();
 
-        RuleSet("items", () =>
+        RuleSet(ModuleConstants.ValidationRuleSets.Items, () =>
             RuleFor(x => x).Custom((cartContext, context) =>
             {
                 ApplyRuleForItems(cartContext, context);
             }));
 
-        RuleSet("shipments", () =>
+        RuleSet(ModuleConstants.ValidationRuleSets.Shipments, () =>
             RuleFor(x => x).Custom((cartContext, context) =>
             {
                 ApplyRuleForShipments(cartContext, context);
             }));
 
-        RuleSet("payments", () =>
+        RuleSet(ModuleConstants.ValidationRuleSets.Payments, () =>
             RuleFor(x => x).Custom((cartContext, context) =>
             {
                 ApplyRuleForPayments(cartContext, context);
             }));
 
-        RuleSet("orderCreate", () =>
+        RuleSet(ModuleConstants.ValidationRuleSets.OrderCreate, () =>
             RuleFor(x => x).Custom((cartContext, context) =>
             {
                 ApplyRuleForOrderCreate(cartContext, context);

--- a/src/VirtoCommerce.XCart.Core/Validators/ChangeCartItemPriceValidator.cs
+++ b/src/VirtoCommerce.XCart.Core/Validators/ChangeCartItemPriceValidator.cs
@@ -9,7 +9,7 @@ namespace VirtoCommerce.XCart.Core.Validators
         {
             RuleFor(x => x.NewPrice).GreaterThanOrEqualTo(0);
             RuleFor(x => x.LineItemId).NotNull().NotEmpty();
-            RuleSet("strict", () =>
+            RuleSet(ModuleConstants.ValidationRuleSets.Strict, () =>
             {
                 RuleFor(x => x).Custom((newPriceRequest, context) =>
                 {

--- a/src/VirtoCommerce.XCart.Core/Validators/ItemQtyAdjustmentValidator.cs
+++ b/src/VirtoCommerce.XCart.Core/Validators/ItemQtyAdjustmentValidator.cs
@@ -13,7 +13,7 @@ namespace VirtoCommerce.XCart.Core.Validators
             RuleFor(x => x.LineItemId).NotNull();
             RuleFor(x => x.CartProduct).NotNull();
 
-            RuleSet("strict", () =>
+            RuleSet(ModuleConstants.ValidationRuleSets.Strict, () =>
             {
                 RuleFor(x => x).Custom((qtyAdjust, context) =>
                 {

--- a/src/VirtoCommerce.XCart.Core/Validators/NewCartItemValidator.cs
+++ b/src/VirtoCommerce.XCart.Core/Validators/NewCartItemValidator.cs
@@ -15,7 +15,7 @@ namespace VirtoCommerce.XCart.Core.Validators
             RuleFor(x => x.ProductId).NotNull();
             RuleFor(x => x.CartProduct).NotNull();
 
-            RuleSet("strict", () =>
+            RuleSet(ModuleConstants.ValidationRuleSets.Strict, () =>
             {
                 RuleFor(x => x).Custom((newCartItem, context) =>
                 {

--- a/src/VirtoCommerce.XCart.Data/Services/CartAggregateRepository.cs
+++ b/src/VirtoCommerce.XCart.Data/Services/CartAggregateRepository.cs
@@ -72,7 +72,11 @@ namespace VirtoCommerce.XCart.Data.Services
 
             await UpdateConfigurationFiles(cartAggregate.Cart);
 
-            // Clear cache
+            // Clear validation cache — cart state changed, cached results are stale.
+            // This ensures the mutation response re-validates against the updated cart.
+            cartAggregate.ClearValidationCache();
+
+            // Clear aggregate cache
             GenericCachingRegion<CartAggregate>.ExpireTokenForKey(cartAggregate.Id);
         }
 

--- a/tests/VirtoCommerce.XCart.Tests/Aggregates/CartAggregateTests.cs
+++ b/tests/VirtoCommerce.XCart.Tests/Aggregates/CartAggregateTests.cs
@@ -43,7 +43,8 @@ namespace VirtoCommerce.XCart.Tests.Aggregates
                 _genericPipelineLauncherMock.Object,
                 _configurationItemValidatorMock.Object,
                 _fileUploadService.Object,
-                _cartSharingService.Object);
+                _cartSharingService.Object,
+                _cartValidationContextFactoryMock.Object);
 
             var cart = GetCart();
             var member = GetMember();
@@ -751,17 +752,20 @@ namespace VirtoCommerce.XCart.Tests.Aggregates
         #region ValidateAsync
 
         [Fact]
-        public async Task ValidateAsync_CartValid_CartValidated()
+        public async Task ValidateAsync_CartValid_ResultsCached()
         {
             // Arrange
             var cartAggregate = GetValidCartAggregate();
-            var context = new CartValidationContext();
+            _cartValidationContextFactoryMock
+                .Setup(x => x.CreateValidationContextAsync(cartAggregate))
+                .ReturnsAsync(new CartValidationContext());
 
             // Act
-            await cartAggregate.ValidateAsync(context, "default");
+            var errors = await cartAggregate.ValidateAsync("default");
 
             // Assert
-            cartAggregate.IsValidated.Should().BeTrue();
+            errors.Should().BeEmpty();
+            cartAggregate.GetValidationErrors().Should().BeEmpty();
         }
 
         #endregion ValidateAsync

--- a/tests/VirtoCommerce.XCart.Tests/Aggregates/CartAggregateTests.cs
+++ b/tests/VirtoCommerce.XCart.Tests/Aggregates/CartAggregateTests.cs
@@ -43,8 +43,7 @@ namespace VirtoCommerce.XCart.Tests.Aggregates
                 _genericPipelineLauncherMock.Object,
                 _configurationItemValidatorMock.Object,
                 _fileUploadService.Object,
-                _cartSharingService.Object,
-                _cartValidationContextFactoryMock.Object);
+                _cartSharingService.Object);
 
             var cart = GetCart();
             var member = GetMember();
@@ -756,12 +755,10 @@ namespace VirtoCommerce.XCart.Tests.Aggregates
         {
             // Arrange
             var cartAggregate = GetValidCartAggregate();
-            _cartValidationContextFactoryMock
-                .Setup(x => x.CreateValidationContextAsync(cartAggregate))
-                .ReturnsAsync(new CartValidationContext());
+            var context = new CartValidationContext();
 
             // Act
-            var errors = await cartAggregate.ValidateAsync("default");
+            var errors = await cartAggregate.ValidateAsync(context, "default");
 
             // Assert
             errors.Should().BeEmpty();

--- a/tests/VirtoCommerce.XCart.Tests/Aggregates/CartAggregateTests.cs
+++ b/tests/VirtoCommerce.XCart.Tests/Aggregates/CartAggregateTests.cs
@@ -43,7 +43,8 @@ namespace VirtoCommerce.XCart.Tests.Aggregates
                 _genericPipelineLauncherMock.Object,
                 _configurationItemValidatorMock.Object,
                 _fileUploadService.Object,
-                _cartSharingService.Object);
+                _cartSharingService.Object,
+                _cartValidationContextFactoryMock.Object);
 
             var cart = GetCart();
             var member = GetMember();
@@ -755,10 +756,12 @@ namespace VirtoCommerce.XCart.Tests.Aggregates
         {
             // Arrange
             var cartAggregate = GetValidCartAggregate();
-            var context = new CartValidationContext();
+            _cartValidationContextFactoryMock
+                .Setup(x => x.CreateValidationContextAsync(cartAggregate))
+                .ReturnsAsync(new CartValidationContext());
 
             // Act
-            var errors = await cartAggregate.ValidateAsync(context, "default");
+            var errors = await cartAggregate.ValidateAsync("default");
 
             // Assert
             errors.Should().BeEmpty();

--- a/tests/VirtoCommerce.XCart.Tests/Builders/CartCommandBuilderTests.cs
+++ b/tests/VirtoCommerce.XCart.Tests/Builders/CartCommandBuilderTests.cs
@@ -10,13 +10,11 @@ using MediatR;
 using Microsoft.AspNetCore.Authorization;
 using Moq;
 using VirtoCommerce.CartModule.Core.Model;
-using VirtoCommerce.Xapi.Core.Extensions;
 using VirtoCommerce.Xapi.Core.Infrastructure;
 using VirtoCommerce.Xapi.Core.Security.Authorization;
 using VirtoCommerce.XCart.Core;
 using VirtoCommerce.XCart.Core.Commands.BaseCommands;
 using VirtoCommerce.XCart.Core.Services;
-using VirtoCommerce.XCart.Data.Authorization;
 using VirtoCommerce.XCart.Data.Commands.BaseCommands;
 using Xunit;
 
@@ -55,7 +53,7 @@ public class CartCommandBuilderTests
     private static CartAggregate CreateCartAggregate(string cartId = "cart-1")
     {
         var mock = new Mock<CartAggregate>(
-            MockBehavior.Loose, null, null, null, null, null, null, null, null, null, null, null, null);
+            MockBehavior.Loose, null, null, null, null, null, null, null, null, null, null, null);
 
         var cartProperty = typeof(CartAggregate).GetProperty(nameof(CartAggregate.Cart));
         cartProperty!.SetValue(mock.Object, new ShoppingCart { Id = cartId });

--- a/tests/VirtoCommerce.XCart.Tests/Builders/CartCommandBuilderTests.cs
+++ b/tests/VirtoCommerce.XCart.Tests/Builders/CartCommandBuilderTests.cs
@@ -10,11 +10,13 @@ using MediatR;
 using Microsoft.AspNetCore.Authorization;
 using Moq;
 using VirtoCommerce.CartModule.Core.Model;
+using VirtoCommerce.Xapi.Core.Extensions;
 using VirtoCommerce.Xapi.Core.Infrastructure;
 using VirtoCommerce.Xapi.Core.Security.Authorization;
 using VirtoCommerce.XCart.Core;
 using VirtoCommerce.XCart.Core.Commands.BaseCommands;
 using VirtoCommerce.XCart.Core.Services;
+using VirtoCommerce.XCart.Data.Authorization;
 using VirtoCommerce.XCart.Data.Commands.BaseCommands;
 using Xunit;
 
@@ -53,7 +55,7 @@ public class CartCommandBuilderTests
     private static CartAggregate CreateCartAggregate(string cartId = "cart-1")
     {
         var mock = new Mock<CartAggregate>(
-            MockBehavior.Loose, null, null, null, null, null, null, null, null, null, null, null);
+            MockBehavior.Loose, null, null, null, null, null, null, null, null, null, null, null, null);
 
         var cartProperty = typeof(CartAggregate).GetProperty(nameof(CartAggregate.Cart));
         cartProperty!.SetValue(mock.Object, new ShoppingCart { Id = cartId });

--- a/tests/VirtoCommerce.XCart.Tests/Builders/CartCommandBuilderTests.cs
+++ b/tests/VirtoCommerce.XCart.Tests/Builders/CartCommandBuilderTests.cs
@@ -55,7 +55,7 @@ public class CartCommandBuilderTests
     private static CartAggregate CreateCartAggregate(string cartId = "cart-1")
     {
         var mock = new Mock<CartAggregate>(
-            MockBehavior.Loose, null, null, null, null, null, null, null, null, null, null, null);
+            MockBehavior.Loose, null, null, null, null, null, null, null, null, null, null, null, null);
 
         var cartProperty = typeof(CartAggregate).GetProperty(nameof(CartAggregate.Cart));
         cartProperty!.SetValue(mock.Object, new ShoppingCart { Id = cartId });

--- a/tests/VirtoCommerce.XCart.Tests/Handlers/AddCartItemCommandHandlerTests.cs
+++ b/tests/VirtoCommerce.XCart.Tests/Handlers/AddCartItemCommandHandlerTests.cs
@@ -39,7 +39,7 @@ namespace VirtoCommerce.XCart.Tests.Handlers
         private static Mock<CartAggregate> CreateCartAggregateMock()
         {
             var mock = new Mock<CartAggregate>(
-                MockBehavior.Loose, null, null, null, null, null, null, null, null, null, null, null);
+                MockBehavior.Loose, null, null, null, null, null, null, null, null, null, null, null, null);
 
             // Cart property has a protected setter and is non-virtual, so we set it via reflection
             var cartProperty = typeof(CartAggregate).GetProperty(nameof(CartAggregate.Cart));

--- a/tests/VirtoCommerce.XCart.Tests/Handlers/AddCartItemCommandHandlerTests.cs
+++ b/tests/VirtoCommerce.XCart.Tests/Handlers/AddCartItemCommandHandlerTests.cs
@@ -1,6 +1,4 @@
 using System.Collections.Generic;
-using System.Linq;
-using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using MediatR;
@@ -10,7 +8,6 @@ using VirtoCommerce.CatalogModule.Core.Model;
 using VirtoCommerce.CatalogModule.Core.Model.Configuration;
 using VirtoCommerce.CatalogModule.Core.Model.Search;
 using VirtoCommerce.CatalogModule.Core.Search;
-using VirtoCommerce.Platform.Core.Common;
 using VirtoCommerce.XCart.Core;
 using VirtoCommerce.XCart.Core.Commands;
 using VirtoCommerce.XCart.Core.Models;
@@ -39,7 +36,7 @@ namespace VirtoCommerce.XCart.Tests.Handlers
         private static Mock<CartAggregate> CreateCartAggregateMock()
         {
             var mock = new Mock<CartAggregate>(
-                MockBehavior.Loose, null, null, null, null, null, null, null, null, null, null, null, null);
+                MockBehavior.Loose, null, null, null, null, null, null, null, null, null, null, null);
 
             // Cart property has a protected setter and is non-virtual, so we set it via reflection
             var cartProperty = typeof(CartAggregate).GetProperty(nameof(CartAggregate.Cart));

--- a/tests/VirtoCommerce.XCart.Tests/Handlers/AddCartItemCommandHandlerTests.cs
+++ b/tests/VirtoCommerce.XCart.Tests/Handlers/AddCartItemCommandHandlerTests.cs
@@ -1,4 +1,6 @@
 using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using MediatR;
@@ -8,6 +10,7 @@ using VirtoCommerce.CatalogModule.Core.Model;
 using VirtoCommerce.CatalogModule.Core.Model.Configuration;
 using VirtoCommerce.CatalogModule.Core.Model.Search;
 using VirtoCommerce.CatalogModule.Core.Search;
+using VirtoCommerce.Platform.Core.Common;
 using VirtoCommerce.XCart.Core;
 using VirtoCommerce.XCart.Core.Commands;
 using VirtoCommerce.XCart.Core.Models;
@@ -36,7 +39,7 @@ namespace VirtoCommerce.XCart.Tests.Handlers
         private static Mock<CartAggregate> CreateCartAggregateMock()
         {
             var mock = new Mock<CartAggregate>(
-                MockBehavior.Loose, null, null, null, null, null, null, null, null, null, null, null);
+                MockBehavior.Loose, null, null, null, null, null, null, null, null, null, null, null, null);
 
             // Cart property has a protected setter and is non-virtual, so we set it via reflection
             var cartProperty = typeof(CartAggregate).GetProperty(nameof(CartAggregate.Cart));

--- a/tests/VirtoCommerce.XCart.Tests/Handlers/AddCartItemsCommandHandlerTests.cs
+++ b/tests/VirtoCommerce.XCart.Tests/Handlers/AddCartItemsCommandHandlerTests.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using MediatR;
@@ -8,6 +9,7 @@ using VirtoCommerce.CatalogModule.Core.Model;
 using VirtoCommerce.CatalogModule.Core.Model.Configuration;
 using VirtoCommerce.CatalogModule.Core.Model.Search;
 using VirtoCommerce.CatalogModule.Core.Search;
+using VirtoCommerce.Platform.Core.Common;
 using VirtoCommerce.XCart.Core;
 using VirtoCommerce.XCart.Core.Commands;
 using VirtoCommerce.XCart.Core.Models;
@@ -36,7 +38,7 @@ namespace VirtoCommerce.XCart.Tests.Handlers
         private static Mock<CartAggregate> CreateCartAggregateMock()
         {
             var mock = new Mock<CartAggregate>(
-                MockBehavior.Loose, null, null, null, null, null, null, null, null, null, null, null);
+                MockBehavior.Loose, null, null, null, null, null, null, null, null, null, null, null, null);
 
             // Cart property has a protected setter and is non-virtual, so we set it via reflection
             var cartProperty = typeof(CartAggregate).GetProperty(nameof(CartAggregate.Cart));

--- a/tests/VirtoCommerce.XCart.Tests/Handlers/AddCartItemsCommandHandlerTests.cs
+++ b/tests/VirtoCommerce.XCart.Tests/Handlers/AddCartItemsCommandHandlerTests.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using MediatR;
@@ -9,7 +8,6 @@ using VirtoCommerce.CatalogModule.Core.Model;
 using VirtoCommerce.CatalogModule.Core.Model.Configuration;
 using VirtoCommerce.CatalogModule.Core.Model.Search;
 using VirtoCommerce.CatalogModule.Core.Search;
-using VirtoCommerce.Platform.Core.Common;
 using VirtoCommerce.XCart.Core;
 using VirtoCommerce.XCart.Core.Commands;
 using VirtoCommerce.XCart.Core.Models;
@@ -38,7 +36,7 @@ namespace VirtoCommerce.XCart.Tests.Handlers
         private static Mock<CartAggregate> CreateCartAggregateMock()
         {
             var mock = new Mock<CartAggregate>(
-                MockBehavior.Loose, null, null, null, null, null, null, null, null, null, null, null, null);
+                MockBehavior.Loose, null, null, null, null, null, null, null, null, null, null, null);
 
             // Cart property has a protected setter and is non-virtual, so we set it via reflection
             var cartProperty = typeof(CartAggregate).GetProperty(nameof(CartAggregate.Cart));

--- a/tests/VirtoCommerce.XCart.Tests/Handlers/AddCartItemsCommandHandlerTests.cs
+++ b/tests/VirtoCommerce.XCart.Tests/Handlers/AddCartItemsCommandHandlerTests.cs
@@ -38,7 +38,7 @@ namespace VirtoCommerce.XCart.Tests.Handlers
         private static Mock<CartAggregate> CreateCartAggregateMock()
         {
             var mock = new Mock<CartAggregate>(
-                MockBehavior.Loose, null, null, null, null, null, null, null, null, null, null, null);
+                MockBehavior.Loose, null, null, null, null, null, null, null, null, null, null, null, null);
 
             // Cart property has a protected setter and is non-virtual, so we set it via reflection
             var cartProperty = typeof(CartAggregate).GetProperty(nameof(CartAggregate.Cart));

--- a/tests/VirtoCommerce.XCart.Tests/Helpers/XCartMoqHelper.cs
+++ b/tests/VirtoCommerce.XCart.Tests/Helpers/XCartMoqHelper.cs
@@ -258,7 +258,8 @@ namespace VirtoCommerce.XCart.Tests.Helpers
                 _genericPipelineLauncherMock.Object,
                 _configurationItemValidatorMock.Object,
                 _fileUploadService.Object,
-                _cartSharingService.Object);
+                _cartSharingService.Object,
+                _cartValidationContextFactoryMock.Object);
 
             aggregate.GrabCart(cart ?? GetCart(), new Store(), null, currency ?? GetCurrency());
 
@@ -278,7 +279,8 @@ namespace VirtoCommerce.XCart.Tests.Helpers
                 _genericPipelineLauncherMock.Object,
                 _configurationItemValidatorMock.Object,
                 _fileUploadService.Object,
-                _cartSharingService.Object);
+                _cartSharingService.Object,
+                _cartValidationContextFactoryMock.Object);
 
             aggregate.GrabCart(cart ?? GetCart(), new Store(), GetMember(), currency ?? GetCurrency());
 

--- a/tests/VirtoCommerce.XCart.Tests/Helpers/XCartMoqHelper.cs
+++ b/tests/VirtoCommerce.XCart.Tests/Helpers/XCartMoqHelper.cs
@@ -258,8 +258,7 @@ namespace VirtoCommerce.XCart.Tests.Helpers
                 _genericPipelineLauncherMock.Object,
                 _configurationItemValidatorMock.Object,
                 _fileUploadService.Object,
-                _cartSharingService.Object,
-                _cartValidationContextFactoryMock.Object);
+                _cartSharingService.Object);
 
             aggregate.GrabCart(cart ?? GetCart(), new Store(), null, currency ?? GetCurrency());
 
@@ -279,8 +278,7 @@ namespace VirtoCommerce.XCart.Tests.Helpers
                 _genericPipelineLauncherMock.Object,
                 _configurationItemValidatorMock.Object,
                 _fileUploadService.Object,
-                _cartSharingService.Object,
-                _cartValidationContextFactoryMock.Object);
+                _cartSharingService.Object);
 
             aggregate.GrabCart(cart ?? GetCart(), new Store(), GetMember(), currency ?? GetCurrency());
 

--- a/tests/VirtoCommerce.XCart.Tests/Helpers/XCartMoqHelper.cs
+++ b/tests/VirtoCommerce.XCart.Tests/Helpers/XCartMoqHelper.cs
@@ -231,8 +231,8 @@ namespace VirtoCommerce.XCart.Tests.Helpers
                 {
                     ProductId = catalogProductId,
                     PricelistId = _fixture.Create<string>(),
-                    List = _fixture.Create<decimal>(),
-                    MinQuantity = _fixture.Create<int>(),
+                    List = productPrice,
+                    MinQuantity = 1,
                 }
             }, GetCurrency());
 

--- a/tests/VirtoCommerce.XCart.Tests/Helpers/XCartMoqHelper.cs
+++ b/tests/VirtoCommerce.XCart.Tests/Helpers/XCartMoqHelper.cs
@@ -55,6 +55,7 @@ namespace VirtoCommerce.XCart.Tests.Helpers
         protected readonly Mock<IConfigurationItemValidator> _configurationItemValidatorMock;
         protected readonly Mock<IFileUploadService> _fileUploadService;
         protected readonly Mock<ICartSharingService> _cartSharingService;
+        protected readonly Mock<ICartValidationContextFactory> _cartValidationContextFactoryMock;
 
         protected readonly Randomizer Rand = new Randomizer();
 
@@ -196,6 +197,7 @@ namespace VirtoCommerce.XCart.Tests.Helpers
                 .ReturnsAsync(() => []);
 
             _cartSharingService = new Mock<ICartSharingService>();
+            _cartValidationContextFactoryMock = new Mock<ICartValidationContextFactory>();
         }
 
         protected ShoppingCart GetCart() => _fixture.Create<ShoppingCart>();
@@ -256,7 +258,8 @@ namespace VirtoCommerce.XCart.Tests.Helpers
                 _genericPipelineLauncherMock.Object,
                 _configurationItemValidatorMock.Object,
                 _fileUploadService.Object,
-                _cartSharingService.Object);
+                _cartSharingService.Object,
+                _cartValidationContextFactoryMock.Object);
 
             aggregate.GrabCart(cart ?? GetCart(), new Store(), null, currency ?? GetCurrency());
 
@@ -276,7 +279,8 @@ namespace VirtoCommerce.XCart.Tests.Helpers
                 _genericPipelineLauncherMock.Object,
                 _configurationItemValidatorMock.Object,
                 _fileUploadService.Object,
-                _cartSharingService.Object);
+                _cartSharingService.Object,
+                _cartValidationContextFactoryMock.Object);
 
             aggregate.GrabCart(cart ?? GetCart(), new Store(), GetMember(), currency ?? GetCurrency());
 

--- a/tests/VirtoCommerce.XCart.Tests/Validators/NewCartItemValidatorTests.cs
+++ b/tests/VirtoCommerce.XCart.Tests/Validators/NewCartItemValidatorTests.cs
@@ -95,11 +95,13 @@ namespace VirtoCommerce.XCart.Tests.Validators
         [Fact]
         public async Task ValidateAddItem_RuleSetStrict_PriceError()
         {
-            // Arrange
-            var productPrice = Rand.Decimal();
+            // Arrange — cart item price is explicitly lower than the product list price
+            var listPrice = 100m;
             var productId = Rand.Guid().ToString();
             var quantity = Rand.Int(1, InStockQuantity);
-            var newCartItem = BuildNewCartItem(productId, quantity, productPrice, true, true);
+            var newCartItem = BuildNewCartItem(productId, quantity, listPrice, true, true);
+            newCartItem.Price = listPrice - 1; // below list price → triggers UNABLE_SET_LESS_PRICE
+            newCartItem.CartProduct.Product.TrackInventory = false;
             var validator = new NewCartItemValidator();
 
             // Act


### PR DESCRIPTION
## Description
### Fix cart validation caching: per-ruleSet results instead of single-shot flag
**Problem**
`CartAggregate` treated validation as a one-time event. A single `IsValidated` boolean flag prevented re-validation with different rulesets on the same aggregate instance (cached in `IPlatformMemoryCache`). This caused:
- RuleSet leaking — `validationErrors(ruleSet: "shipments")` could return errors from "default" (or vice versa)
- Stale errors — `CartValidationErrors` was only overwritten when `result.IsValid == false`, so errors persisted after the cart became valid
- Cross-request contamination — the cached aggregate carried stale `IsValidated = true` across requests and mutation responses

**Changes**
- **CartAggregate.cs**
Added `ConcurrentDictionary<string, IList<ValidationFailure>> ValidationErrorsByRuleSet` — per-ruleSet cache with normalized keys (sorted composite keys, `"*"` collapsing, `null/""` → `"default"`)
New `ValidateAsync(string ruleSet)` — checks cache, creates validation context internally via injected `ICartValidationContextFactory`, validates only on cache miss
New `ClearValidationCache()` — clears all cached results
`GetValidationErrors()` — returns union of all cached ruleSet entries + `OperationValidationErrors`
`IsValid` — checks all dictionary entries
New constructor accepting `ICartValidationContextFactory`; old constructor marked `[Obsolete]`
Old `ValidateAsync(CartValidationContext, string)`, `IsValidated`, `CartValidationErrors` marked `[Obsolete]` (kept for backward compatibility)

- **CartType.cs**
Resolver simplified to `context.Source.ValidateAsync(ruleSet)` + `OperationValidationErrors`
Removed `EnsureThatCartValidatedAsync` (private, safe to delete)
Old constructor with `ICartValidationContextFactory` kept as `[Obsolete]`

- **CartAggregateRepository.cs**
`SaveAsync` calls `ClearValidationCache()` before expiring the aggregate cache key
 
**Minor improvements**
- **CartValidationContextFactory.cs**
Replaced `new CartValidationContext` with `AbstractTypeFactory<CartValidationContext>.TryCreateInstance()` — allows downstream modules to override the context type
- **Tests**
Updated `XCartMoqHelper`, `CartAggregateTests`, `NewCartItemValidatorTests` for new constructor and deterministic test data (fixed flaky price-related tests)

## References
### QA-test:
### Jira-link:
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.XCart_3.1011.0-pr-110-78e2.zip
