### PR TITLE
VCST-4961: [Cart][GraphQL] selectedForCheckout on configurationItems has no write path — schema field silently ignored

### DIFF
--- a/src/VirtoCommerce.XCart.Core/CartAggregate.cs
+++ b/src/VirtoCommerce.XCart.Core/CartAggregate.cs
@@ -562,6 +562,14 @@ namespace VirtoCommerce.XCart.Core
                 if (lineItem != null)
                 {
                     lineItem.SelectedForCheckout = selectedForCheckout;
+
+                    if (lineItem.IsConfigured && lineItem.ConfigurationItems != null)
+                    {
+                        foreach (var configurationItem in lineItem.ConfigurationItems)
+                        {
+                            configurationItem.SelectedForCheckout = selectedForCheckout;
+                        }
+                    }
                 }
             }
 

--- a/src/VirtoCommerce.XCart.Core/CartAggregate.cs
+++ b/src/VirtoCommerce.XCart.Core/CartAggregate.cs
@@ -552,22 +552,34 @@ namespace VirtoCommerce.XCart.Core
             return Task.FromResult(this);
         }
 
-        public virtual Task<CartAggregate> ChangeItemsSelectedAsync(IList<string> lineItemIds, bool selectedForCheckout)
+        public virtual async Task<CartAggregate> ChangeItemsSelectedAsync(IList<string> lineItemIds, bool selectedForCheckout)
         {
             EnsureCartExists();
+
+            var lineItemsToReprice = new List<LineItem>();
 
             foreach (var lineItemId in lineItemIds)
             {
                 var lineItem = Cart.Items.FirstOrDefault(x => x.Id == lineItemId);
-                if (lineItem != null)
+                if (lineItem == null)
                 {
-                    lineItem.SelectedForCheckout = selectedForCheckout;
-                    SetConfigurationItemsSelectedForCheckout(lineItem, selectedForCheckout);
+                    continue;
+                }
 
+                lineItem.SelectedForCheckout = selectedForCheckout;
+
+                if (SetConfigurationItemsSelectedForCheckout(lineItem, selectedForCheckout))
+                {
+                    lineItemsToReprice.Add(lineItem);
                 }
             }
 
-            return Task.FromResult(this);
+            if (lineItemsToReprice.Count > 0)
+            {
+                await UpdateConfiguredLineItemPrice(lineItemsToReprice);
+            }
+
+            return this;
         }
 
         public virtual Task<CartAggregate> RemoveItemAsync(string lineItemId)
@@ -1997,17 +2009,24 @@ namespace VirtoCommerce.XCart.Core
             }
         }
 
-        protected static void SetConfigurationItemsSelectedForCheckout(LineItem lineItem, bool selectedForCheckout)
+        protected static bool SetConfigurationItemsSelectedForCheckout(LineItem lineItem, bool selectedForCheckout)
         {
+            var changed = false;
             if (!lineItem.IsConfigured || lineItem.ConfigurationItems == null)
             {
-                return;
+                return changed;
             }
 
             foreach (var configurationItem in lineItem.ConfigurationItems)
             {
-                configurationItem.SelectedForCheckout = selectedForCheckout;
+                if (configurationItem.SelectedForCheckout != selectedForCheckout)
+                {
+                    configurationItem.SelectedForCheckout = selectedForCheckout;
+                    changed = true;
+                }
             }
+
+            return changed;
         }
 
         #region ICloneable

--- a/src/VirtoCommerce.XCart.Core/CartAggregate.cs
+++ b/src/VirtoCommerce.XCart.Core/CartAggregate.cs
@@ -562,14 +562,8 @@ namespace VirtoCommerce.XCart.Core
                 if (lineItem != null)
                 {
                     lineItem.SelectedForCheckout = selectedForCheckout;
+                    SetConfigurationItemsSelectedForCheckout(lineItem, selectedForCheckout);
 
-                    if (lineItem.IsConfigured && lineItem.ConfigurationItems != null)
-                    {
-                        foreach (var configurationItem in lineItem.ConfigurationItems)
-                        {
-                            configurationItem.SelectedForCheckout = selectedForCheckout;
-                        }
-                    }
                 }
             }
 
