### PR TITLE
feat: add configurationItem selection mutations

### DIFF
--- a/src/VirtoCommerce.XCart.Core/CartAggregate.cs
+++ b/src/VirtoCommerce.XCart.Core/CartAggregate.cs
@@ -1929,10 +1929,10 @@ namespace VirtoCommerce.XCart.Core
                             break;
                         }
                     case ConfigurationSectionTypeText:
-                        container.AddTextSectionLineItem(configurationItem.CustomText, configurationItem.SectionId);
+                        container.AddTextSectionLineItem(configurationItem);
                         break;
                     case ConfigurationSectionTypeFile:
-                        container.AddFileSectionLineItem(configurationItem.Files, configurationItem.SectionId);
+                        container.AddFileSectionLineItem(configurationItem);
                         break;
                 }
             }

--- a/src/VirtoCommerce.XCart.Core/CartAggregate.cs
+++ b/src/VirtoCommerce.XCart.Core/CartAggregate.cs
@@ -1415,7 +1415,7 @@ namespace VirtoCommerce.XCart.Core
             return AddConfigurationItemsAsync(lineItemId, [configurationSection]);
         }
 
-        public virtual async Task<CartAggregate> AddConfigurationItemsAsync(string lineItemId, IList<ProductConfigurationSection> configurationSections)
+        public virtual Task<CartAggregate> AddConfigurationItemsAsync(string lineItemId, IList<ProductConfigurationSection> configurationSections)
         {
             ArgumentNullException.ThrowIfNull(lineItemId);
             ArgumentNullException.ThrowIfNull(configurationSections);
@@ -1426,10 +1426,11 @@ namespace VirtoCommerce.XCart.Core
             if (lineItem is null)
             {
                 OperationValidationErrors.Add(CartErrorDescriber.ConfiguredLineItemNotFound(lineItemId));
-                return this;
+
+                return Task.FromResult(this);
             }
 
-            return await AddConfigurationItemsAsync(lineItem, configurationSections);
+            return AddConfigurationItemsAsync(lineItem, configurationSections);
         }
 
         protected virtual async Task<CartAggregate> AddConfigurationItemsAsync(LineItem lineItem, IList<ProductConfigurationSection> configurationSections)
@@ -1487,7 +1488,7 @@ namespace VirtoCommerce.XCart.Core
             return UpdateConfigurationItemsAsync(lineItemId, [configurationSection]);
         }
 
-        public virtual async Task<CartAggregate> UpdateConfigurationItemsAsync(string lineItemId, IList<ProductConfigurationSection> configurationSections)
+        public virtual Task<CartAggregate> UpdateConfigurationItemsAsync(string lineItemId, IList<ProductConfigurationSection> configurationSections)
         {
             ArgumentNullException.ThrowIfNull(lineItemId);
             ArgumentNullException.ThrowIfNull(configurationSections);
@@ -1498,10 +1499,11 @@ namespace VirtoCommerce.XCart.Core
             if (lineItem is null)
             {
                 OperationValidationErrors.Add(CartErrorDescriber.ConfiguredLineItemNotFound(lineItemId));
-                return this;
+
+                return Task.FromResult(this);
             }
 
-            return await UpdateConfigurationItemsAsync(lineItem, configurationSections);
+            return UpdateConfigurationItemsAsync(lineItem, configurationSections);
         }
 
         protected virtual async Task<CartAggregate> UpdateConfigurationItemsAsync(LineItem lineItem, IList<ProductConfigurationSection> configurationSections)
@@ -1604,6 +1606,102 @@ namespace VirtoCommerce.XCart.Core
                         break;
                     }
             }
+        }
+
+        public virtual Task<CartAggregate> ChangeConfigurationItemSelectedAsync(string lineItemId, ProductConfigurationSection configurationSection, bool selectedForCheckout)
+        {
+            ArgumentNullException.ThrowIfNull(lineItemId);
+            ArgumentNullException.ThrowIfNull(configurationSection);
+
+            EnsureCartExists();
+
+            return ChangeConfigurationItemsSelectedAsync(lineItemId, [configurationSection], selectedForCheckout);
+        }
+
+        public virtual Task<CartAggregate> ChangeConfigurationItemsSelectedAsync(string lineItemId, IList<ProductConfigurationSection> configurationSections, bool selectedForCheckout)
+        {
+            ArgumentNullException.ThrowIfNull(lineItemId);
+            ArgumentNullException.ThrowIfNull(configurationSections);
+
+            EnsureCartExists();
+
+            var lineItem = GetConfiguredLineItem(lineItemId);
+            if (lineItem is null)
+            {
+                OperationValidationErrors.Add(CartErrorDescriber.ConfiguredLineItemNotFound(lineItemId));
+
+                return Task.FromResult(this);
+            }
+
+            return ChangeConfigurationItemsSelectedAsync(lineItem, configurationSections, selectedForCheckout);
+        }
+
+        protected virtual async Task<CartAggregate> ChangeConfigurationItemsSelectedAsync(LineItem lineItem, IList<ProductConfigurationSection> configurationSections, bool selectedForCheckout)
+        {
+            if (lineItem.ConfigurationItems.IsNullOrEmpty() || configurationSections.IsNullOrEmpty())
+            {
+                return this;
+            }
+
+            var changed = false;
+            foreach (var section in configurationSections)
+            {
+                var configurationItem = FindConfigurationItem(lineItem, section);
+                if (configurationItem is not null && configurationItem.SelectedForCheckout != selectedForCheckout)
+                {
+                    configurationItem.SelectedForCheckout = selectedForCheckout;
+                    changed = true;
+                }
+            }
+
+            if (changed)
+            {
+                await UpdateConfiguredLineItemPrice([lineItem]);
+            }
+
+            return this;
+        }
+
+        public virtual Task<CartAggregate> ChangeAllConfigurationItemsSelectedAsync(string lineItemId, bool selectedForCheckout)
+        {
+            ArgumentNullException.ThrowIfNull(lineItemId);
+
+            EnsureCartExists();
+
+            var lineItem = GetConfiguredLineItem(lineItemId);
+            if (lineItem is null)
+            {
+                OperationValidationErrors.Add(CartErrorDescriber.ConfiguredLineItemNotFound(lineItemId));
+
+                return Task.FromResult(this);
+            }
+
+            return ChangeAllConfigurationItemsSelectedAsync(lineItem, selectedForCheckout);
+        }
+
+        protected virtual async Task<CartAggregate> ChangeAllConfigurationItemsSelectedAsync(LineItem lineItem, bool selectedForCheckout)
+        {
+            if (lineItem.ConfigurationItems.IsNullOrEmpty())
+            {
+                return this;
+            }
+
+            var changed = false;
+            foreach (var configurationItem in lineItem.ConfigurationItems)
+            {
+                if (configurationItem.SelectedForCheckout != selectedForCheckout)
+                {
+                    configurationItem.SelectedForCheckout = selectedForCheckout;
+                    changed = true;
+                }
+            }
+
+            if (changed)
+            {
+                await UpdateConfiguredLineItemPrice([lineItem]);
+            }
+
+            return this;
         }
 
         public virtual Task<CartAggregate> RemoveConfigurationItemAsync(string lineItemId, ProductConfigurationSection configurationSection)

--- a/src/VirtoCommerce.XCart.Core/Commands/ChangeAllCartConfigurationItemsSelectedCommand.cs
+++ b/src/VirtoCommerce.XCart.Core/Commands/ChangeAllCartConfigurationItemsSelectedCommand.cs
@@ -1,0 +1,11 @@
+using VirtoCommerce.XCart.Core.Commands.BaseCommands;
+
+namespace VirtoCommerce.XCart.Core.Commands
+{
+    public class ChangeAllCartConfigurationItemsSelectedCommand : CartCommand
+    {
+        public string LineItemId { get; set; }
+
+        public bool SelectedForCheckout { get; set; }
+    }
+}

