### PR TITLE
VCST-5053: Merge cart loses configured-product identity

### DIFF
--- a/src/VirtoCommerce.XCart.Core/CartAggregate.cs
+++ b/src/VirtoCommerce.XCart.Core/CartAggregate.cs
@@ -1241,7 +1241,9 @@ namespace VirtoCommerce.XCart.Core
 
         protected virtual async Task<CartAggregate> InnerAddLineItemAsync(LineItem newLineItem, bool overrideQuantity, CartProduct product = null, IList<DynamicPropertyValue> dynamicProperties = null)
         {
-            var existingLineItem = FindExistingLineItemBeforeAdd(newLineItem.ProductId, product, dynamicProperties);
+            var existingLineItem = newLineItem.IsConfigured
+                ? null
+                : FindExistingLineItemBeforeAdd(newLineItem.ProductId, product, dynamicProperties);
 
             if (existingLineItem != null)
             {
@@ -1277,7 +1279,7 @@ namespace VirtoCommerce.XCart.Core
         /// <returns></returns>
         protected virtual LineItem FindExistingLineItemBeforeAdd(string newProductId, CartProduct newProduct, IList<DynamicPropertyValue> newDynamicProperties)
         {
-            return LineItems.FirstOrDefault(x => x.ProductId == newProductId);
+            return LineItems.FirstOrDefault(x => x.ProductId == newProductId && !x.IsConfigured);
         }
 
         protected virtual void EnsureCartExists()

--- a/src/VirtoCommerce.XCart.Core/CartAggregate.cs
+++ b/src/VirtoCommerce.XCart.Core/CartAggregate.cs
@@ -1214,7 +1214,9 @@ namespace VirtoCommerce.XCart.Core
         [Obsolete("Use InnerAddLineItemAsync(LineItem newLineItem, bool overrideQuantity) instead", DiagnosticId = "VC0011", UrlFormat = "https://docs.virtocommerce.org/products/products-virto3-versions")]
         protected virtual async Task<CartAggregate> InnerAddLineItemAsync(LineItem newLineItem, CartProduct product = null, IList<DynamicPropertyValue> dynamicProperties = null)
         {
-            var existingLineItem = FindExistingLineItemBeforeAdd(newLineItem.ProductId, product, dynamicProperties);
+            var existingLineItem = newLineItem.IsConfigured
+                ? null
+                : FindExistingLineItemBeforeAdd(newLineItem.ProductId, product, dynamicProperties);
 
             if (existingLineItem != null)
             {

--- a/tests/VirtoCommerce.XCart.Tests/Aggregates/CartAggregateTests.cs
+++ b/tests/VirtoCommerce.XCart.Tests/Aggregates/CartAggregateTests.cs
@@ -586,9 +586,11 @@ namespace VirtoCommerce.XCart.Tests.Aggregates
 
             var sourceLineItem1 = _fixture.Create<LineItem>();
             sourceLineItem1.ProductId = sourceProduct1.Id;
+            sourceLineItem1.IsConfigured = false;
 
             var sourceLineItem2 = _fixture.Create<LineItem>();
             sourceLineItem2.ProductId = sourceProduct2.Id;
+            sourceLineItem2.IsConfigured = false;
 
             sourceAggregate.Cart.Items = new List<LineItem> { sourceLineItem1, sourceLineItem2 };
 
@@ -599,9 +601,11 @@ namespace VirtoCommerce.XCart.Tests.Aggregates
 
             var destinationLineItem1 = _fixture.Create<LineItem>();
             destinationLineItem1.ProductId = destinationProduct1.Id;
+            destinationLineItem1.IsConfigured = false;
 
             var destinationLineItem2 = _fixture.Create<LineItem>();
             destinationLineItem2.ProductId = sourceProduct2.Id;
+            destinationLineItem2.IsConfigured = false;
             var quantity = destinationLineItem2.Quantity;
 
             destinationAggregate.Cart.Items = new List<LineItem> { destinationLineItem1, destinationLineItem2 };
@@ -745,6 +749,149 @@ namespace VirtoCommerce.XCart.Tests.Aggregates
             // Assert
             destinationAggregate.Cart.Payments.Should().HaveCount(1);
             destinationAggregate.Cart.Payments.Should().Contain(sourcePayment);
+        }
+
+        [Fact]
+        public async Task MergeWithCartAsync_ConfiguredItemsSameProduct_KeptSeparate()
+        {
+            // Arrange
+            var sourceAggregate = GetValidCartAggregate();
+            sourceAggregate.Cart.Coupons = Enumerable.Empty<string>().ToList();
+            sourceAggregate.Cart.Shipments = Enumerable.Empty<Shipment>().ToList();
+            sourceAggregate.Cart.Payments = Enumerable.Empty<Payment>().ToList();
+
+            var sharedProduct = _fixture.Create<CartProduct>();
+            sharedProduct.Id = "shared-product";
+            sourceAggregate.CartProducts.Add(sharedProduct.Id, sharedProduct);
+
+            var sourceConfiguredItem = _fixture.Create<LineItem>();
+            sourceConfiguredItem.ProductId = sharedProduct.Id;
+            sourceConfiguredItem.IsConfigured = true;
+            sourceConfiguredItem.ConfigurationItems = new List<ConfigurationItem>
+            {
+                new() { SectionId = "section-A", ProductId = "component-A" },
+            };
+            var sourceQuantity = sourceConfiguredItem.Quantity;
+
+            sourceAggregate.Cart.Items = new List<LineItem> { sourceConfiguredItem };
+
+            var destinationAggregate = GetValidCartAggregate();
+
+            var destinationConfiguredItem = _fixture.Create<LineItem>();
+            destinationConfiguredItem.ProductId = sharedProduct.Id;
+            destinationConfiguredItem.IsConfigured = true;
+            destinationConfiguredItem.ConfigurationItems = new List<ConfigurationItem>
+            {
+                new() { SectionId = "section-B", ProductId = "component-B" },
+            };
+            var destinationQuantity = destinationConfiguredItem.Quantity;
+
+            destinationAggregate.Cart.Items = new List<LineItem> { destinationConfiguredItem };
+
+            // Act
+            await destinationAggregate.MergeWithCartAsync(sourceAggregate);
+
+            // Assert
+            destinationAggregate.Cart.Items.Should().HaveCount(2);
+            destinationAggregate.Cart.Items.Should().OnlyContain(x => x.IsConfigured && x.ProductId == sharedProduct.Id);
+            destinationAggregate.Cart.Items.Should().Contain(x => x.Quantity == destinationQuantity
+                && x.ConfigurationItems.Any(c => c.SectionId == "section-B"));
+            destinationAggregate.Cart.Items.Should().Contain(x => x.Quantity == sourceQuantity
+                && x.ConfigurationItems.Any(c => c.SectionId == "section-A"));
+        }
+
+        [Fact]
+        public async Task MergeWithCartAsync_NewConfiguredAndExistingSimple_KeptSeparate()
+        {
+            // Arrange
+            var sourceAggregate = GetValidCartAggregate();
+            sourceAggregate.Cart.Coupons = Enumerable.Empty<string>().ToList();
+            sourceAggregate.Cart.Shipments = Enumerable.Empty<Shipment>().ToList();
+            sourceAggregate.Cart.Payments = Enumerable.Empty<Payment>().ToList();
+
+            var sharedProduct = _fixture.Create<CartProduct>();
+            sharedProduct.Id = "shared-product";
+            sourceAggregate.CartProducts.Add(sharedProduct.Id, sharedProduct);
+
+            var sourceConfiguredItem = _fixture.Create<LineItem>();
+            sourceConfiguredItem.ProductId = sharedProduct.Id;
+            sourceConfiguredItem.IsConfigured = true;
+            sourceConfiguredItem.ConfigurationItems = new List<ConfigurationItem>
+            {
+                new() { SectionId = "section-A", ProductId = "component-A" },
+            };
+            var sourceQuantity = sourceConfiguredItem.Quantity;
+
+            sourceAggregate.Cart.Items = new List<LineItem> { sourceConfiguredItem };
+
+            var destinationAggregate = GetValidCartAggregate();
+
+            var destinationSimpleItem = _fixture.Create<LineItem>();
+            destinationSimpleItem.ProductId = sharedProduct.Id;
+            destinationSimpleItem.IsConfigured = false;
+            destinationSimpleItem.ConfigurationItems = null;
+            var destinationQuantity = destinationSimpleItem.Quantity;
+
+            destinationAggregate.Cart.Items = new List<LineItem> { destinationSimpleItem };
+
+            // Act
+            await destinationAggregate.MergeWithCartAsync(sourceAggregate);
+
+            // Assert
+            destinationAggregate.Cart.Items.Should().HaveCount(2);
+            destinationAggregate.Cart.Items.Should().Contain(x => !x.IsConfigured
+                && x.ProductId == sharedProduct.Id
+                && x.Quantity == destinationQuantity);
+            destinationAggregate.Cart.Items.Should().Contain(x => x.IsConfigured
+                && x.ProductId == sharedProduct.Id
+                && x.Quantity == sourceQuantity);
+        }
+
+        [Fact]
+        public async Task MergeWithCartAsync_NewSimpleAndExistingConfigured_KeptSeparate()
+        {
+            // Arrange
+            var sourceAggregate = GetValidCartAggregate();
+            sourceAggregate.Cart.Coupons = Enumerable.Empty<string>().ToList();
+            sourceAggregate.Cart.Shipments = Enumerable.Empty<Shipment>().ToList();
+            sourceAggregate.Cart.Payments = Enumerable.Empty<Payment>().ToList();
+
+            var sharedProduct = _fixture.Create<CartProduct>();
+            sharedProduct.Id = "shared-product";
+            sourceAggregate.CartProducts.Add(sharedProduct.Id, sharedProduct);
+
+            var sourceSimpleItem = _fixture.Create<LineItem>();
+            sourceSimpleItem.ProductId = sharedProduct.Id;
+            sourceSimpleItem.IsConfigured = false;
+            sourceSimpleItem.ConfigurationItems = null;
+            var sourceQuantity = sourceSimpleItem.Quantity;
+
+            sourceAggregate.Cart.Items = new List<LineItem> { sourceSimpleItem };
+
+            var destinationAggregate = GetValidCartAggregate();
+
+            var destinationConfiguredItem = _fixture.Create<LineItem>();
+            destinationConfiguredItem.ProductId = sharedProduct.Id;
+            destinationConfiguredItem.IsConfigured = true;
+            destinationConfiguredItem.ConfigurationItems = new List<ConfigurationItem>
+            {
+                new() { SectionId = "section-A", ProductId = "component-A" },
+            };
+            var destinationQuantity = destinationConfiguredItem.Quantity;
+
+            destinationAggregate.Cart.Items = new List<LineItem> { destinationConfiguredItem };
+
+            // Act
+            await destinationAggregate.MergeWithCartAsync(sourceAggregate);
+
+            // Assert
+            destinationAggregate.Cart.Items.Should().HaveCount(2);
+            destinationAggregate.Cart.Items.Should().Contain(x => x.IsConfigured
+                && x.ProductId == sharedProduct.Id
+                && x.Quantity == destinationQuantity);
+            destinationAggregate.Cart.Items.Should().Contain(x => !x.IsConfigured
+                && x.ProductId == sharedProduct.Id
+                && x.Quantity == sourceQuantity);
         }
 
         #endregion MergeWithCartAsync


### PR DESCRIPTION
## Description
fix: Implements that configured products always be separate line items per configuration, even across a cart merge.

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-5053
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.XCart_3.1012.0-pr-116-71c7.zip

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes cart line-item merge behavior to stop deduplicating configured products, which can affect quantity aggregation and downstream totals/checkout expectations. Scope is limited and covered by new unit tests for configured vs simple item merge scenarios.
> 
> **Overview**
> Ensures *configured products* are never merged/deduplicated with existing line items when adding items or merging carts.
> 
> `CartAggregate.InnerAddLineItemAsync` and `FindExistingLineItemBeforeAdd` now skip matching/merging when `LineItem.IsConfigured` is true (and also avoid merging into already-configured items), so each distinct configuration remains a separate cart line.
> 
> Updates and expands `CartAggregateTests` to explicitly validate configured-vs-configured and configured-vs-simple merge cases, and sets `IsConfigured = false` in existing merge tests to preserve prior expectations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 71c72e39f9c2a6b13dcc61b05e10961125910ae6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->