@@ -2000,6 +1994,19 @@ namespace VirtoCommerce.XCart.Core
             {
                 var fileIds = files.Select(x => x.Id).ToArray();
                 await _fileUploadService.DeleteAsync(fileIds);
+            }
+        }
+
+        protected static void SetConfigurationItemsSelectedForCheckout(LineItem lineItem, bool selectedForCheckout)
+        {
+            if (!lineItem.IsConfigured || lineItem.ConfigurationItems == null)
+            {
+                return;
+            }
+
+            foreach (var configurationItem in lineItem.ConfigurationItems)
+            {
+                configurationItem.SelectedForCheckout = selectedForCheckout;
             }
         }
 

--- a/src/VirtoCommerce.XCart.Core/ConfiguredLineItemContainer.cs
+++ b/src/VirtoCommerce.XCart.Core/ConfiguredLineItemContainer.cs
@@ -74,9 +74,10 @@ namespace VirtoCommerce.XCart.Core
         /// Adds a product section line item for a new configuration item (e.g. from a GraphQL mutation).
         /// Prices are loaded from the catalog product.
         /// </summary>
-        public virtual void AddProductSectionLineItem(CartProduct cartProduct, int quantity, string sectionId, string type = ConfigurationSectionTypeProduct)
+        public virtual void AddProductSectionLineItem(CartProduct cartProduct, int quantity, string sectionId, string type = ConfigurationSectionTypeProduct, bool selectedForCheckout = true)
         {
             var lineItem = CreateLineItem(cartProduct, quantity);
+            lineItem.SelectedForCheckout = selectedForCheckout;
 
             AddProductSectionLineItem(lineItem, sectionId, type);
         }
@@ -234,6 +235,7 @@ namespace VirtoCommerce.XCart.Core
                     subItem.Sku = x.Item?.Sku;
                     subItem.ImageUrl = x.Item?.ImageUrl;
                     subItem.Quantity = x.Item?.Quantity ?? 1;