--- a/src/VirtoCommerce.XCart.Core/Commands/ChangeCartConfigurationItemSelectedCommand.cs
+++ b/src/VirtoCommerce.XCart.Core/Commands/ChangeCartConfigurationItemSelectedCommand.cs
@@ -1,0 +1,14 @@
+using VirtoCommerce.XCart.Core.Commands.BaseCommands;
+using VirtoCommerce.XCart.Core.Models;
+
+namespace VirtoCommerce.XCart.Core.Commands
+{
+    public class ChangeCartConfigurationItemSelectedCommand : CartCommand
+    {
+        public string LineItemId { get; set; }
+
+        public ProductConfigurationSection ConfigurationSection { get; set; }
+
+        public bool SelectedForCheckout { get; set; }
+    }
+}

--- a/src/VirtoCommerce.XCart.Core/Commands/ChangeCartConfigurationItemsSelectedCommand.cs
+++ b/src/VirtoCommerce.XCart.Core/Commands/ChangeCartConfigurationItemsSelectedCommand.cs
@@ -1,0 +1,15 @@
+using System.Collections.Generic;
+using VirtoCommerce.XCart.Core.Commands.BaseCommands;
+using VirtoCommerce.XCart.Core.Models;
+
+namespace VirtoCommerce.XCart.Core.Commands
+{
+    public class ChangeCartConfigurationItemsSelectedCommand : CartCommand
+    {
+        public string LineItemId { get; set; }
+
+        public IList<ProductConfigurationSection> ConfigurationSections { get; set; } = new List<ProductConfigurationSection>();
+
+        public bool SelectedForCheckout { get; set; }
+    }
+}

--- a/src/VirtoCommerce.XCart.Core/ConfiguredLineItemContainer.cs
+++ b/src/VirtoCommerce.XCart.Core/ConfiguredLineItemContainer.cs
@@ -174,16 +174,19 @@ namespace VirtoCommerce.XCart.Core
 
         /// <summary>
         /// Creates an empty <see cref="SectionLineItem"/> with the given identifying fields.
-        /// Used by both creation-path and source-aware overloads as the single point of
-        /// <see cref="AbstractTypeFactory{T}"/> construction.
+        /// Used by both creation-path and source-aware overloads. Override to return a
+        /// derived <see cref="SectionLineItem"/> type — <see cref="SectionLineItem"/> is
+        /// nested-protected, so external <see cref="AbstractTypeFactory{T}"/> registration
+        /// is not reachable; subclassing <see cref="ConfiguredLineItemContainer"/> is the
+        /// supported extension point.
         /// </summary>
         protected virtual SectionLineItem CreateSectionLineItem(string sectionId, string type)
         {
-            var item = AbstractTypeFactory<SectionLineItem>.TryCreateInstance();
-            item.SectionId = sectionId;
-            item.Type = type;
-
-            return item;
+            return new SectionLineItem
+            {
+                SectionId = sectionId,
+                Type = type,
+            };
         }
 
         public virtual ExpConfigurationLineItem CreateConfiguredLineItem(int quantity)

--- a/src/VirtoCommerce.XCart.Core/ConfiguredLineItemContainer.cs
+++ b/src/VirtoCommerce.XCart.Core/ConfiguredLineItemContainer.cs
@@ -81,24 +81,27 @@ namespace VirtoCommerce.XCart.Core
             AddProductSectionLineItem(lineItem, sectionId, type);
         }
 
+        protected virtual void AddProductSectionLineItem(LineItem lineItem, string sectionId, string type)
+        {
+            var item = CreateSectionLineItem(sectionId, type);
+            item.Item = lineItem;
+
+            Items.Add(item);
+        }
+
         /// <summary>
         /// Adds a product section line item for an existing configuration item (e.g. during price recalculation).
         /// Propagates <see cref="ConfigurationItem.SelectedForCheckout"/> and uses
         /// <see cref="CreateLineItem(CartProduct, ConfigurationItem)"/> for pricing — override
-        /// to inject pre-computed prices instead of catalog prices.
+        /// to inject pre-computed prices instead of catalog prices. Stores
+        /// <paramref name="configurationItem"/> on <see cref="SectionLineItem.Source"/>
+        /// for downstream consumers.
         /// </summary>
         public virtual void AddProductSectionLineItem(CartProduct cartProduct, ConfigurationItem configurationItem)
         {
             var lineItem = CreateLineItem(cartProduct, configurationItem);
 
-            AddProductSectionLineItem(lineItem, configurationItem.SectionId, configurationItem.Type);
-        }
-
-        protected virtual void AddProductSectionLineItem(LineItem lineItem, string sectionId, string type)
-        {
-            var item = AbstractTypeFactory<SectionLineItem>.TryCreateInstance();
-            item.SectionId = sectionId;
-            item.Type = type;
+            var item = CreateSectionLineItem(configurationItem);
             item.Item = lineItem;
 
             Items.Add(item);
@@ -106,22 +109,81 @@ namespace VirtoCommerce.XCart.Core
 
         public virtual void AddTextSectionLineItem(string customText, string sectionId)
         {
-            var item = AbstractTypeFactory<SectionLineItem>.TryCreateInstance();
-            item.SectionId = sectionId;
-            item.Type = ConfigurationSectionTypeText;
+            var item = CreateSectionLineItem(sectionId, ConfigurationSectionTypeText);
             item.CustomText = customText;
+
+            Items.Add(item);
+        }
+
+        /// <summary>
+        /// Adds a text section line item for an existing configuration item. Stores
+        /// <paramref name="configurationItem"/> on <see cref="SectionLineItem.Source"/>
+        /// for downstream consumers.
+        /// </summary>
+        public virtual void AddTextSectionLineItem(ConfigurationItem configurationItem)
+        {
+            var item = CreateSectionLineItem(configurationItem);
 
             Items.Add(item);
         }
 
         public virtual void AddFileSectionLineItem(IList<ConfigurationItemFile> files, string sectionId)
         {
-            var item = AbstractTypeFactory<SectionLineItem>.TryCreateInstance();
-            item.SectionId = sectionId;
-            item.Type = ConfigurationSectionTypeFile;
+            var item = CreateSectionLineItem(sectionId, ConfigurationSectionTypeFile);
             item.Files = files;
 
             Items.Add(item);
+        }
+
+        /// <summary>
+        /// Adds a file section line item for an existing configuration item. Stores
+        /// <paramref name="configurationItem"/> on <see cref="SectionLineItem.Source"/>
+        /// for downstream consumers.
+        /// </summary>
+        /// <param name="configurationItem">Source configuration item; its
+        /// <see cref="ConfigurationItem.Files"/> are used by default.</param>
+        /// <param name="files">Optional override for the file list. Pass a non-null value
+        /// when the files must be transformed before being added (e.g. duplicated for a
+        /// different currency context). When <c>null</c>, <c>configurationItem.Files</c>
+        /// is used.</param>
+        public virtual void AddFileSectionLineItem(ConfigurationItem configurationItem, IList<ConfigurationItemFile> files = null)
+        {
+            var item = CreateSectionLineItem(configurationItem);
+            if (files is not null)
+            {
+                item.Files = files;
+            }
+
+            Items.Add(item);
+        }
+
+        /// <summary>
+        /// Creates a <see cref="SectionLineItem"/> initialized from <paramref name="configurationItem"/>.
+        /// Override to populate additional fields from a derived <see cref="ConfigurationItem"/> type.
+        /// </summary>
+        protected virtual SectionLineItem CreateSectionLineItem(ConfigurationItem configurationItem)
+        {
+            var item = CreateSectionLineItem(configurationItem.SectionId, configurationItem.Type);
+
+            item.CustomText = configurationItem.CustomText;
+            item.Files = configurationItem.Files ?? [];
+            item.Source = configurationItem;
+
+            return item;
+        }
+
+        /// <summary>
+        /// Creates an empty <see cref="SectionLineItem"/> with the given identifying fields.
+        /// Used by both creation-path and source-aware overloads as the single point of
+        /// <see cref="AbstractTypeFactory{T}"/> construction.
+        /// </summary>
+        protected virtual SectionLineItem CreateSectionLineItem(string sectionId, string type)
+        {
+            var item = AbstractTypeFactory<SectionLineItem>.TryCreateInstance();
+            item.SectionId = sectionId;
+            item.Type = type;
+
+            return item;
         }
 
         public virtual ExpConfigurationLineItem CreateConfiguredLineItem(int quantity)
@@ -263,6 +325,15 @@ namespace VirtoCommerce.XCart.Core
             public LineItem Item { get; set; }
             public string CustomText { get; set; }
             public IList<ConfigurationItemFile> Files { get; set; } = [];
+
+            /// <summary>
+            /// Reference to the source <see cref="ConfigurationItem"/> from which this section line
+            /// item was built, when one exists. <c>null</c> for items added via creation-path
+            /// overloads (e.g. <see cref="AddTextSectionLineItem(string, string)"/>) where the
+            /// configuration item does not yet exist; non-null for items added via the source-aware
+            /// overloads (e.g. <see cref="AddTextSectionLineItem(ConfigurationItem)"/>).
+            /// </summary>
+            public ConfigurationItem Source { get; set; }
         }
     }
 }

