### PR TITLE
feat(VCST-4715): Add default option support

### DIFF
--- a/.claude/worktrees/laughing-wescoff/.claude/settings.local.json
+++ b/.claude/worktrees/laughing-wescoff/.claude/settings.local.json
@@ -1,0 +1,8 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(ls \"C:\\\\Source\\\\vc-modules\\\\vc-module-x-cart\\\\tests\"\" 2>/dev/null || echo \"no tests dir \")",
+      "Bash(dotnet test:*)"
+    ]
+  }
+}

--- a/.claude/worktrees/laughing-wescoff/.claude/settings.local.json
+++ b/.claude/worktrees/laughing-wescoff/.claude/settings.local.json
@@ -1,8 +1,0 @@
-{
-  "permissions": {
-    "allow": [
-      "Bash(ls \"C:\\\\Source\\\\vc-modules\\\\vc-module-x-cart\\\\tests\"\" 2>/dev/null || echo \"no tests dir \")",
-      "Bash(dotnet test:*)"
-    ]
-  }
-}

--- a/src/VirtoCommerce.XCart.Core/Models/ExpConfigurationLineItem.cs
+++ b/src/VirtoCommerce.XCart.Core/Models/ExpConfigurationLineItem.cs
@@ -15,5 +15,6 @@ namespace VirtoCommerce.XCart.Core.Models
         public string Id { get; set; }
         public string Text { get; set; }
         public int Quantity { get; set; }
+        public bool IsDefault { get; set; }
     }
 }

--- a/src/VirtoCommerce.XCart.Core/Schemas/ConfigurationLineItemType.cs
+++ b/src/VirtoCommerce.XCart.Core/Schemas/ConfigurationLineItemType.cs
@@ -26,6 +26,7 @@ namespace VirtoCommerce.XCart.Core.Schemas
             Field(x => x.Id, nullable: true).Description("The unique identifier");
             Field(x => x.Text, nullable: true).Description("The text of the Text-type option");
             Field(x => x.Quantity).Description("The quantity of the option");