+                    subItem.SelectedForCheckout = x.Item?.SelectedForCheckout ?? true;
                     if (x.Type is ConfigurationSectionTypeProduct or ConfigurationSectionTypeVariation)
                     {
                         subItem.ListPrice = x.Item?.ListPrice ?? 0m;

--- a/src/VirtoCommerce.XCart.Core/ConfiguredLineItemContainer.cs
+++ b/src/VirtoCommerce.XCart.Core/ConfiguredLineItemContainer.cs
@@ -72,9 +72,20 @@ namespace VirtoCommerce.XCart.Core
 
         /// <summary>
         /// Adds a product section line item for a new configuration item (e.g. from a GraphQL mutation).
-        /// Prices are loaded from the catalog product.
+        /// Prices are loaded from the catalog product. 
         /// </summary>
-        public virtual void AddProductSectionLineItem(CartProduct cartProduct, int quantity, string sectionId, string type = ConfigurationSectionTypeProduct, bool selectedForCheckout = true)
+        public virtual void AddProductSectionLineItem(CartProduct cartProduct, int quantity, string sectionId, string type = ConfigurationSectionTypeProduct)
+        {
+            AddProductSectionLineItem(cartProduct, quantity, sectionId, type, selectedForCheckout: true);
+        }
+
+        /// <summary>
+        /// Adds a product section line item for a new configuration item and propagates
+        /// <paramref name="selectedForCheckout"/> onto the synthetic <see cref="LineItem"/>,
+        /// from which <see cref="CreateConfiguredLineItem"/> copies it onto the
+        /// resulting <see cref="ConfigurationItem"/>.
+        /// </summary>
+        public virtual void AddProductSectionLineItem(CartProduct cartProduct, int quantity, string sectionId, string type, bool selectedForCheckout)
         {
             var lineItem = CreateLineItem(cartProduct, quantity);
             lineItem.SelectedForCheckout = selectedForCheckout;

--- a/src/VirtoCommerce.XCart.Data/Commands/CreateConfiguredLineItemHandler.cs
+++ b/src/VirtoCommerce.XCart.Data/Commands/CreateConfiguredLineItemHandler.cs
@@ -66,7 +66,7 @@ public class CreateConfiguredLineItemHandler : IRequestHandler<CreateConfiguredL
                 var productOption = section.Option;
                 var selectedProduct = products.FirstOrDefault(x => x.Product.Id == productOption.ProductId) ?? throw new InvalidOperationException($"Product with id {productOption.ProductId} not found");
 
-                container.AddProductSectionLineItem(selectedProduct, productOption.Quantity, section.SectionId, section.Type);
+                container.AddProductSectionLineItem(selectedProduct, productOption.Quantity, section.SectionId, section.Type, productOption.SelectedForCheckout);
             }
             else if (section.Type == ConfigurationSectionTypeText)
             {

--- a/tests/VirtoCommerce.XCart.Tests/Aggregates/CartAggregateTests.cs
+++ b/tests/VirtoCommerce.XCart.Tests/Aggregates/CartAggregateTests.cs
@@ -3206,6 +3206,10 @@ namespace VirtoCommerce.XCart.Tests.Aggregates
             };
             cartAggregate.Cart.Items.Add(lineItem);
 
+            _cartProductServiceMock
+                .Setup(x => x.GetCartProductsByIdsAsync(It.IsAny<CartAggregate>(), It.IsAny<IList<string>>()))
+                .ReturnsAsync([]);
+
             // Act
             await cartAggregate.ChangeItemsSelectedAsync([lineItem.Id], selectedForCheckout: false);
 
@@ -3213,6 +3217,10 @@ namespace VirtoCommerce.XCart.Tests.Aggregates
             lineItem.SelectedForCheckout.Should().BeFalse();
             lineItem.ConfigurationItems.Should().OnlyContain(ci => !ci.SelectedForCheckout,
                 "deselecting the parent configured line item must cascade to all configuration items to avoid an inconsistent state at checkout");
+            _cartProductServiceMock.Verify(
+                x => x.GetCartProductsByIdsAsync(cartAggregate, It.IsAny<IList<string>>()),
+                Times.Once,
+                "configured line item must be repriced after children change selection");
         }
 
         [Fact]
@@ -3231,6 +3239,10 @@ namespace VirtoCommerce.XCart.Tests.Aggregates
             };
             cartAggregate.Cart.Items.Add(lineItem);
 
+            _cartProductServiceMock
+                .Setup(x => x.GetCartProductsByIdsAsync(It.IsAny<CartAggregate>(), It.IsAny<IList<string>>()))
+                .ReturnsAsync([]);
+
             // Act
             await cartAggregate.ChangeItemsSelectedAsync([lineItem.Id], selectedForCheckout: true);
 
@@ -3238,6 +3250,38 @@ namespace VirtoCommerce.XCart.Tests.Aggregates
             lineItem.SelectedForCheckout.Should().BeTrue();
             configItem.SelectedForCheckout.Should().BeTrue(
                 "reselecting the parent must propagate to the children so the configured line item is fully back in checkout");