--- a/src/VirtoCommerce.XCart.Core/Schemas/ConfigurableProductOptionKeyInput.cs
+++ b/src/VirtoCommerce.XCart.Core/Schemas/ConfigurableProductOptionKeyInput.cs
@@ -1,0 +1,17 @@
+using GraphQL.Types;
+using VirtoCommerce.XCart.Core.Models;
+
+namespace VirtoCommerce.XCart.Core.Schemas;
+
+/// <summary>
+/// Identifying subset of <see cref="ConfigurableProductOption"/> — only the fields required
+/// to locate an existing configuration item. <c>Quantity</c> and <c>SelectedForCheckout</c>
+/// are intentionally omitted because mutations that use this type do not modify them.
+/// </summary>
+public class ConfigurableProductOptionKeyInput : InputObjectGraphType<ConfigurableProductOption>
+{
+    public ConfigurableProductOptionKeyInput()
+    {
+        Field<NonNullGraphType<StringGraphType>>("productId").Description("Product ID");
+    }
+}

--- a/src/VirtoCommerce.XCart.Core/Schemas/ConfigurationSectionKeyInput.cs
+++ b/src/VirtoCommerce.XCart.Core/Schemas/ConfigurationSectionKeyInput.cs
@@ -1,0 +1,21 @@
+using GraphQL.Types;
+using VirtoCommerce.Xapi.Core.Schemas;
+using VirtoCommerce.XCart.Core.Models;
+
+namespace VirtoCommerce.XCart.Core.Schemas;
+
+/// <summary>
+/// Identifying subset of <see cref="ProductConfigurationSection"/> sufficient to locate
+/// an existing <see cref="VirtoCommerce.CartModule.Core.Model.ConfigurationItem"/> on a line item.
+/// Used by mutations that act on an already-configured item (e.g. selection toggling)
+/// where the full configuration payload is not relevant.
+/// </summary>
+public class ConfigurationSectionKeyInput : ExtendableInputObjectGraphType<ProductConfigurationSection>
+{
+    public ConfigurationSectionKeyInput()
+    {
+        Field<NonNullGraphType<StringGraphType>>("sectionId").Description("Configuration section ID");
+        Field<NonNullGraphType<StringGraphType>>("type").Description("Configuration section type. Possible values: 'Product', 'Variation', 'Text', 'File'");
+        Field<ConfigurableProductOptionKeyInput>("option").Description("Identifying subset of the configuration section option (Product/Variation only)");
+    }
+}

--- a/src/VirtoCommerce.XCart.Core/Schemas/InputChangeAllCartConfigurationItemsSelectedType.cs
+++ b/src/VirtoCommerce.XCart.Core/Schemas/InputChangeAllCartConfigurationItemsSelectedType.cs
@@ -1,0 +1,12 @@
+using GraphQL.Types;
+
+namespace VirtoCommerce.XCart.Core.Schemas
+{
+    public class InputChangeAllCartConfigurationItemsSelectedType : InputCartBaseType
+    {
+        public InputChangeAllCartConfigurationItemsSelectedType()
+        {
+            Field<NonNullGraphType<StringGraphType>>("lineItemId").Description("Line item Id");
+        }
+    }
+}

--- a/src/VirtoCommerce.XCart.Core/Schemas/InputChangeCartConfigurationItemSelectedType.cs
+++ b/src/VirtoCommerce.XCart.Core/Schemas/InputChangeCartConfigurationItemSelectedType.cs
@@ -1,0 +1,14 @@
+using GraphQL.Types;
+
+namespace VirtoCommerce.XCart.Core.Schemas
+{
+    public class InputChangeCartConfigurationItemSelectedType : InputCartBaseType
+    {
+        public InputChangeCartConfigurationItemSelectedType()
+        {
+            Field<NonNullGraphType<StringGraphType>>("lineItemId").Description("Line item Id");
+            Field<NonNullGraphType<ConfigurationSectionKeyInput>>("configurationSection").Description("Configuration section that identifies the configuration item to toggle");
+            Field<NonNullGraphType<BooleanGraphType>>("selectedForCheckout").Description("Is configuration item selected for checkout");
+        }
+    }
+}

--- a/src/VirtoCommerce.XCart.Core/Schemas/InputChangeCartConfigurationItemsSelectedType.cs
+++ b/src/VirtoCommerce.XCart.Core/Schemas/InputChangeCartConfigurationItemsSelectedType.cs
@@ -1,0 +1,13 @@
+using GraphQL.Types;
+
+namespace VirtoCommerce.XCart.Core.Schemas
+{
+    public class InputChangeCartConfigurationItemsSelectedType : InputCartBaseType
+    {
+        public InputChangeCartConfigurationItemsSelectedType()
+        {
+            Field<NonNullGraphType<StringGraphType>>("lineItemId").Description("Line item Id");
+            Field<ListGraphType<NonNullGraphType<ConfigurationSectionKeyInput>>>("configurationSections").Description("Configuration sections that identify the configuration items to toggle");
+        }
+    }
+}

--- a/src/VirtoCommerce.XCart.Core/Schemas/InputChangeCartConfigurationItemsSelectedType.cs
+++ b/src/VirtoCommerce.XCart.Core/Schemas/InputChangeCartConfigurationItemsSelectedType.cs
@@ -7,7 +7,7 @@ namespace VirtoCommerce.XCart.Core.Schemas
         public InputChangeCartConfigurationItemsSelectedType()
         {
             Field<NonNullGraphType<StringGraphType>>("lineItemId").Description("Line item Id");
-            Field<ListGraphType<NonNullGraphType<ConfigurationSectionKeyInput>>>("configurationSections").Description("Configuration sections that identify the configuration items to toggle");
+            Field<NonNullGraphType<ListGraphType<NonNullGraphType<ConfigurationSectionKeyInput>>>>("configurationSections").Description("Configuration sections that identify the configuration items to toggle");
         }
     }
 }

--- a/src/VirtoCommerce.XCart.Data/Commands/ChangeAllCartConfigurationItemsSelectedCommandHandler.cs
+++ b/src/VirtoCommerce.XCart.Data/Commands/ChangeAllCartConfigurationItemsSelectedCommandHandler.cs
@@ -1,0 +1,26 @@
+using System.Threading;
+using System.Threading.Tasks;
+using VirtoCommerce.XCart.Core;
+using VirtoCommerce.XCart.Core.Commands;
+using VirtoCommerce.XCart.Core.Commands.BaseCommands;
+using VirtoCommerce.XCart.Core.Services;
+
+namespace VirtoCommerce.XCart.Data.Commands
+{
+    public class ChangeAllCartConfigurationItemsSelectedCommandHandler : CartCommandHandler<ChangeAllCartConfigurationItemsSelectedCommand>
+    {
+        public ChangeAllCartConfigurationItemsSelectedCommandHandler(ICartAggregateRepository cartAggregateRepository)
+            : base(cartAggregateRepository)
+        {
+        }
+
+        public override async Task<CartAggregate> Handle(ChangeAllCartConfigurationItemsSelectedCommand request, CancellationToken cancellationToken)
+        {
+            var cartAggregate = await GetOrCreateCartFromCommandAsync(request);
+
+            await cartAggregate.ChangeAllConfigurationItemsSelectedAsync(request.LineItemId, request.SelectedForCheckout);
+
+            return await SaveCartAsync(cartAggregate);
+        }
+    }
+}