+            Field(x => x.IsDefault).Description("Whether the option is selected by default");
 
             var productField = new FieldType
             {

--- a/src/VirtoCommerce.XCart.Core/VirtoCommerce.XCart.Core.csproj
+++ b/src/VirtoCommerce.XCart.Core/VirtoCommerce.XCart.Core.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <IsPackable>True</IsPackable>
@@ -9,7 +9,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="FluentValidation" Version="12.1.1" />
-    <PackageReference Include="VirtoCommerce.CatalogModule.Core" Version="3.1020.0" />
+    <PackageReference Include="VirtoCommerce.CatalogModule.Core" Version="3.1021.0-alpha.2505-vcst-4715" />
     <PackageReference Include="VirtoCommerce.CartModule.Core" Version="3.1002.0" />
     <PackageReference Include="VirtoCommerce.FileExperienceApi.Core" Version="3.1000.0" />
     <PackageReference Include="VirtoCommerce.InventoryModule.Core" Version="3.1000.0" />

--- a/src/VirtoCommerce.XCart.Core/VirtoCommerce.XCart.Core.csproj
+++ b/src/VirtoCommerce.XCart.Core/VirtoCommerce.XCart.Core.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="FluentValidation" Version="12.1.1" />
-    <PackageReference Include="VirtoCommerce.CatalogModule.Core" Version="3.1021.0-alpha.2505-vcst-4715" />
+    <PackageReference Include="VirtoCommerce.CatalogModule.Core" Version="3.1023.0-alpha.2513-vcst-4715" />
     <PackageReference Include="VirtoCommerce.CartModule.Core" Version="3.1002.0" />
     <PackageReference Include="VirtoCommerce.FileExperienceApi.Core" Version="3.1000.0" />
     <PackageReference Include="VirtoCommerce.InventoryModule.Core" Version="3.1000.0" />

--- a/src/VirtoCommerce.XCart.Core/VirtoCommerce.XCart.Core.csproj
+++ b/src/VirtoCommerce.XCart.Core/VirtoCommerce.XCart.Core.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="FluentValidation" Version="12.1.1" />
-    <PackageReference Include="VirtoCommerce.CatalogModule.Core" Version="3.1023.0-alpha.2513-vcst-4715" />
+    <PackageReference Include="VirtoCommerce.CatalogModule.Core" Version="3.1025.0" />
     <PackageReference Include="VirtoCommerce.CartModule.Core" Version="3.1002.0" />
     <PackageReference Include="VirtoCommerce.FileExperienceApi.Core" Version="3.1000.0" />
     <PackageReference Include="VirtoCommerce.InventoryModule.Core" Version="3.1000.0" />

--- a/src/VirtoCommerce.XCart.Data/Queries/GetProductConfigurationQueryHandler.cs
+++ b/src/VirtoCommerce.XCart.Data/Queries/GetProductConfigurationQueryHandler.cs
@@ -107,6 +107,7 @@ public class GetProductConfigurationQueryHandler : IQueryHandler<GetProductConfi
 
                     var expConfigurationLineItem = AbstractTypeFactory<ExpConfigurationLineItem>.TryCreateInstance();
                     expConfigurationLineItem.Id = option.Id;
+                    expConfigurationLineItem.IsDefault = option.IsDefault;
                     expConfigurationLineItem.Quantity = option.Quantity;
                     expConfigurationLineItem.Item = item;
                     expConfigurationLineItem.Currency = container.Currency;
@@ -128,6 +129,7 @@ public class GetProductConfigurationQueryHandler : IQueryHandler<GetProductConfi
             {
                 var expConfigurationLineItem = AbstractTypeFactory<ExpConfigurationLineItem>.TryCreateInstance();
                 expConfigurationLineItem.Id = option.Id;
+                expConfigurationLineItem.IsDefault = option.IsDefault;
                 expConfigurationLineItem.Text = option.Text;
 
                 configurationSection.Options.Add(expConfigurationLineItem);

--- a/src/VirtoCommerce.XCart.Web/module.manifest
+++ b/src/VirtoCommerce.XCart.Web/module.manifest
@@ -6,7 +6,7 @@
 
   <platformVersion>3.1002.0</platformVersion>
   <dependencies>
-    <dependency id="VirtoCommerce.Catalog" version="3.1020.0" />
+    <dependency id="VirtoCommerce.Catalog" version="3.1021.0-alpha.2505-vcst-4715" />
     <dependency id="VirtoCommerce.Cart" version="3.1002.0" />
     <dependency id="VirtoCommerce.FileExperienceApi" version="3.1000.0" />
     <dependency id="VirtoCommerce.Inventory" version="3.1000.0" />

--- a/src/VirtoCommerce.XCart.Web/module.manifest
+++ b/src/VirtoCommerce.XCart.Web/module.manifest
@@ -6,7 +6,7 @@
 
   <platformVersion>3.1002.0</platformVersion>
   <dependencies>
-    <dependency id="VirtoCommerce.Catalog" version="3.1021.0-alpha.2505-vcst-4715" />
+    <dependency id="VirtoCommerce.Catalog" version="3.1023.0-alpha.2513-vcst-4715" />
     <dependency id="VirtoCommerce.Cart" version="3.1002.0" />
     <dependency id="VirtoCommerce.FileExperienceApi" version="3.1000.0" />
     <dependency id="VirtoCommerce.Inventory" version="3.1000.0" />

--- a/src/VirtoCommerce.XCart.Web/module.manifest
+++ b/src/VirtoCommerce.XCart.Web/module.manifest
@@ -6,7 +6,7 @@
 
   <platformVersion>3.1002.0</platformVersion>
   <dependencies>
-    <dependency id="VirtoCommerce.Catalog" version="3.1023.0-alpha.2513-vcst-4715" />
+    <dependency id="VirtoCommerce.Catalog" version="3.1025.0" />
     <dependency id="VirtoCommerce.Cart" version="3.1002.0" />
     <dependency id="VirtoCommerce.FileExperienceApi" version="3.1000.0" />
     <dependency id="VirtoCommerce.Inventory" version="3.1000.0" />


### PR DESCRIPTION
## Description
Implemented support for default options in configurable products across Catalog, XCart GraphQL, and Storefront. The feature allows a product configuration option to be marked as default in admin, exposes that flag through XCart GraphQL, and makes the storefront automatically preselect default values, including defaults in dependent configuration sections.

Implementation Details

Exposed the new default-option flag through the Experience API.

Changes include:

Added IsDefault to ExpConfigurationLineItem.
Exposed isDefault in GraphQL ConfigurationLineItemType.

Updated GetProductConfigurationQueryHandler to populate IsDefault for:

product-based configuration options
text-based configuration options

This allows the storefront to know which option should be selected by default when rendering configurable product sections.


## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-4715
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.XCart_3.1016.0-pr-115-f76c.zip