+            _cartProductServiceMock.Verify(
+                x => x.GetCartProductsByIdsAsync(cartAggregate, It.IsAny<IList<string>>()),
+                Times.Once);
+        }
+
+        [Fact]
+        public async Task ChangeItemsSelectedAsync_NoChildChange_SkipsReprice()
+        {
+            // Arrange — children are already at the target state; cascade is a no-op,
+            // so the parent must NOT be repriced (matches ChangeAllConfigurationItemsSelectedAsync semantics).
+            var cartAggregate = GetValidCartAggregate();
+            var configItem = new ConfigurationItem { Id = "ci-1", SectionId = "s1", Type = "Product", ProductId = "p1", SelectedForCheckout = false };
+            var lineItem = new LineItem
+            {
+                Id = "line-item-1",
+                ProductId = "configurable-product",
+                IsConfigured = true,
+                SelectedForCheckout = true,
+                ConfigurationItems = [configItem],
+            };
+            cartAggregate.Cart.Items.Add(lineItem);
+
+            // Act
+            await cartAggregate.ChangeItemsSelectedAsync([lineItem.Id], selectedForCheckout: false);
+
+            // Assert
+            lineItem.SelectedForCheckout.Should().BeFalse();
+            configItem.SelectedForCheckout.Should().BeFalse();
+            _cartProductServiceMock.Verify(
+                x => x.GetCartProductsByIdsAsync(It.IsAny<CartAggregate>(), It.IsAny<IList<string>>()),
+                Times.Never,
+                "no child flag actually changed, so the configured line item should not be repriced");
         }
 
         [Fact]

--- a/tests/VirtoCommerce.XCart.Tests/Aggregates/CartAggregateTests.cs
+++ b/tests/VirtoCommerce.XCart.Tests/Aggregates/CartAggregateTests.cs
@@ -3186,5 +3186,103 @@ namespace VirtoCommerce.XCart.Tests.Aggregates
         }
 
         #endregion ChangeConfigurationItemSelected
+
+        #region ChangeItemsSelectedAsync
+
+        [Fact]
+        public async Task ChangeItemsSelectedAsync_ConfiguredLineItem_CascadesDeselectToConfigurationItems()
+        {
+            // Arrange — configured line item with selected children, all flagged true initially.
+            var cartAggregate = GetValidCartAggregate();
+            var configItem1 = new ConfigurationItem { Id = "ci-1", SectionId = "s1", Type = "Product", ProductId = "p1", SelectedForCheckout = true };
+            var configItem2 = new ConfigurationItem { Id = "ci-2", SectionId = "s2", Type = "Variation", ProductId = "p2", SelectedForCheckout = true };
+            var lineItem = new LineItem
+            {
+                Id = "line-item-1",
+                ProductId = "configurable-product",
+                IsConfigured = true,
+                SelectedForCheckout = true,
+                ConfigurationItems = [configItem1, configItem2],
+            };
+            cartAggregate.Cart.Items.Add(lineItem);
+
+            // Act
+            await cartAggregate.ChangeItemsSelectedAsync([lineItem.Id], selectedForCheckout: false);
+
+            // Assert
+            lineItem.SelectedForCheckout.Should().BeFalse();
+            lineItem.ConfigurationItems.Should().OnlyContain(ci => !ci.SelectedForCheckout,
+                "deselecting the parent configured line item must cascade to all configuration items to avoid an inconsistent state at checkout");
+        }
+
+        [Fact]
+        public async Task ChangeItemsSelectedAsync_ConfiguredLineItem_CascadesReselectToConfigurationItems()
+        {
+            // Arrange — symmetric case: previously deselected, now reselecting.
+            var cartAggregate = GetValidCartAggregate();
+            var configItem = new ConfigurationItem { Id = "ci-1", SectionId = "s1", Type = "Product", ProductId = "p1", SelectedForCheckout = false };
+            var lineItem = new LineItem
+            {
+                Id = "line-item-1",
+                ProductId = "configurable-product",
+                IsConfigured = true,
+                SelectedForCheckout = false,
+                ConfigurationItems = [configItem],
+            };
+            cartAggregate.Cart.Items.Add(lineItem);
+
+            // Act
+            await cartAggregate.ChangeItemsSelectedAsync([lineItem.Id], selectedForCheckout: true);
+
+            // Assert
+            lineItem.SelectedForCheckout.Should().BeTrue();
+            configItem.SelectedForCheckout.Should().BeTrue(
+                "reselecting the parent must propagate to the children so the configured line item is fully back in checkout");
+        }
+
+        [Fact]
+        public async Task ChangeItemsSelectedAsync_RegularLineItem_DoesNotThrowOnNullOrEmptyConfigurationItems()
+        {
+            // Arrange — non-configured line item; ConfigurationItems is empty (typical for plain products).
+            var cartAggregate = GetValidCartAggregate();
+            var lineItem = new LineItem
+            {
+                Id = "line-item-2",
+                ProductId = "regular-product",
+                IsConfigured = false,
+                SelectedForCheckout = true,
+                ConfigurationItems = [],
+            };
+            cartAggregate.Cart.Items.Add(lineItem);
+
+            // Act
+            await cartAggregate.ChangeItemsSelectedAsync([lineItem.Id], selectedForCheckout: false);
+
+            // Assert
+            lineItem.SelectedForCheckout.Should().BeFalse();
+        }
+
+        [Fact]
+        public async Task ChangeItemsSelectedAsync_UnknownLineItemId_IsNoop()
+        {
+            // Arrange — line item not in cart; method must skip it silently.
+            var cartAggregate = GetValidCartAggregate();
+            var existingItem = new LineItem
+            {
+                Id = "line-item-existing",
+                ProductId = "regular-product",
+                IsConfigured = false,
+                SelectedForCheckout = true,
+            };
+            cartAggregate.Cart.Items.Add(existingItem);
+
+            // Act
+            await cartAggregate.ChangeItemsSelectedAsync(["does-not-exist"], selectedForCheckout: false);
+
+            // Assert
+            existingItem.SelectedForCheckout.Should().BeTrue();
+        }
+
+        #endregion ChangeItemsSelectedAsync
     }
 }