--- a/src/VirtoCommerce.XCart.Data/Commands/ChangeCartConfigurationItemSelectedCommandBuilder.cs
+++ b/src/VirtoCommerce.XCart.Data/Commands/ChangeCartConfigurationItemSelectedCommandBuilder.cs
@@ -1,0 +1,20 @@
+using MediatR;
+using Microsoft.AspNetCore.Authorization;
+using VirtoCommerce.Xapi.Core.Infrastructure;
+using VirtoCommerce.XCart.Core.Commands;
+using VirtoCommerce.XCart.Core.Schemas;
+using VirtoCommerce.XCart.Core.Services;
+using VirtoCommerce.XCart.Data.Commands.BaseCommands;
+
+namespace VirtoCommerce.XCart.Data.Commands;
+
+public class ChangeCartConfigurationItemSelectedCommandBuilder(
+    IMediator mediator,
+    IAuthorizationService authorizationService,
+    IDistributedLockService distributedLockService,
+    ICartAggregateRepository cartRepository)
+    : CartCommandBuilder<ChangeCartConfigurationItemSelectedCommand, InputChangeCartConfigurationItemSelectedType>(
+        mediator, authorizationService, distributedLockService, cartRepository)
+{
+    protected override string Name => "changeCartConfigurationItemSelected";
+}

--- a/src/VirtoCommerce.XCart.Data/Commands/ChangeCartConfigurationItemSelectedCommandHandler.cs
+++ b/src/VirtoCommerce.XCart.Data/Commands/ChangeCartConfigurationItemSelectedCommandHandler.cs
@@ -1,0 +1,26 @@
+using System.Threading;
+using System.Threading.Tasks;
+using VirtoCommerce.XCart.Core;
+using VirtoCommerce.XCart.Core.Commands;
+using VirtoCommerce.XCart.Core.Commands.BaseCommands;
+using VirtoCommerce.XCart.Core.Services;
+
+namespace VirtoCommerce.XCart.Data.Commands
+{
+    public class ChangeCartConfigurationItemSelectedCommandHandler : CartCommandHandler<ChangeCartConfigurationItemSelectedCommand>
+    {
+        public ChangeCartConfigurationItemSelectedCommandHandler(ICartAggregateRepository cartAggregateRepository)
+            : base(cartAggregateRepository)
+        {
+        }
+
+        public override async Task<CartAggregate> Handle(ChangeCartConfigurationItemSelectedCommand request, CancellationToken cancellationToken)
+        {
+            var cartAggregate = await GetOrCreateCartFromCommandAsync(request);
+
+            await cartAggregate.ChangeConfigurationItemSelectedAsync(request.LineItemId, request.ConfigurationSection, request.SelectedForCheckout);
+
+            return await SaveCartAsync(cartAggregate);
+        }
+    }
+}

--- a/src/VirtoCommerce.XCart.Data/Commands/ChangeCartConfigurationItemsSelectedCommandHandler.cs
+++ b/src/VirtoCommerce.XCart.Data/Commands/ChangeCartConfigurationItemsSelectedCommandHandler.cs
@@ -1,0 +1,26 @@
+using System.Threading;
+using System.Threading.Tasks;
+using VirtoCommerce.XCart.Core;
+using VirtoCommerce.XCart.Core.Commands;
+using VirtoCommerce.XCart.Core.Commands.BaseCommands;
+using VirtoCommerce.XCart.Core.Services;
+
+namespace VirtoCommerce.XCart.Data.Commands
+{
+    public class ChangeCartConfigurationItemsSelectedCommandHandler : CartCommandHandler<ChangeCartConfigurationItemsSelectedCommand>
+    {
+        public ChangeCartConfigurationItemsSelectedCommandHandler(ICartAggregateRepository cartAggregateRepository)
+            : base(cartAggregateRepository)
+        {
+        }
+
+        public override async Task<CartAggregate> Handle(ChangeCartConfigurationItemsSelectedCommand request, CancellationToken cancellationToken)
+        {
+            var cartAggregate = await GetOrCreateCartFromCommandAsync(request);
+
+            await cartAggregate.ChangeConfigurationItemsSelectedAsync(request.LineItemId, request.ConfigurationSections, request.SelectedForCheckout);
+
+            return await SaveCartAsync(cartAggregate);
+        }
+    }
+}

--- a/src/VirtoCommerce.XCart.Data/Commands/ChangeCartCurrencyCommandHandler.cs
+++ b/src/VirtoCommerce.XCart.Data/Commands/ChangeCartCurrencyCommandHandler.cs
@@ -177,12 +177,12 @@ namespace VirtoCommerce.XCart.Data.Commands
                         break;
                     }
                     case ConfigurationSectionTypeText:
-                        container.AddTextSectionLineItem(configurationItem.CustomText, configurationItem.SectionId);
+                        container.AddTextSectionLineItem(configurationItem);
                         break;
                     case ConfigurationSectionTypeFile:
                     {
                         var files = await CopyConfigurationFiles(configurationItem, currentCurrencyCartAggregate.Cart);
-                        container.AddFileSectionLineItem(files, configurationItem.SectionId);
+                        container.AddFileSectionLineItem(configurationItem, files);
                         break;
                     }
                 }

--- a/src/VirtoCommerce.XCart.Data/Commands/ChangeCartCurrencyCommandHandler.cs
+++ b/src/VirtoCommerce.XCart.Data/Commands/ChangeCartCurrencyCommandHandler.cs
@@ -201,7 +201,7 @@ namespace VirtoCommerce.XCart.Data.Commands
 
             if (fileUrls.IsNullOrEmpty())
             {
-                return null;
+                return [];
             }
 
             return (await _fileUploadService.GetByPublicUrlAsync(fileUrls))

--- a/src/VirtoCommerce.XCart.Data/Commands/SelectAllCartConfigurationItemsCommandBuilder.cs
+++ b/src/VirtoCommerce.XCart.Data/Commands/SelectAllCartConfigurationItemsCommandBuilder.cs
@@ -1,0 +1,29 @@
+using GraphQL;
+using MediatR;
+using Microsoft.AspNetCore.Authorization;
+using VirtoCommerce.Xapi.Core.Infrastructure;
+using VirtoCommerce.XCart.Core.Commands;
+using VirtoCommerce.XCart.Core.Schemas;
+using VirtoCommerce.XCart.Core.Services;
+using VirtoCommerce.XCart.Data.Commands.BaseCommands;
+
+namespace VirtoCommerce.XCart.Data.Commands;
+
+public class SelectAllCartConfigurationItemsCommandBuilder(
+    IMediator mediator,
+    IAuthorizationService authorizationService,
+    IDistributedLockService distributedLockService,
+    ICartAggregateRepository cartRepository)
+    : CartCommandBuilder<ChangeAllCartConfigurationItemsSelectedCommand, InputChangeAllCartConfigurationItemsSelectedType>(
+        mediator, authorizationService, distributedLockService, cartRepository)
+{
+    protected override string Name => "selectAllCartConfigurationItems";
+
+    protected override ChangeAllCartConfigurationItemsSelectedCommand GetRequest(IResolveFieldContext<object> context)
+    {
+        var request = base.GetRequest(context);
+        request.SelectedForCheckout = true;
+
+        return request;
+    }
+}

--- a/src/VirtoCommerce.XCart.Data/Commands/SelectCartConfigurationItemsCommandBuilder.cs
+++ b/src/VirtoCommerce.XCart.Data/Commands/SelectCartConfigurationItemsCommandBuilder.cs
@@ -1,0 +1,29 @@
+using GraphQL;
+using MediatR;
+using Microsoft.AspNetCore.Authorization;
+using VirtoCommerce.Xapi.Core.Infrastructure;
+using VirtoCommerce.XCart.Core.Commands;
+using VirtoCommerce.XCart.Core.Schemas;
+using VirtoCommerce.XCart.Core.Services;
+using VirtoCommerce.XCart.Data.Commands.BaseCommands;
+
+namespace VirtoCommerce.XCart.Data.Commands;
+
+public class SelectCartConfigurationItemsCommandBuilder(
+    IMediator mediator,
+    IAuthorizationService authorizationService,
+    IDistributedLockService distributedLockService,
+    ICartAggregateRepository cartRepository)
+    : CartCommandBuilder<ChangeCartConfigurationItemsSelectedCommand, InputChangeCartConfigurationItemsSelectedType>(
+        mediator, authorizationService, distributedLockService, cartRepository)
+{
+    protected override string Name => "selectCartConfigurationItems";
+
+    protected override ChangeCartConfigurationItemsSelectedCommand GetRequest(IResolveFieldContext<object> context)
+    {
+        var request = base.GetRequest(context);
+        request.SelectedForCheckout = true;
+
+        return request;
+    }
+}

--- a/src/VirtoCommerce.XCart.Data/Commands/UnSelectAllCartConfigurationItemsCommandBuilder.cs
+++ b/src/VirtoCommerce.XCart.Data/Commands/UnSelectAllCartConfigurationItemsCommandBuilder.cs
@@ -1,0 +1,20 @@
+using MediatR;
+using Microsoft.AspNetCore.Authorization;
+using VirtoCommerce.Xapi.Core.Infrastructure;
+using VirtoCommerce.XCart.Core.Commands;
+using VirtoCommerce.XCart.Core.Schemas;
+using VirtoCommerce.XCart.Core.Services;
+using VirtoCommerce.XCart.Data.Commands.BaseCommands;
+
+namespace VirtoCommerce.XCart.Data.Commands;
+
+public class UnSelectAllCartConfigurationItemsCommandBuilder(
+    IMediator mediator,
+    IAuthorizationService authorizationService,
+    IDistributedLockService distributedLockService,
+    ICartAggregateRepository cartRepository)
+    : CartCommandBuilder<ChangeAllCartConfigurationItemsSelectedCommand, InputChangeAllCartConfigurationItemsSelectedType>(
+        mediator, authorizationService, distributedLockService, cartRepository)
+{
+    protected override string Name => "unSelectAllCartConfigurationItems";
+}

--- a/src/VirtoCommerce.XCart.Data/Commands/UnSelectCartConfigurationItemsCommandBuilder.cs
+++ b/src/VirtoCommerce.XCart.Data/Commands/UnSelectCartConfigurationItemsCommandBuilder.cs
@@ -1,0 +1,20 @@
+using MediatR;
+using Microsoft.AspNetCore.Authorization;
+using VirtoCommerce.Xapi.Core.Infrastructure;
+using VirtoCommerce.XCart.Core.Commands;
+using VirtoCommerce.XCart.Core.Schemas;
+using VirtoCommerce.XCart.Core.Services;
+using VirtoCommerce.XCart.Data.Commands.BaseCommands;
+
+namespace VirtoCommerce.XCart.Data.Commands;
+
+public class UnSelectCartConfigurationItemsCommandBuilder(
+    IMediator mediator,
+    IAuthorizationService authorizationService,
+    IDistributedLockService distributedLockService,
+    ICartAggregateRepository cartRepository)
+    : CartCommandBuilder<ChangeCartConfigurationItemsSelectedCommand, InputChangeCartConfigurationItemsSelectedType>(
+        mediator, authorizationService, distributedLockService, cartRepository)
+{
+    protected override string Name => "unSelectCartConfigurationItems";
+}

--- a/tests/VirtoCommerce.XCart.Tests/Aggregates/CartAggregateTests.cs
+++ b/tests/VirtoCommerce.XCart.Tests/Aggregates/CartAggregateTests.cs
@@ -2739,5 +2739,305 @@ namespace VirtoCommerce.XCart.Tests.Aggregates
         }
 
         #endregion ConfigurationItem Validation