--- a/tests/VirtoCommerce.XCart.Tests/Aggregates/ConfiguredLineItemContainerTests.cs
+++ b/tests/VirtoCommerce.XCart.Tests/Aggregates/ConfiguredLineItemContainerTests.cs
@@ -1,9 +1,11 @@
 using System.Collections.Generic;
+using System.Linq;
 using FluentAssertions;
 using VirtoCommerce.CartModule.Core.Model;
 using VirtoCommerce.CatalogModule.Core.Model;
 using VirtoCommerce.CoreModule.Core.Common;
 using VirtoCommerce.CoreModule.Core.Currency;
+using VirtoCommerce.StoreModule.Core.Model;
 using VirtoCommerce.XCart.Core;
 using VirtoCommerce.XCart.Core.Models;
 using Xunit;
@@ -29,6 +31,7 @@ namespace VirtoCommerce.XCart.Tests.Aggregates
             {
                 Currency = new Currency(new Language("en-US"), "USD"),
                 CultureName = "en-US",
+                Store = new Store { Id = "test-store" },
             };
         }
 
@@ -116,6 +119,56 @@ namespace VirtoCommerce.XCart.Tests.Aggregates
             _container.FilesAt(0).Should().BeSameAs(files);
         }
 
+        [Fact]
+        public void AddProductSectionLineItem_CreationPath_FalseSelectedForCheckout_StoresOnInnerLineItem()
+        {
+            _container.ConfigurableProduct = NewCartProduct();
+
+            _container.AddProductSectionLineItem(NewCartProduct(), quantity: 1, sectionId: "sec-1", type: ConfigurationSectionTypeProduct, selectedForCheckout: false);
+
+            _container.InnerLineItemSelectedForCheckoutAt(0).Should().BeFalse(
+                "creation-path overload must propagate selectedForCheckout to the synthetic LineItem so that CreateConfiguredLineItem can read it back");
+        }
+
+        [Fact]
+        public void AddProductSectionLineItem_CreationPath_DefaultsToTrue()
+        {
+            _container.ConfigurableProduct = NewCartProduct();
+
+            _container.AddProductSectionLineItem(NewCartProduct(), quantity: 1, sectionId: "sec-1", type: ConfigurationSectionTypeProduct);
+
+            _container.InnerLineItemSelectedForCheckoutAt(0).Should().BeTrue(
+                "default for the optional parameter must keep the existing behavior — item participates in checkout");
+        }
+
+        [Fact]
+        public void CreateConfiguredLineItem_PropagatesSelectedForCheckoutFromInnerLineItem()
+        {
+            _container.ConfigurableProduct = NewCartProduct();
+
+            _container.AddProductSectionLineItem(NewCartProduct(), quantity: 1, sectionId: "sec-1", type: ConfigurationSectionTypeProduct, selectedForCheckout: false);
+
+            var result = _container.CreateConfiguredLineItem(quantity: 1);
+
+            result.Item.ConfigurationItems.Should().HaveCount(1);
+            result.Item.ConfigurationItems.Single().SelectedForCheckout.Should().BeFalse(
+                "ConfigurationItem.SelectedForCheckout must reflect the value supplied in the mutation input");
+        }
+
+        [Fact]
+        public void CreateConfiguredLineItem_DefaultsConfigurationItemToSelected_WhenInnerLineItemMissing()
+        {
+            _container.ConfigurableProduct = NewCartProduct();
+
+            _container.AddTextSectionLineItem("ENGRAVING", "sec-text");
+
+            var result = _container.CreateConfiguredLineItem(quantity: 1);
+
+            result.Item.ConfigurationItems.Should().HaveCount(1);
+            result.Item.ConfigurationItems.Single().SelectedForCheckout.Should().BeTrue(
+                "sections without an inner LineItem (text/file) must default to selected, matching ConfigurableProductOption.SelectedForCheckout = true");
+        }
+
         private static ConfigurationItem NewConfigurationItem(string sectionId, string type)
         {
             return new ConfigurationItem
@@ -148,6 +201,14 @@ namespace VirtoCommerce.XCart.Tests.Aggregates
             public string CustomTextAt(int index) => Items[index].CustomText;
 
             public IList<ConfigurationItemFile> FilesAt(int index) => Items[index].Files;
+
+            public bool? InnerLineItemSelectedForCheckoutAt(int index) => Items[index].Item?.SelectedForCheckout;
+
+            // Pricing is out of scope for these tests and requires fully constructed
+            // ProductPrice/Money graphs to avoid NREs from UpdatePrice. Bypass it.
+            public override void UpdatePrice(LineItem lineItem)
+            {
+            }
         }
     }
 }

--- a/tests/VirtoCommerce.XCart.Tests/Aggregates/ConfiguredLineItemContainerTests.cs
+++ b/tests/VirtoCommerce.XCart.Tests/Aggregates/ConfiguredLineItemContainerTests.cs
@@ -5,6 +5,7 @@ using VirtoCommerce.CartModule.Core.Model;
 using VirtoCommerce.CatalogModule.Core.Model;
 using VirtoCommerce.CoreModule.Core.Common;
 using VirtoCommerce.CoreModule.Core.Currency;
+using VirtoCommerce.Platform.Core.Common;
 using VirtoCommerce.StoreModule.Core.Model;
 using VirtoCommerce.XCart.Core;
 using VirtoCommerce.XCart.Core.Models;
@@ -128,6 +129,14 @@ namespace VirtoCommerce.XCart.Tests.Aggregates
 
             _container.InnerLineItemSelectedForCheckoutAt(0).Should().BeFalse(
                 "creation-path overload must propagate selectedForCheckout to the synthetic LineItem so that CreateConfiguredLineItem can read it back");
+        }
+
+        [Fact]
+        public void LineItemFactoryDefault_SelectedForCheckout_IsTrue_NoRegressionForLegacyOverload()
+        {
+            var lineItem = AbstractTypeFactory<LineItem>.TryCreateInstance();
+
+            lineItem.SelectedForCheckout.Should().BeTrue();
         }
 
         [Fact]


### PR DESCRIPTION
## Description

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-4961
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.XCart_3.1014.0-pr-117-dc94.zip