+
+        #region ChangeConfigurationItemSelected
+
+        private static ProductConfigurationSection VariationSectionRef(string sectionId, string productId)
+        {
+            return new ProductConfigurationSection
+            {
+                SectionId = sectionId,
+                Type = "Variation",
+                Option = new ConfigurableProductOption { ProductId = productId },
+            };
+        }
+
+        [Fact]
+        public async Task ChangeConfigurationItemSelectedAsync_NullLineItemId_ShouldThrow()
+        {
+            var cartAggregate = GetValidCartAggregate();
+
+            var action = async () => await cartAggregate.ChangeConfigurationItemSelectedAsync(null, VariationSectionRef("section-1", "p1"), true);
+
+            await action.Should().ThrowExactlyAsync<ArgumentNullException>();
+        }
+
+        [Fact]
+        public async Task ChangeConfigurationItemSelectedAsync_NullConfigurationSection_ShouldThrow()
+        {
+            var cartAggregate = GetValidCartAggregate();
+
+            var action = async () => await cartAggregate.ChangeConfigurationItemSelectedAsync("line-item-1", null, true);
+
+            await action.Should().ThrowExactlyAsync<ArgumentNullException>();
+        }
+
+        [Fact]
+        public async Task ChangeConfigurationItemSelectedAsync_ShouldFlipFlag_OnMatchingConfigItem()
+        {
+            // Arrange
+            var cartAggregate = GetValidCartAggregate();
+            var configItem = new ConfigurationItem { Id = "config-1", SectionId = "size", Type = "Variation", ProductId = "p1", SelectedForCheckout = true };
+            var lineItem = new LineItem
+            {
+                Id = "line-item-1",
+                ProductId = "configurable-product",
+                IsConfigured = true,
+                ConfigurationItems = new List<ConfigurationItem> { configItem },
+            };
+            cartAggregate.Cart.Items.Add(lineItem);
+
+            _cartProductServiceMock.Setup(x => x.GetCartProductsByIdsAsync(It.IsAny<CartAggregate>(), It.IsAny<IList<string>>()))
+                .ReturnsAsync([]);
+
+            // Act
+            await cartAggregate.ChangeConfigurationItemSelectedAsync(lineItem.Id, VariationSectionRef("size", "p1"), false);
+
+            // Assert
+            configItem.SelectedForCheckout.Should().BeFalse();
+            _cartProductServiceMock.Verify(x => x.GetCartProductsByIdsAsync(cartAggregate, It.IsAny<IList<string>>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task ChangeConfigurationItemSelectedAsync_ShouldFlipFlag_OnTextSection()
+        {
+            // Arrange — Text/File sections are unique by (Type, SectionId); Option.ProductId is irrelevant.
+            var cartAggregate = GetValidCartAggregate();
+            var textConfigItem = new ConfigurationItem { Id = "text-1", SectionId = "label", Type = "Text", CustomText = "hello", SelectedForCheckout = true };
+            var lineItem = new LineItem
+            {
+                Id = "line-item-1",
+                ProductId = "configurable-product",
+                IsConfigured = true,
+                ConfigurationItems = new List<ConfigurationItem> { textConfigItem },
+            };
+            cartAggregate.Cart.Items.Add(lineItem);
+
+            _cartProductServiceMock.Setup(x => x.GetCartProductsByIdsAsync(It.IsAny<CartAggregate>(), It.IsAny<IList<string>>()))
+                .ReturnsAsync([]);
+
+            var textSection = new ProductConfigurationSection { SectionId = "label", Type = "Text" };
+
+            // Act
+            await cartAggregate.ChangeConfigurationItemSelectedAsync(lineItem.Id, textSection, false);
+
+            // Assert
+            textConfigItem.SelectedForCheckout.Should().BeFalse();
+        }
+
+        [Fact]
+        public async Task ChangeConfigurationItemsSelectedAsync_ShouldFlipFlagsForMatching_LeavingOthersUnchanged()
+        {
+            // Arrange — three Variation items in one section, discriminated by ProductId.
+            var cartAggregate = GetValidCartAggregate();
+            var configA = new ConfigurationItem { Id = "config-a", SectionId = "size", Type = "Variation", ProductId = "pa", SelectedForCheckout = true };
+            var configB = new ConfigurationItem { Id = "config-b", SectionId = "size", Type = "Variation", ProductId = "pb", SelectedForCheckout = true };
+            var configC = new ConfigurationItem { Id = "config-c", SectionId = "size", Type = "Variation", ProductId = "pc", SelectedForCheckout = true };
+            var lineItem = new LineItem
+            {
+                Id = "line-item-1",
+                ProductId = "configurable-product",
+                IsConfigured = true,
+                ConfigurationItems = new List<ConfigurationItem> { configA, configB, configC },
+            };
+            cartAggregate.Cart.Items.Add(lineItem);
+
+            _cartProductServiceMock.Setup(x => x.GetCartProductsByIdsAsync(It.IsAny<CartAggregate>(), It.IsAny<IList<string>>()))
+                .ReturnsAsync([]);
+
+            // Act
+            await cartAggregate.ChangeConfigurationItemsSelectedAsync(
+                lineItem.Id,
+                [VariationSectionRef("size", "pa"), VariationSectionRef("size", "pc")],
+                false);
+
+            // Assert
+            configA.SelectedForCheckout.Should().BeFalse();
+            configB.SelectedForCheckout.Should().BeTrue("pb was not in the selection list");
+            configC.SelectedForCheckout.Should().BeFalse();
+        }
+
+        [Fact]
+        public async Task ChangeConfigurationItemsSelectedAsync_OtherLineItemConfigItems_AreUntouched()
+        {
+            // Arrange
+            var cartAggregate = GetValidCartAggregate();
+            var configInTarget = new ConfigurationItem { Id = "config-1", SectionId = "size", Type = "Variation", ProductId = "p1", SelectedForCheckout = true };
+            var configInOther = new ConfigurationItem { Id = "config-2", SectionId = "size", Type = "Variation", ProductId = "p1", SelectedForCheckout = true };
+            cartAggregate.Cart.Items.Add(new LineItem
+            {
+                Id = "target-line",
+                ProductId = "configurable-product",
+                IsConfigured = true,
+                ConfigurationItems = new List<ConfigurationItem> { configInTarget },
+            });
+            cartAggregate.Cart.Items.Add(new LineItem
+            {
+                Id = "other-line",
+                ProductId = "configurable-product",
+                IsConfigured = true,
+                ConfigurationItems = new List<ConfigurationItem> { configInOther },
+            });
+
+            _cartProductServiceMock.Setup(x => x.GetCartProductsByIdsAsync(It.IsAny<CartAggregate>(), It.IsAny<IList<string>>()))
+                .ReturnsAsync([]);
+
+            // Act — section ref matches both lineItems' configItems, but lineItemId scopes the lookup.
+            await cartAggregate.ChangeConfigurationItemsSelectedAsync("target-line", [VariationSectionRef("size", "p1")], false);
+
+            // Assert
+            configInTarget.SelectedForCheckout.Should().BeFalse();
+            configInOther.SelectedForCheckout.Should().BeTrue("the other lineItem's configItem must not be touched");
+        }
+
+        [Fact]
+        public async Task ChangeConfigurationItemsSelectedAsync_LineItemNotFound_ShouldAddValidationError_AndNotReprice()
+        {
+            // Arrange
+            var cartAggregate = GetValidCartAggregate();
+
+            // Act
+            await cartAggregate.ChangeConfigurationItemsSelectedAsync("missing-line-item", [VariationSectionRef("size", "p1")], false);
+
+            // Assert
+            cartAggregate.OperationValidationErrors.Should().Contain(x => x.ErrorCode == "CONFIGURED_LINE_ITEM_NOT_FOUND");
+            _cartProductServiceMock.Verify(x => x.GetCartProductsByIdsAsync(It.IsAny<CartAggregate>(), It.IsAny<IList<string>>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task ChangeConfigurationItemsSelectedAsync_NoChange_ShouldNotReprice()
+        {
+            // Arrange — config item already at desired state.
+            var cartAggregate = GetValidCartAggregate();
+            var configItem = new ConfigurationItem { Id = "config-1", SectionId = "size", Type = "Variation", ProductId = "p1", SelectedForCheckout = false };
+            var lineItem = new LineItem
+            {
+                Id = "line-item-1",
+                ProductId = "configurable-product",
+                IsConfigured = true,
+                ConfigurationItems = new List<ConfigurationItem> { configItem },
+            };
+            cartAggregate.Cart.Items.Add(lineItem);
+
+            // Act
+            await cartAggregate.ChangeConfigurationItemsSelectedAsync(lineItem.Id, [VariationSectionRef("size", "p1")], false);
+
+            // Assert
+            configItem.SelectedForCheckout.Should().BeFalse();
+            _cartProductServiceMock.Verify(x => x.GetCartProductsByIdsAsync(It.IsAny<CartAggregate>(), It.IsAny<IList<string>>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task ChangeConfigurationItemsSelectedAsync_UnmatchedSection_ShouldNoOp()
+        {
+            // Arrange — section ref points at a non-existent (sectionId, productId).
+            var cartAggregate = GetValidCartAggregate();
+            var configItem = new ConfigurationItem { Id = "config-1", SectionId = "size", Type = "Variation", ProductId = "p1", SelectedForCheckout = true };
+            var lineItem = new LineItem
+            {
+                Id = "line-item-1",
+                ProductId = "configurable-product",
+                IsConfigured = true,
+                ConfigurationItems = new List<ConfigurationItem> { configItem },
+            };
+            cartAggregate.Cart.Items.Add(lineItem);
+
+            // Act
+            await cartAggregate.ChangeConfigurationItemsSelectedAsync(lineItem.Id, [VariationSectionRef("size", "non-existent")], false);
+
+            // Assert
+            configItem.SelectedForCheckout.Should().BeTrue("no item matched, nothing should change");
+            _cartProductServiceMock.Verify(x => x.GetCartProductsByIdsAsync(It.IsAny<CartAggregate>(), It.IsAny<IList<string>>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task ChangeConfigurationItemsSelectedAsync_EmptySectionList_ShouldNoOp()
+        {
+            // Arrange
+            var cartAggregate = GetValidCartAggregate();
+            var configItem = new ConfigurationItem { Id = "config-1", SectionId = "size", Type = "Variation", ProductId = "p1", SelectedForCheckout = true };
+            var lineItem = new LineItem
+            {
+                Id = "line-item-1",
+                ProductId = "configurable-product",
+                IsConfigured = true,
+                ConfigurationItems = new List<ConfigurationItem> { configItem },
+            };
+            cartAggregate.Cart.Items.Add(lineItem);
+
+            // Act
+            await cartAggregate.ChangeConfigurationItemsSelectedAsync(lineItem.Id, [], false);
+
+            // Assert
+            configItem.SelectedForCheckout.Should().BeTrue("empty section list must not flip anything");
+            _cartProductServiceMock.Verify(x => x.GetCartProductsByIdsAsync(It.IsAny<CartAggregate>(), It.IsAny<IList<string>>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task ChangeAllConfigurationItemsSelectedAsync_ShouldFlipAllConfigItems()
+        {
+            // Arrange
+            var cartAggregate = GetValidCartAggregate();
+            var configA = new ConfigurationItem { Id = "config-a", ProductId = "pa", SelectedForCheckout = true };
+            var configB = new ConfigurationItem { Id = "config-b", ProductId = "pb", SelectedForCheckout = true };
+            var lineItem = new LineItem
+            {
+                Id = "line-item-1",
+                ProductId = "configurable-product",
+                IsConfigured = true,
+                ConfigurationItems = new List<ConfigurationItem> { configA, configB },
+            };
+            cartAggregate.Cart.Items.Add(lineItem);
+
+            _cartProductServiceMock.Setup(x => x.GetCartProductsByIdsAsync(It.IsAny<CartAggregate>(), It.IsAny<IList<string>>()))
+                .ReturnsAsync([]);
+
+            // Act
+            await cartAggregate.ChangeAllConfigurationItemsSelectedAsync(lineItem.Id, false);
+
+            // Assert
+            configA.SelectedForCheckout.Should().BeFalse();
+            configB.SelectedForCheckout.Should().BeFalse();
+            _cartProductServiceMock.Verify(x => x.GetCartProductsByIdsAsync(cartAggregate, It.IsAny<IList<string>>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task ChangeAllConfigurationItemsSelectedAsync_LineItemNotFound_ShouldAddValidationError()
+        {
+            // Arrange
+            var cartAggregate = GetValidCartAggregate();
+
+            // Act
+            await cartAggregate.ChangeAllConfigurationItemsSelectedAsync("missing-line-item", false);
+
+            // Assert
+            cartAggregate.OperationValidationErrors.Should().Contain(x => x.ErrorCode == "CONFIGURED_LINE_ITEM_NOT_FOUND");
+            _cartProductServiceMock.Verify(x => x.GetCartProductsByIdsAsync(It.IsAny<CartAggregate>(), It.IsAny<IList<string>>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task ChangeAllConfigurationItemsSelectedAsync_AlreadyAtDesiredState_ShouldNotReprice()
+        {
+            // Arrange
+            var cartAggregate = GetValidCartAggregate();
+            var configA = new ConfigurationItem { Id = "config-a", ProductId = "pa", SelectedForCheckout = false };
+            var configB = new ConfigurationItem { Id = "config-b", ProductId = "pb", SelectedForCheckout = false };
+            var lineItem = new LineItem
+            {
+                Id = "line-item-1",
+                ProductId = "configurable-product",
+                IsConfigured = true,
+                ConfigurationItems = new List<ConfigurationItem> { configA, configB },
+            };
+            cartAggregate.Cart.Items.Add(lineItem);
+
+            // Act
+            await cartAggregate.ChangeAllConfigurationItemsSelectedAsync(lineItem.Id, false);
+
+            // Assert
+            _cartProductServiceMock.Verify(x => x.GetCartProductsByIdsAsync(It.IsAny<CartAggregate>(), It.IsAny<IList<string>>()), Times.Never);
+        }
+
+        #endregion ChangeConfigurationItemSelected
     }
 }

--- a/tests/VirtoCommerce.XCart.Tests/Aggregates/ConfiguredLineItemContainerTests.cs
+++ b/tests/VirtoCommerce.XCart.Tests/Aggregates/ConfiguredLineItemContainerTests.cs
@@ -1,0 +1,153 @@
+using System.Collections.Generic;
+using FluentAssertions;
+using VirtoCommerce.CartModule.Core.Model;
+using VirtoCommerce.CatalogModule.Core.Model;
+using VirtoCommerce.CoreModule.Core.Common;
+using VirtoCommerce.CoreModule.Core.Currency;
+using VirtoCommerce.XCart.Core;
+using VirtoCommerce.XCart.Core.Models;
+using Xunit;
+using static VirtoCommerce.CatalogModule.Core.ModuleConstants;
+
+namespace VirtoCommerce.XCart.Tests.Aggregates
+{
+    /// <summary>
+    /// Pins down the <c>SectionLineItem.Source</c> contract on
+    /// <see cref="ConfiguredLineItemContainer"/>: source-aware overloads link
+    /// <see cref="ConfigurationItem"/> by reference; creation-path overloads leave
+    /// <c>Source</c> as <c>null</c>.
+    /// </summary>
+    public class ConfiguredLineItemContainerTests
+    {
+        private const string EngravingText = "ENGRAVING";
+
+        private readonly TestableContainer _container;
+
+        public ConfiguredLineItemContainerTests()
+        {
+            _container = new TestableContainer
+            {
+                Currency = new Currency(new Language("en-US"), "USD"),
+                CultureName = "en-US",
+            };
+        }
+
+        [Fact]
+        public void AddProductSectionLineItem_WithConfigurationItem_LinksSourceByReference()
+        {
+            var configurationItem = NewConfigurationItem("sec-product", ConfigurationSectionTypeProduct);
+            var cartProduct = NewCartProduct();
+
+            _container.AddProductSectionLineItem(cartProduct, configurationItem);
+
+            _container.SourceAt(0).Should().BeSameAs(configurationItem,
+                "source-aware overloads must store the ConfigurationItem by reference, not a clone");
+        }
+
+        [Fact]
+        public void AddTextSectionLineItem_WithConfigurationItem_LinksSource_AndCopiesCustomText()
+        {
+            var configurationItem = NewConfigurationItem("sec-text", ConfigurationSectionTypeText);
+            configurationItem.CustomText = EngravingText;
+
+            _container.AddTextSectionLineItem(configurationItem);
+
+            _container.SourceAt(0).Should().BeSameAs(configurationItem);
+            _container.CustomTextAt(0).Should().Be(EngravingText);
+        }
+
+        [Fact]
+        public void AddFileSectionLineItem_WithConfigurationItem_NoOverride_UsesSourceFilesByReference()
+        {
+            var sourceFiles = new List<ConfigurationItemFile>
+            {
+                new() { Name = "front.png", Url = "/files/front.png" },
+            };
+            var configurationItem = NewConfigurationItem("sec-file", ConfigurationSectionTypeFile);
+            configurationItem.Files = sourceFiles;
+
+            _container.AddFileSectionLineItem(configurationItem);
+
+            _container.SourceAt(0).Should().BeSameAs(configurationItem);
+            _container.FilesAt(0).Should().BeSameAs(sourceFiles,
+                "with files=null, the source file list must propagate as-is");
+        }
+
+        [Fact]
+        public void AddFileSectionLineItem_WithExplicitFiles_OverridesFiles_AndPreservesSourceLink()
+        {
+            var configurationItem = NewConfigurationItem("sec-file", ConfigurationSectionTypeFile);
+            configurationItem.Files = new List<ConfigurationItemFile> { new() { Name = "old.png" } };
+
+            var customFiles = new List<ConfigurationItemFile>
+            {
+                new() { Name = "transformed.png", Url = "/files/transformed.png" },
+            };
+
+            _container.AddFileSectionLineItem(configurationItem, customFiles);
+
+            _container.SourceAt(0).Should().BeSameAs(configurationItem,
+                "explicit files override must not break the source link");
+            _container.FilesAt(0).Should().BeSameAs(customFiles,
+                "non-null files argument must override source.Files");
+        }
+
+        [Fact]
+        public void AddTextSectionLineItem_CreationPath_LeavesSourceNull()
+        {
+            _container.AddTextSectionLineItem(EngravingText, "sec-text");
+
+            _container.SourceAt(0).Should().BeNull(
+                "creation-path overloads have no ConfigurationItem yet — Source is null by design");
+            _container.CustomTextAt(0).Should().Be(EngravingText);
+        }
+
+        [Fact]
+        public void AddFileSectionLineItem_CreationPath_LeavesSourceNull()
+        {
+            var files = new List<ConfigurationItemFile>
+            {
+                new() { Name = "creation.png" },
+            };
+
+            _container.AddFileSectionLineItem(files, "sec-file");
+
+            _container.SourceAt(0).Should().BeNull();
+            _container.FilesAt(0).Should().BeSameAs(files);
+        }
+
+        private static ConfigurationItem NewConfigurationItem(string sectionId, string type)
+        {
+            return new ConfigurationItem
+            {
+                SectionId = sectionId,
+                Type = type,
+            };
+        }
+
+        private static CartProduct NewCartProduct()
+        {
+            var catalogProduct = new CatalogProduct
+            {
+                Id = "test-product",
+                Code = "TEST-CODE",
+            };
+
+            return new CartProduct(catalogProduct);
+        }
+
+        /// <summary>
+        /// Exposes assertion-friendly accessors on the protected <c>Items</c> collection
+        /// without leaking the protected <c>SectionLineItem</c> nested type into the outer
+        /// test class.
+        /// </summary>
+        private sealed class TestableContainer : ConfiguredLineItemContainer
+        {
+            public ConfigurationItem SourceAt(int index) => Items[index].Source;
+
+            public string CustomTextAt(int index) => Items[index].CustomText;
+
+            public IList<ConfigurationItemFile> FilesAt(int index) => Items[index].Files;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds five GraphQL mutations for toggling `ConfigurationItem.SelectedForCheckout`, mirroring the existing `lineItem` selection family. Until now, flipping a single `selectedForCheckout` on a nested config item required calling `updateConfigurationItem`, which has `productId`/`quantity` as `NonNull` inputs and reloads catalog products + runs full validation just to change a boolean.

### New mutations

| Mutation | Behavior |
|---|---|
| `changeCartConfigurationItemSelected` | Single config item, explicit `selectedForCheckout` |
| `selectCartConfigurationItems` / `unSelectCartConfigurationItems` | Batch within one `lineItem` (hardcoded true / false) |
| `selectAllCartConfigurationItems` / `unSelectAllCartConfigurationItems` | All config items within one `lineItem` |

All five are scoped to a single `LineItemId` for two reasons: scoping the "all" operation, and giving the handler an exact reprice target.

### Identification model

Configuration items are identified by **`ConfigurationSectionKeyInput`** — a new lightweight input type carrying only the fields that `FindConfigurationItem` (CartAggregate.cs) needs:

- `sectionId: String!`
- `type: String!`
- `option: ConfigurableProductOptionKeyInput` (only `productId` — required for `Variation`, omitted for `Product` / `Text` / `File`)

This matches how `Add/Update/RemoveConfigurationItem` already identify items (via `ProductConfigurationSection` shape) — same lookup path, no new identification convention introduced. Clients don't need to send `quantity`, `customText`, etc. that selection mutations would silently ignore. Both new input types deserialize into the existing `ProductConfigurationSection` / `ConfigurableProductOption` C# models, so the aggregate signature accepts the same model type the existing config-item mutations already use — **no model changes**.

### Registration

Mutations register via the modern `CommandBuilder` auto-discovery path (`AddSchemaBuilders` scans for `ISchemaBuilder` implementations). No `PurchaseSchema.cs` touched — that file remains the legacy `FieldBuilder` flow and migrating its existing `changeCartItemSelected` family to the new pattern is intentionally out of scope (separate refactor).

### CartAggregate methods

Five new virtual methods following the existing `UpdateConfigurationItemsAsync` precedent — public-by-id entry points reuse `GetConfiguredLineItem` and emit `CartErrorDescriber.ConfiguredLineItemNotFound` on miss; protected-by-LineItem overloads are the extension surface for subclasses.

**Critical asymmetry vs. `ChangeItemsSelectedAsync` (lineItems):** the new methods explicitly call `UpdateConfiguredLineItemPrice` because `configItem.SelectedForCheckout` is filtered inside `ConfiguredLineItemContainer.UpdatePrice` when summing into `lineItem.ListPrice`. LineItem-level selection has no such effect on price, hence the existing method skips repricing. A no-change short-circuit ensures the heavy reprice path runs only when at least one flag actually flips — relevant for batch UIs that resend the entire selection state on every interaction.

### Drive-by cleanup

`AddConfigurationItemsAsync(string, ...)` and `UpdateConfigurationItemsAsync(string, ...)` lost their unnecessary `async/await` — they're single-line passthroughs that benefit from returning the `Task<>` directly (no state machine generated). Consistent with the new selection methods which adopt the same shape.

### `SectionLineItem.Source` — back-reference to source `ConfigurationItem`

`SectionLineItem` now exposes a `Source: ConfigurationItem` property — a back-reference to the `ConfigurationItem` it was built from. Read-path `Add*` overloads accept and propagate the source `ConfigurationItem`; creation-path overloads leave `Source` as `null` (no source exists yet at creation time).

**Why:** consumers needed access to fields beyond `SectionId` / `Type` / `CustomText` / `Files` of the source — e.g. derived modules carrying flags on a subtype of `ConfigurationItem`. Without a back-reference, the only option was a positional walk over `Items` and `ConfigurationItems` paired by `(SectionId, Type, ProductId)` — fragile, breaks on duplicate keys, and forces every consumer to re-derive the same pairing.

**New overloads:**

| Overload | Notes |
|---|---|
| `AddProductSectionLineItem(CartProduct, ConfigurationItem)` | Existing — now stores `Source` |
| `AddTextSectionLineItem(ConfigurationItem)` | New — replaces denormalized `(CustomText, SectionId)` callsite shape |
| `AddFileSectionLineItem(ConfigurationItem, IList<ConfigurationItemFile> files = null)` | New — optional `files` override for transformation cases (e.g. `ChangeCartCurrencyCommandHandler` duplicates files for the new currency context) |

**Factory:** new `protected virtual SectionLineItem CreateSectionLineItem(ConfigurationItem)` plus a base `CreateSectionLineItem(string sectionId, string type)` collapse the previously 4× duplicated `AbstractTypeFactory<SectionLineItem>.TryCreateInstance() + property-set` pattern into a single point.

**Callsite cleanup:** read-path callers in `CartAggregate` (Text/File branches in the load path) and `ChangeCartCurrencyCommandHandler` migrate to the new overloads, removing the denormalized `(propertyA, propertyB, source)` argument shape.

**Backward compat:** existing loose-params overloads (`AddProductSectionLineItem(LineItem, sectionId, type)`, `AddTextSectionLineItem(string, string)`, `AddFileSectionLineItem(IList<>, string)`) preserved — used by `CreateConfiguredLineItemHandler` (creation flow), where no source `ConfigurationItem` exists yet. No breaking change in public API surface.

## Test plan

- [x] 13 new unit tests in `CartAggregateTests` covering: flag flip on matching items, **Text-section discrimination via `(Type, SectionId)` only**, **unmatched section no-op**, scoping by `lineItemId` (other lineItems untouched even when section ref would match), missing `lineItemId` validation error, no-change short-circuit, empty section list, all-variant flip + idempotency
- [x] 6 new unit tests in `ConfiguredLineItemContainerTests` pinning down the `Source` contract: linked by reference for read-path overloads (Product / Text / File); `null` for creation-path overloads; explicit `files` override on the File overload preserves the source link
- [x] Full test suite passes: 186/186 (was 180 before the `Source` commit, 175 before this PR)
- [x] Reviewer to validate via integration: `mutation { changeCartConfigurationItemSelected(command: { storeId, userId, cartName, cartType, lineItemId, configurationSection: { sectionId, type, option: { productId } }, selectedForCheckout: false }) { items { id listPrice { amount } configurationItems { id selectedForCheckout } } total { amount } } }` — expected: target flag flips, parent lineItem `listPrice` decreases by the placement's contribution, downstream recalc (totals, etc.) follows via `SaveAsync → RecalculateAsync`
Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.XCart_3.1013.0-pr-114-8518.zip

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new GraphQL mutations/command handlers that toggle `ConfigurationItem.SelectedForCheckout` and trigger repricing of configured line items, which can affect cart totals and checkout behavior. Also changes how configured item sections are constructed (including new `Source` back-references), so regressions could impact configured-item pricing or downstream extensions relying on section mapping.
> 
> **Overview**
> Adds a new set of cart mutations/commands to toggle `ConfigurationItem.SelectedForCheckout` for configured line items (single item, batch in a line item, and select/unselect all), using lightweight GraphQL inputs (`ConfigurationSectionKeyInput`) and new `CartAggregate` methods that reprice the configured parent line item only when a flag actually changes.
> 
> Refactors configured-item price recalculation plumbing so text/file section line items are created via new source-aware overloads and `SectionLineItem` now carries a `Source` back-reference to the originating `ConfigurationItem` (with optional file-list overrides for currency copy). Includes updated currency-copy behavior for empty file lists and adds unit tests covering selection toggling and the new `Source` contract.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 33b77cba0ba71dfe2aa3a4a4161b91506ba022bc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->