### PR TITLE
VCST-5101: Mixed currency line items support

### DIFF
--- a/src/VirtoCommerce.XCart.Core/CartAggregate.cs
+++ b/src/VirtoCommerce.XCart.Core/CartAggregate.cs
@@ -104,6 +104,7 @@ namespace VirtoCommerce.XCart.Core
                 {
                     item.IsDefaultTotalCurrency = Cart.Currency.EqualsIgnoreCase(item.CartTotal.CurrencyCode);
                     item.Currency = AllCurrencies?.FirstOrDefault(x => x.Code.EqualsIgnoreCase(item.CartTotal.CurrencyCode)) ?? Currency;
+                    item.CartAggregate = this;
                 }
 
                 return cartTotals;
@@ -1016,7 +1017,7 @@ namespace VirtoCommerce.XCart.Core
             var promotionResult = new PromotionResult();
 
             // Promotions are evaluated against the cart's main currency; skip when there are no items in it.
-            if (CartCurrencySelectedLineItems.Any() && !CartCurrencySelectedLineItems.Any(i => i.IsReadOnly))
+            if (HasSelectedLineItems && !CartCurrencySelectedLineItems.Any(i => i.IsReadOnly))
             {
                 var evalContext = AbstractTypeFactory<PromotionEvaluationContext>.TryCreateInstance();
                 var evalContextCartMap = AbstractTypeFactory<PromotionEvaluationContextCartMap>.TryCreateInstance();
@@ -1040,13 +1041,19 @@ namespace VirtoCommerce.XCart.Core
         protected virtual async Task<IEnumerable<TaxRate>> EvaluateTaxesAsync()
         {
             EnsureCartExists();
+
             var result = Enumerable.Empty<TaxRate>();
-            var taxProvider = await GetActiveTaxProviderAsync();
-            if (taxProvider != null)
+
+            if (HasSelectedLineItems)
             {
-                var taxEvalContext = _mapper.Map<TaxEvaluationContext>(this);
-                result = taxProvider.CalculateRates(taxEvalContext);
+                var taxProvider = await GetActiveTaxProviderAsync();
+                if (taxProvider != null)
+                {
+                    var taxEvalContext = _mapper.Map<TaxEvaluationContext>(this);
+                    result = taxProvider.CalculateRates(taxEvalContext);
+                }
             }
+
             return result;
         }
 

--- a/src/VirtoCommerce.XCart.Core/CartAggregate.cs
+++ b/src/VirtoCommerce.XCart.Core/CartAggregate.cs
@@ -98,7 +98,7 @@ namespace VirtoCommerce.XCart.Core
         {
             get
             {
-                var cartTotals = Cart.CartTotals.Select(x => new CartTotalAggregate() { CartTotal = x }).ToList();
+                var cartTotals = Cart.CartTotals?.Select(x => new CartTotalAggregate() { CartTotal = x }).ToList() ?? [];
 
                 foreach (var item in cartTotals)
                 {

--- a/src/VirtoCommerce.XCart.Core/CartAggregate.cs
+++ b/src/VirtoCommerce.XCart.Core/CartAggregate.cs
@@ -103,7 +103,7 @@ namespace VirtoCommerce.XCart.Core
                 foreach (var item in cartTotals)
                 {
                     item.IsDefaultTotalCurrency = Cart.Currency.EqualsIgnoreCase(item.CartTotal.CurrencyCode);
-                    item.Currency = ItemCurrencies?.FirstOrDefault(x => x.Code.EqualsIgnoreCase(item.CartTotal.CurrencyCode));
+                    item.Currency = ItemCurrencies?.FirstOrDefault(x => x.Code.EqualsIgnoreCase(item.CartTotal.CurrencyCode)) ?? Currency;
                 }
 
                 return cartTotals;

--- a/src/VirtoCommerce.XCart.Core/CartAggregate.cs
+++ b/src/VirtoCommerce.XCart.Core/CartAggregate.cs
@@ -92,6 +92,24 @@ namespace VirtoCommerce.XCart.Core
         public Currency Currency { get; protected set; }
         public Member Member { get; protected set; }
 
+        public IList<Currency> ItemCurrencies { get; set; }
+
+        public IList<CartTotalAggregate> CartTotals
+        {
+            get
+            {
+                var cartTotals = Cart.CartTotals.Select(x => new CartTotalAggregate() { CartTotal = x }).ToList();
+
+                foreach (var item in cartTotals)
+                {
+                    item.IsDefaultTotalCurrency = Cart.Currency.EqualsIgnoreCase(item.CartTotal.CurrencyCode);
+                    item.Currency = ItemCurrencies.FirstOrDefault(x => x.Code.EqualsIgnoreCase(item.CartTotal.CurrencyCode));
+                }
+
+                return cartTotals;
+            }
+        }
+
         public IEnumerable<CartCoupon> Coupons
         {
             get
@@ -123,9 +141,29 @@ namespace VirtoCommerce.XCart.Core
         public bool HasSelectedLineItems => SelectedLineItems.Any();
 
         /// <summary>
-        /// Represents the dictionary of all CartProducts data for each  existing cart line item
+        /// Represents the dictionary of all CartProducts data for each  existing cart line item.
+        /// Key is a composite "{productId}:{CURRENCYCODE}" — built via <see cref="GetCartProductKey(string, string)"/>.
+        /// This allows storing the same product under different currencies in the same cart.
         /// </summary>
         public IDictionary<string, CartProduct> CartProducts { get; protected set; } = new Dictionary<string, CartProduct>().WithDefaultValue(null);
+
+        /// <summary>
+        /// Builds a CartProducts dictionary key from product id and currency code.
+        /// </summary>
+        public static string GetCartProductKey(string productId, string currencyCode)
+        {
+            return $"{productId}:{currencyCode?.ToUpperInvariant()}";
+        }
+
+        /// <summary>
+        /// Builds a CartProducts dictionary key for the specified line item.
+        /// Falls back to <see cref="ShoppingCart.Currency"/> when the line item has no currency set.
+        /// </summary>
+        public virtual string GetCartProductKey(LineItem lineItem)
+        {
+            var currencyCode = !string.IsNullOrEmpty(lineItem?.Currency) ? lineItem.Currency : Cart?.Currency;
+            return GetCartProductKey(lineItem?.ProductId, currencyCode);
+        }
 
         /// <summary>
         /// Contains a new of validation rule set that will be executed each time the basket is changed.
@@ -246,7 +284,7 @@ namespace VirtoCommerce.XCart.Core
                 return this;
             }
 
-            CartProducts[newCartItem.CartProduct.Id] = newCartItem.CartProduct;
+            CartProducts[GetCartProductKey(newConfiguredItem)] = newCartItem.CartProduct;
 
             newConfiguredItem.Id = null;
             newConfiguredItem.SelectedForCheckout = IsSelectedForCheckout;
@@ -295,7 +333,15 @@ namespace VirtoCommerce.XCart.Core
                 newCartItem.CartProduct.Price = new ProductPrice(Currency);
             }
 
-            var lineItem = _mapper.Map<LineItem>(newCartItem.CartProduct, options => options.Items.TryAdd("cultureName", Cart.LanguageCode));
+            var lineItem = _mapper.Map<LineItem>(newCartItem.CartProduct, options =>
+            {
+                options.Items.TryAdd("cultureName", Cart.LanguageCode);
+
+                if (!newCartItem.CurrencyCode.IsNullOrEmpty())
+                {
+                    options.Items.TryAdd("currencyCode", newCartItem.CurrencyCode);
+                }
+            });
 
             lineItem.Currency ??= Currency.Code;
             lineItem.SelectedForCheckout = newCartItem.IsSelectedForCheckout ?? IsSelectedForCheckout;
@@ -318,7 +364,7 @@ namespace VirtoCommerce.XCart.Core
                 lineItem.Note = newCartItem.Comment;
             }
 
-            CartProducts[newCartItem.CartProduct.Id] = newCartItem.CartProduct;
+            CartProducts[GetCartProductKey(lineItem)] = newCartItem.CartProduct;
             await SetItemFulfillmentCenterAsync(lineItem, newCartItem.CartProduct);
             await UpdateVendor(lineItem, newCartItem.CartProduct);
             await InnerAddLineItemAsync(lineItem, newCartItem.OverrideQuantity, newCartItem.CartProduct, newCartItem.DynamicProperties);
@@ -607,6 +653,19 @@ namespace VirtoCommerce.XCart.Core
             return Task.FromResult(this);
         }
 
+        public virtual Task<CartAggregate> RemoveItemsByProductIdAndCurrencyAsync(string productId, string currencyCode)
+        {
+            EnsureCartExists();
+
+            var lineItems = LineItems.Where(x => x.ProductId == productId && x.Currency.EqualsIgnoreCase(currencyCode)).ToList();
+            if (lineItems.Count != 0)
+            {
+                lineItems.ForEach(x => Cart.Items.Remove(x));
+            }
+
+            return Task.FromResult(this);
+        }
+
         public virtual Task<CartAggregate> AddCouponAsync(string couponCode)
         {
             EnsureCartExists();
@@ -809,7 +868,7 @@ namespace VirtoCommerce.XCart.Core
         {
             foreach (var lineItem in otherCart.Cart.Items.ToList())
             {
-                await InnerAddLineItemAsync(lineItem, overrideQuantity: false, product: otherCart.CartProducts[lineItem.ProductId]);
+                await InnerAddLineItemAsync(lineItem, overrideQuantity: false, product: otherCart.CartProducts[otherCart.GetCartProductKey(lineItem)]);
             }
         }
 
@@ -1245,7 +1304,7 @@ namespace VirtoCommerce.XCart.Core
         {
             var existingLineItem = newLineItem.IsConfigured
                 ? null
-                : FindExistingLineItemBeforeAdd(newLineItem.ProductId, product, dynamicProperties);
+                : FindExistingLineItemBeforeAdd(newLineItem, product, dynamicProperties);
 
             if (existingLineItem != null)
             {
@@ -1279,9 +1338,23 @@ namespace VirtoCommerce.XCart.Core
         /// <param name="newProduct">new product object</param>
         /// <param name="newDynamicProperties">new dynamuc properties that should be added/updated in cart line item</param>
         /// <returns></returns>
+        [Obsolete]
         protected virtual LineItem FindExistingLineItemBeforeAdd(string newProductId, CartProduct newProduct, IList<DynamicPropertyValue> newDynamicProperties)
         {
             return LineItems.FirstOrDefault(x => x.ProductId == newProductId && !x.IsConfigured);
+        }
+
+        /// <summary>
+        /// Responsible for finding an existing line item before adding a new one.
+        /// If method returns line item, it means that the new line item should be merged with the existing one.
+        /// </summary>
+        /// <param name="newLineItem">new line item</param>
+        /// <param name="newProduct">new product object</param>
+        /// <param name="newDynamicProperties">new dynamuc properties that should be added/updated in cart line item</param>
+        /// <returns></returns>
+        protected virtual LineItem FindExistingLineItemBeforeAdd(LineItem newLineItem, CartProduct newProduct, IList<DynamicPropertyValue> newDynamicProperties)
+        {
+            return LineItems.FirstOrDefault(x => x.ProductId == newLineItem.ProductId && x.Currency.EqualsIgnoreCase(newLineItem.Currency) && !x.IsConfigured);
         }
 
         protected virtual void EnsureCartExists()
@@ -1914,7 +1987,7 @@ namespace VirtoCommerce.XCart.Core
             container.Currency = Currency;
             container.Store = Store;
 
-            if (CartProducts.TryGetValue(configurationLineItem.ProductId, out var configurableProduct))
+            if (CartProducts.TryGetValue(GetCartProductKey(configurationLineItem), out var configurableProduct))
             {
                 container.ConfigurableProduct = configurableProduct;
             }
@@ -2021,4 +2094,13 @@ namespace VirtoCommerce.XCart.Core
 
         #endregion ICloneable
     }
+}
+
+public class CartTotalAggregate
+{
+    public bool IsDefaultTotalCurrency { get; set; }
+
+    public Currency Currency { get; set; }
+
+    public CartTotal CartTotal { get; set; }
 }

--- a/src/VirtoCommerce.XCart.Core/CartAggregate.cs
+++ b/src/VirtoCommerce.XCart.Core/CartAggregate.cs
@@ -166,6 +166,15 @@ namespace VirtoCommerce.XCart.Core
         }
 
         /// <summary>
+        /// Resolves the <see cref="Currency"/> matching the specified code from <see cref="ItemCurrencies"/>.
+        /// Falls back to the cart's default <see cref="Currency"/> when no match is found.
+        /// </summary>
+        public virtual Currency GetCurrencyByCode(string currencyCode)
+        {
+            return ItemCurrencies?.FirstOrDefault(x => x.Code.EqualsIgnoreCase(currencyCode)) ?? Currency;
+        }
+
+        /// <summary>
         /// Contains a new of validation rule set that will be executed each time the basket is changed.
         /// FluentValidation RuleSets allow you to group validation rules together which can be executed together as a group. You can set exists rule set name to evaluate default.
         /// <see cref="CartValidator"/>
@@ -372,12 +381,13 @@ namespace VirtoCommerce.XCart.Core
         {
             EnsureCartExists();
 
-            var productIds = newCartItems.Select(x => x.ProductId).Distinct().ToArray();
-            var productsByIds = (await _cartProductService.GetCartProductsByIdsAsync(this, productIds)).ToDictionary(x => x.Id);
+            var productPairs = newCartItems.Select(x => (x.CurrencyCode, x.ProductId)).Distinct().ToList();
+            var products = await _cartProductService.GetCartProductsAsync(this, productPairs);
 
             foreach (var item in newCartItems)
             {
-                if (!productsByIds.TryGetValue(item.ProductId, out var product))
+                var currencyCode = !string.IsNullOrEmpty(item.CurrencyCode) ? item.CurrencyCode : Currency.Code;
+                if (!products.TryGetValue(GetCartProductKey(item.ProductId, currencyCode), out var product))
                 {
                     var error = CartErrorDescriber.ProductUnavailableError(nameof(CatalogProduct), item.ProductId);
                     OperationValidationErrors.Add(error);
@@ -407,9 +417,10 @@ namespace VirtoCommerce.XCart.Core
                 return new List<GiftItem>();
             }
 
-            var productsByIds = (await _cartProductService.GetCartProductsByIdsAsync(this, productIds)).ToDictionary(x => x.Id);
+            var productPairs = productIds.Select(id => (Currency.Code, id)).ToList();
+            var products = await _cartProductService.GetCartProductsAsync(this, productPairs);
 
-            var availableProductsIds = productsByIds.Values
+            var availableProductsIds = products.Values
                 .Where(x => (x.Product.IsActive ?? false) &&
                             (x.Product.IsBuyable ?? false) &&
                             x.Price != null &&
@@ -425,7 +436,7 @@ namespace VirtoCommerce.XCart.Core
                     var result = _mapper.Map<GiftItem>(reward);
 
                     // if reward has assigned product, add data from product
-                    if (!reward.ProductId.IsNullOrEmpty() && productsByIds.TryGetValue(reward.ProductId, out var product))
+                    if (!reward.ProductId.IsNullOrEmpty() && products.TryGetValue(GetCartProductKey(reward.ProductId, Currency.Code), out var product))
                     {
                         result.CatalogId = product.Product.CatalogId;
                         result.CategoryId ??= product.Product.CategoryId;
@@ -1517,14 +1528,14 @@ namespace VirtoCommerce.XCart.Core
             var cloneItem = lineItem.CloneTyped();
             cloneItem.ConfigurationItems ??= new List<ConfigurationItem>();
 
-            var productIds = configurationSections
+            var productPairs = configurationSections
                 .Where(x => x.Type is ConfigurationSectionTypeProduct or ConfigurationSectionTypeVariation && !string.IsNullOrEmpty(x.Option?.ProductId))
-                .Select(x => x.Option.ProductId)
+                .Select(x => (lineItem.Currency, x.Option.ProductId))
                 .Distinct()
-                .ToArray();
+                .ToList();
 
-            var products = productIds.Length > 0
-                ? (await _cartProductService.GetCartProductsByIdsAsync(this, productIds)).ToDictionary(x => x.Product.Id)
+            var products = productPairs.Count > 0
+                ? await _cartProductService.GetCartProductsAsync(this, productPairs)
                 : null;
 
             foreach (var section in configurationSections)
@@ -1591,14 +1602,14 @@ namespace VirtoCommerce.XCart.Core
             cloneItem.ConfigurationItems ??= new List<ConfigurationItem>();
 
             // Load products for Product/Variation types (needed for both update and create)
-            var productIds = configurationSections
+            var productPairs = configurationSections
                 .Where(x => x.Type is ConfigurationSectionTypeProduct or ConfigurationSectionTypeVariation && !string.IsNullOrEmpty(x.Option?.ProductId))
-                .Select(x => x.Option.ProductId)
+                .Select(x => (lineItem.Currency, x.Option.ProductId))
                 .Distinct()
-                .ToArray();
+                .ToList();
 
-            var products = productIds.Length > 0
-                ? (await _cartProductService.GetCartProductsByIdsAsync(this, productIds)).ToDictionary(x => x.Product.Id)
+            var products = productPairs.Count > 0
+                ? await _cartProductService.GetCartProductsAsync(this, productPairs)
                 : null;
 
             var fileUrlsToDelete = new List<string>();
@@ -1636,14 +1647,14 @@ namespace VirtoCommerce.XCart.Core
         protected virtual async Task ApplyConfigurationSectionAsync(
             LineItem lineItem,
             ProductConfigurationSection section,
-            Dictionary<string, CartProduct> products,
+            IDictionary<string, CartProduct> products,
             IList<string> fileUrlsToDelete = null)
         {
             switch (section.Type)
             {
                 case ConfigurationSectionTypeProduct or ConfigurationSectionTypeVariation:
                     {
-                        if (products?.TryGetValue(section.Option.ProductId, out var cartProduct) != true)
+                        if (products?.TryGetValue(GetCartProductKey(section.Option.ProductId, lineItem.Currency), out var cartProduct) != true)
                         {
                             OperationValidationErrors.Add(CartErrorDescriber.ProductUnavailableError(nameof(CatalogProduct), section.Option.ProductId));
                             return;
@@ -1957,14 +1968,14 @@ namespace VirtoCommerce.XCart.Core
 
         public virtual async Task<CartAggregate> UpdateConfiguredLineItemPrice(IList<LineItem> configuredItems)
         {
-            var configProductsIds = configuredItems
+            var configProductPairs = configuredItems
                 .Where(x => !x.ConfigurationItems.IsNullOrEmpty())
-                .SelectMany(x => x.ConfigurationItems.Where(c => c.ProductId != null).Select(c => c.ProductId))
+                .SelectMany(x => x.ConfigurationItems.Where(c => c.ProductId != null).Select(c => (x.Currency, c.ProductId)))
                 .Distinct()
-                .ToArray();
+                .ToList();
 
-            var configProducts = configProductsIds.Length > 0
-                ? (await _cartProductService.GetCartProductsByIdsAsync(this, configProductsIds)).ToDictionary(x => x.Id)
+            var configProducts = configProductPairs.Count > 0
+                ? await _cartProductService.GetCartProductsAsync(this, configProductPairs)
                 : new Dictionary<string, CartProduct>();
 
             foreach (var configurationLineItem in configuredItems)
@@ -1977,10 +1988,10 @@ namespace VirtoCommerce.XCart.Core
             return this;
         }
 
-        protected virtual ConfiguredLineItemContainer CreateConfiguredLineItemContainer(LineItem configurationLineItem, Dictionary<string, CartProduct> configProducts)
+        protected virtual ConfiguredLineItemContainer CreateConfiguredLineItemContainer(LineItem configurationLineItem, IDictionary<string, CartProduct> configProducts)
         {
             var container = AbstractTypeFactory<ConfiguredLineItemContainer>.TryCreateInstance();
-            container.Currency = Currency;
+            container.Currency = GetCurrencyByCode(configurationLineItem.Currency);
             container.Store = Store;
 
             if (CartProducts.TryGetValue(GetCartProductKey(configurationLineItem), out var configurableProduct))
@@ -1994,7 +2005,7 @@ namespace VirtoCommerce.XCart.Core
                 {
                     case ConfigurationSectionTypeProduct or ConfigurationSectionTypeVariation:
                         {
-                            if (configProducts.TryGetValue(configurationItem.ProductId, out var product))
+                            if (configProducts.TryGetValue(GetCartProductKey(configurationItem.ProductId, configurationLineItem.Currency), out var product))
                             {
                                 container.AddProductSectionLineItem(product, configurationItem);
                             }

--- a/src/VirtoCommerce.XCart.Core/CartAggregate.cs
+++ b/src/VirtoCommerce.XCart.Core/CartAggregate.cs
@@ -137,13 +137,13 @@ namespace VirtoCommerce.XCart.Core
         public IEnumerable<LineItem> GiftItems => Cart?.Items.Where(x => x.IsGift) ?? Enumerable.Empty<LineItem>();
         public IEnumerable<LineItem> LineItems => Cart?.Items.Where(x => !x.IsGift) ?? Enumerable.Empty<LineItem>();
         public IEnumerable<LineItem> SelectedLineItems => LineItems.Where(x => x.SelectedForCheckout);
-        public IEnumerable<LineItem> CartCurrencySelectedLineItems => SelectedLineItems.Where(x => x.Currency.EqualsIgnoreCase(Cart.Currency));
+        public IEnumerable<LineItem> CartCurrencySelectedLineItems => SelectedLineItems.Where(x => x.Currency.EqualsIgnoreCase(Cart.Currency) || x.Currency.IsNullOrEmpty());
 
         public bool HasSelectedLineItems => CartCurrencySelectedLineItems.Any();
 
         /// <summary>
         /// Represents the dictionary of all CartProducts data for each  existing cart line item.
-        /// Key is a composite "{productId}:{CURRENCYCODE}" — built via <see cref="GetCartProductKey(string, string)"/>.
+        /// Key is a composite "{productId}:{CURRENCYCODE}" — built via <see cref="FormatGetCartProductKey(string, string)"/>.
         /// This allows storing the same product under different currencies in the same cart.
         /// </summary>
         public IDictionary<string, CartProduct> CartProducts { get; protected set; } = new Dictionary<string, CartProduct>().WithDefaultValue(null);
@@ -151,7 +151,7 @@ namespace VirtoCommerce.XCart.Core
         /// <summary>
         /// Builds a CartProducts dictionary key from product id and currency code.
         /// </summary>
-        public static string GetCartProductKey(string productId, string currencyCode)
+        public static string FormatGetCartProductKey(string productId, string currencyCode)
         {
             return $"{productId}:{currencyCode}";
         }
@@ -163,7 +163,13 @@ namespace VirtoCommerce.XCart.Core
         public virtual string GetCartProductKey(LineItem lineItem)
         {
             var currencyCode = !string.IsNullOrEmpty(lineItem?.Currency) ? lineItem.Currency : Cart?.Currency;
-            return GetCartProductKey(lineItem?.ProductId, currencyCode);
+            return FormatGetCartProductKey(lineItem?.ProductId, currencyCode);
+        }
+
+        public virtual string GetCartProductKey(string productId, string currencyCode)
+        {
+            var normalizedCode = !string.IsNullOrEmpty(currencyCode) ? currencyCode : Cart?.Currency;
+            return FormatGetCartProductKey(productId, normalizedCode);
         }
 
         /// <summary>

--- a/src/VirtoCommerce.XCart.Core/CartAggregate.cs
+++ b/src/VirtoCommerce.XCart.Core/CartAggregate.cs
@@ -137,8 +137,9 @@ namespace VirtoCommerce.XCart.Core
         public IEnumerable<LineItem> GiftItems => Cart?.Items.Where(x => x.IsGift) ?? Enumerable.Empty<LineItem>();
         public IEnumerable<LineItem> LineItems => Cart?.Items.Where(x => !x.IsGift) ?? Enumerable.Empty<LineItem>();
         public IEnumerable<LineItem> SelectedLineItems => LineItems.Where(x => x.SelectedForCheckout);
+        public IEnumerable<LineItem> CartCurrencySelectedLineItems => SelectedLineItems.Where(x => x.Currency.EqualsIgnoreCase(Cart.Currency));
 
-        public bool HasSelectedLineItems => SelectedLineItems.Any();
+        public bool HasSelectedLineItems => CartCurrencySelectedLineItems.Any();
 
         /// <summary>
         /// Represents the dictionary of all CartProducts data for each  existing cart line item.
@@ -669,7 +670,7 @@ namespace VirtoCommerce.XCart.Core
             var lineItems = LineItems.Where(x =>
                 x.ProductId == productId &&
                 (string.IsNullOrEmpty(x.Currency) ? Cart.Currency : x.Currency).EqualsIgnoreCase(targetCurrency)).ToList();
-                
+
             if (lineItems.Count != 0)
             {
                 lineItems.ForEach(x => Cart.Items.Remove(x));
@@ -1007,7 +1008,9 @@ namespace VirtoCommerce.XCart.Core
             EnsureCartExists();
 
             var promotionResult = new PromotionResult();
-            if (!LineItems.IsNullOrEmpty() && !LineItems.Any(i => i.IsReadOnly))
+
+            // Promotions are evaluated against the cart's main currency; skip when there are no items in it.
+            if (CartCurrencySelectedLineItems.Any() && !CartCurrencySelectedLineItems.Any(i => i.IsReadOnly))
             {
                 var evalContext = AbstractTypeFactory<PromotionEvaluationContext>.TryCreateInstance();
                 var evalContextCartMap = AbstractTypeFactory<PromotionEvaluationContextCartMap>.TryCreateInstance();

--- a/src/VirtoCommerce.XCart.Core/CartAggregate.cs
+++ b/src/VirtoCommerce.XCart.Core/CartAggregate.cs
@@ -345,7 +345,7 @@ namespace VirtoCommerce.XCart.Core
             var lineItem = _mapper.Map<LineItem>(newCartItem.CartProduct, options =>
             {
                 options.Items.TryAdd("cultureName", Cart.LanguageCode);
-                options.Items.TryAdd("currencyCode", newCartItem.CurrencyCode);
+                options.Items.TryAdd("currencyCode", newCartItem.ItemCurrencyCode);
             });
 
             lineItem.Currency ??= Currency.Code;
@@ -381,12 +381,12 @@ namespace VirtoCommerce.XCart.Core
         {
             EnsureCartExists();
 
-            var productPairs = newCartItems.Select(x => (x.CurrencyCode, x.ProductId)).Distinct().ToList();
+            var productPairs = newCartItems.Select(x => (x.ItemCurrencyCode, x.ProductId)).Distinct().ToList();
             var products = await _cartProductService.GetCartProductsAsync(this, productPairs);
 
             foreach (var item in newCartItems)
             {
-                var currencyCode = !string.IsNullOrEmpty(item.CurrencyCode) ? item.CurrencyCode : Currency.Code;
+                var currencyCode = !string.IsNullOrEmpty(item.ItemCurrencyCode) ? item.ItemCurrencyCode : Currency.Code;
                 if (!products.TryGetValue(GetCartProductKey(item.ProductId, currencyCode), out var product))
                 {
                     var error = CartErrorDescriber.ProductUnavailableError(nameof(CatalogProduct), item.ProductId);

--- a/src/VirtoCommerce.XCart.Core/CartAggregate.cs
+++ b/src/VirtoCommerce.XCart.Core/CartAggregate.cs
@@ -92,7 +92,7 @@ namespace VirtoCommerce.XCart.Core
         public Currency Currency { get; protected set; }
         public Member Member { get; protected set; }
 
-        public IList<Currency> ItemCurrencies { get; set; }
+        public IList<Currency> AllCurrencies { get; set; }
 
         public IList<CartTotalAggregate> CartTotals
         {
@@ -103,7 +103,7 @@ namespace VirtoCommerce.XCart.Core
                 foreach (var item in cartTotals)
                 {
                     item.IsDefaultTotalCurrency = Cart.Currency.EqualsIgnoreCase(item.CartTotal.CurrencyCode);
-                    item.Currency = ItemCurrencies?.FirstOrDefault(x => x.Code.EqualsIgnoreCase(item.CartTotal.CurrencyCode)) ?? Currency;
+                    item.Currency = AllCurrencies?.FirstOrDefault(x => x.Code.EqualsIgnoreCase(item.CartTotal.CurrencyCode)) ?? Currency;
                 }
 
                 return cartTotals;
@@ -167,12 +167,12 @@ namespace VirtoCommerce.XCart.Core
         }
 
         /// <summary>
-        /// Resolves the <see cref="Currency"/> matching the specified code from <see cref="ItemCurrencies"/>.
+        /// Resolves the <see cref="Currency"/> matching the specified code from <see cref="AllCurrencies"/>.
         /// Falls back to the cart's default <see cref="Currency"/> when no match is found.
         /// </summary>
         public virtual Currency GetCurrencyByCode(string currencyCode)
         {
-            return ItemCurrencies?.FirstOrDefault(x => x.Code.EqualsIgnoreCase(currencyCode)) ?? Currency;
+            return AllCurrencies?.FirstOrDefault(x => x.Code.EqualsIgnoreCase(currencyCode)) ?? Currency;
         }
 
         /// <summary>

--- a/src/VirtoCommerce.XCart.Core/CartAggregate.cs
+++ b/src/VirtoCommerce.XCart.Core/CartAggregate.cs
@@ -103,7 +103,7 @@ namespace VirtoCommerce.XCart.Core
                 foreach (var item in cartTotals)
                 {
                     item.IsDefaultTotalCurrency = Cart.Currency.EqualsIgnoreCase(item.CartTotal.CurrencyCode);
-                    item.Currency = ItemCurrencies.FirstOrDefault(x => x.Code.EqualsIgnoreCase(item.CartTotal.CurrencyCode));
+                    item.Currency = ItemCurrencies?.FirstOrDefault(x => x.Code.EqualsIgnoreCase(item.CartTotal.CurrencyCode));
                 }
 
                 return cartTotals;

--- a/src/VirtoCommerce.XCart.Core/CartAggregate.cs
+++ b/src/VirtoCommerce.XCart.Core/CartAggregate.cs
@@ -152,7 +152,7 @@ namespace VirtoCommerce.XCart.Core
         /// </summary>
         public static string GetCartProductKey(string productId, string currencyCode)
         {
-            return $"{productId}:{currencyCode?.ToUpperInvariant()}";
+            return $"{productId}:{currencyCode}";
         }
 
         /// <summary>
@@ -664,7 +664,12 @@ namespace VirtoCommerce.XCart.Core
         {
             EnsureCartExists();
 
-            var lineItems = LineItems.Where(x => x.ProductId == productId && x.Currency.EqualsIgnoreCase(currencyCode)).ToList();
+            // Missing currencies on either side are treated as the cart's currency.
+            var targetCurrency = !string.IsNullOrEmpty(currencyCode) ? currencyCode : Cart.Currency;
+            var lineItems = LineItems.Where(x =>
+                x.ProductId == productId &&
+                (string.IsNullOrEmpty(x.Currency) ? Cart.Currency : x.Currency).EqualsIgnoreCase(targetCurrency)).ToList();
+                
             if (lineItems.Count != 0)
             {
                 lineItems.ForEach(x => Cart.Items.Remove(x));
@@ -1343,7 +1348,7 @@ namespace VirtoCommerce.XCart.Core
         /// </summary>
         /// <param name="newProductId">new product id</param>
         /// <param name="newProduct">new product object</param>
-        /// <param name="newDynamicProperties">new dynamuc properties that should be added/updated in cart line item</param>
+        /// <param name="newDynamicProperties">new dynamic properties that should be added/updated in cart line item</param>
         /// <returns></returns>
         [Obsolete("Use FindExistingLineItemBeforeAdd.FindExistingLineItemBeforeAdd(LineItem newLineItem...) instead.", DiagnosticId = "VC0014")]
         protected virtual LineItem FindExistingLineItemBeforeAdd(string newProductId, CartProduct newProduct, IList<DynamicPropertyValue> newDynamicProperties)
@@ -1357,11 +1362,16 @@ namespace VirtoCommerce.XCart.Core
         /// </summary>
         /// <param name="newLineItem">new line item</param>
         /// <param name="newProduct">new product object</param>
-        /// <param name="newDynamicProperties">new dynamuc properties that should be added/updated in cart line item</param>
+        /// <param name="newDynamicProperties">new dynamic properties that should be added/updated in cart line item</param>
         /// <returns></returns>
         protected virtual LineItem FindExistingLineItemBeforeAdd(LineItem newLineItem, CartProduct newProduct, IList<DynamicPropertyValue> newDynamicProperties)
         {
-            return LineItems.FirstOrDefault(x => x.ProductId == newLineItem.ProductId && x.Currency.EqualsIgnoreCase(newLineItem.Currency) && !x.IsConfigured);
+            // Missing currencies on either side are treated as the cart's currency.
+            var newCurrency = !string.IsNullOrEmpty(newLineItem.Currency) ? newLineItem.Currency : Cart.Currency;
+            return LineItems.FirstOrDefault(x =>
+                x.ProductId == newLineItem.ProductId &&
+                !x.IsConfigured &&
+                (string.IsNullOrEmpty(x.Currency) ? Cart.Currency : x.Currency).EqualsIgnoreCase(newCurrency));
         }
 
         protected virtual void EnsureCartExists()

--- a/src/VirtoCommerce.XCart.Core/CartAggregate.cs
+++ b/src/VirtoCommerce.XCart.Core/CartAggregate.cs
@@ -336,11 +336,7 @@ namespace VirtoCommerce.XCart.Core
             var lineItem = _mapper.Map<LineItem>(newCartItem.CartProduct, options =>
             {
                 options.Items.TryAdd("cultureName", Cart.LanguageCode);
-
-                if (!newCartItem.CurrencyCode.IsNullOrEmpty())
-                {
-                    options.Items.TryAdd("currencyCode", newCartItem.CurrencyCode);
-                }
+                options.Items.TryAdd("currencyCode", newCartItem.CurrencyCode);
             });
 
             lineItem.Currency ??= Currency.Code;
@@ -1338,7 +1334,7 @@ namespace VirtoCommerce.XCart.Core
         /// <param name="newProduct">new product object</param>
         /// <param name="newDynamicProperties">new dynamuc properties that should be added/updated in cart line item</param>
         /// <returns></returns>
-        [Obsolete]
+        [Obsolete("Use FindExistingLineItemBeforeAdd.FindExistingLineItemBeforeAdd(LineItem newLineItem...) instead.", DiagnosticId = "VC0014")]
         protected virtual LineItem FindExistingLineItemBeforeAdd(string newProductId, CartProduct newProduct, IList<DynamicPropertyValue> newDynamicProperties)
         {
             return LineItems.FirstOrDefault(x => x.ProductId == newProductId && !x.IsConfigured);
@@ -2094,13 +2090,4 @@ namespace VirtoCommerce.XCart.Core
 
         #endregion ICloneable
     }
-}
-
-public class CartTotalAggregate
-{
-    public bool IsDefaultTotalCurrency { get; set; }
-
-    public Currency Currency { get; set; }
-
-    public CartTotal CartTotal { get; set; }
 }

--- a/src/VirtoCommerce.XCart.Core/CartTotalAggregate.cs
+++ b/src/VirtoCommerce.XCart.Core/CartTotalAggregate.cs
@@ -7,6 +7,8 @@ public class CartTotalAggregate
 {
     public bool IsDefaultTotalCurrency { get; set; }
 
+    public CartAggregate CartAggregate { get; set; }
+
     public Currency Currency { get; set; }
 
     public CartTotal CartTotal { get; set; }

--- a/src/VirtoCommerce.XCart.Core/CartTotalAggregate.cs
+++ b/src/VirtoCommerce.XCart.Core/CartTotalAggregate.cs
@@ -1,0 +1,13 @@
+using VirtoCommerce.CartModule.Core.Model;
+using VirtoCommerce.CoreModule.Core.Currency;
+
+namespace VirtoCommerce.XCart.Core;
+
+public class CartTotalAggregate
+{
+    public bool IsDefaultTotalCurrency { get; set; }
+
+    public Currency Currency { get; set; }
+
+    public CartTotal CartTotal { get; set; }
+}

--- a/src/VirtoCommerce.XCart.Core/Commands/AddCartItemCommand.cs
+++ b/src/VirtoCommerce.XCart.Core/Commands/AddCartItemCommand.cs
@@ -18,6 +18,11 @@ namespace VirtoCommerce.XCart.Core.Commands
         public decimal? Price { get; set; }
 
         /// <summary>
+        /// Manual currency
+        /// </summary>
+        public string ItemCurrencyCode { get; set; }
+
+        /// <summary>
         /// Comment
         /// </summary>
         public string Comment { get; set; }

--- a/src/VirtoCommerce.XCart.Core/Commands/UpdateCartQuantityCommand.cs
+++ b/src/VirtoCommerce.XCart.Core/Commands/UpdateCartQuantityCommand.cs
@@ -1,10 +1,16 @@
-﻿using System.Collections.Generic;
+using System;
+using System.Collections.Generic;
 using VirtoCommerce.XCart.Core.Commands.BaseCommands;
 
 namespace VirtoCommerce.XCart.Core.Commands
 {
-    public class UpdateCartQuantityCommand : CartCommand
+    public class UpdateCartQuantityCommand : CartCommand, ICloneable
     {
         public IList<UpdateCartQuantityItem> Items { get; set; }
+
+        public object Clone()
+        {
+            return MemberwiseClone();
+        }
     }
 }

--- a/src/VirtoCommerce.XCart.Core/Commands/UpdateCartQuantityItem.cs
+++ b/src/VirtoCommerce.XCart.Core/Commands/UpdateCartQuantityItem.cs
@@ -1,9 +1,11 @@
-﻿namespace VirtoCommerce.XCart.Core.Commands
+namespace VirtoCommerce.XCart.Core.Commands
 {
     public class UpdateCartQuantityItem
     {
         public string ProductId { get; set; }
 
         public int Quantity { get; set; }
+
+        public string CurrencyCode { get; set; }
     }
 }

--- a/src/VirtoCommerce.XCart.Core/Commands/UpdateCartQuantityItem.cs
+++ b/src/VirtoCommerce.XCart.Core/Commands/UpdateCartQuantityItem.cs
@@ -6,6 +6,6 @@ namespace VirtoCommerce.XCart.Core.Commands
 
         public int Quantity { get; set; }
 
-        public string CurrencyCode { get; set; }
+        public string ItemCurrencyCode { get; set; }
     }
 }

--- a/src/VirtoCommerce.XCart.Core/Extensions/DataLoaderContextAccessorExtensions.cs
+++ b/src/VirtoCommerce.XCart.Core/Extensions/DataLoaderContextAccessorExtensions.cs
@@ -79,7 +79,7 @@ public static class DataLoaderContextAccessorExtensions
         ICurrencyService currencyService,
         string loaderKey)
     {
-        var loader = dataLoader.Context.GetOrAddBatchLoader<(string CurrencyCode, string ProductId), ExpProduct>(loaderKey, async lineItems =>
+        var loader = dataLoader.Context.GetOrAddBatchLoader<(string CurrencyCode, string ProductId), ExpProduct>(loaderKey, async productCurrencyPairs =>
         {
             var cartAggregate = context.GetValueForSource<CartAggregate>();
             var cart = cartAggregate.Cart;
@@ -93,7 +93,7 @@ public static class DataLoaderContextAccessorExtensions
             context.UserContext.TryAdd("store", cartAggregate.Store);
             context.UserContext.TryAdd("cultureName", cultureName);
 
-            var lineItemsByCurrency = lineItems.GroupBy(x => x.CurrencyCode);
+            var lineItemsByCurrency = productCurrencyPairs.GroupBy(x => x.CurrencyCode);
             var result = new Dictionary<(string CurrencyCode, string ProductId), ExpProduct>();
 
             foreach (var currencyLineItems in lineItemsByCurrency)

--- a/src/VirtoCommerce.XCart.Core/Extensions/DataLoaderContextAccessorExtensions.cs
+++ b/src/VirtoCommerce.XCart.Core/Extensions/DataLoaderContextAccessorExtensions.cs
@@ -1,9 +1,10 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Linq;
 using GraphQL;
 using GraphQL.DataLoader;
 using MediatR;
 using VirtoCommerce.CoreModule.Core.Currency;
+using VirtoCommerce.Platform.Core.Common;
 using VirtoCommerce.Xapi.Core.Extensions;
 using VirtoCommerce.XCatalog.Core.Models;
 using VirtoCommerce.XCatalog.Core.Queries;
@@ -69,5 +70,78 @@ public static class DataLoaderContextAccessorExtensions
         var loader = dataLoader.GetCartProductDataLoader(context, mediator, currencyService, loaderKey);
 
         return loader.LoadAsync(productId);
+    }
+
+    public static IDataLoader<(string CurrencyCode, string ProductId), ExpProduct> GetCartCurrencyProductDataLoader(
+        this IDataLoaderContextAccessor dataLoader,
+        IResolveFieldContext context,
+        IMediator mediator,
+        ICurrencyService currencyService,
+        string loaderKey)
+    {
+        var loader = dataLoader.Context.GetOrAddBatchLoader<(string CurrencyCode, string ProductId), ExpProduct>(loaderKey, async lineItems =>
+        {
+            var cartAggregate = context.GetValueForSource<CartAggregate>();
+            var cart = cartAggregate.Cart;
+            var userId = context.GetArgumentOrValue<string>("userId") ?? cart.CustomerId;
+            var allCurrencies = await currencyService.GetAllCurrenciesAsync();
+            var cultureName = context.GetArgumentOrValue<string>("cultureName") ?? cart.LanguageCode;
+
+            context.SetCurrencies(allCurrencies, cultureName);
+            context.UserContext.TryAdd("currencyCode", cart.Currency);
+            context.UserContext.TryAdd("storeId", cart.StoreId);
+            context.UserContext.TryAdd("store", cartAggregate.Store);
+            context.UserContext.TryAdd("cultureName", cultureName);
+
+            var lineItemsByCurrency = lineItems.GroupBy(x => x.CurrencyCode);
+            var result = new Dictionary<(string CurrencyCode, string ProductId), ExpProduct>();
+
+            foreach (var currencyLineItems in lineItemsByCurrency)
+            {
+                var request = new LoadProductsQuery
+                {
+                    StoreId = cart.StoreId,
+                    CurrencyCode = currencyLineItems.Key,
+                    ObjectIds = currencyLineItems.Select(x => x.ProductId).ToArray(),
+                    IncludeFields = context.SubFields.Values.GetAllNodesPaths(context).ToArray(),
+                    UserId = userId,
+                    OrganizationId = context.GetCurrentOrganizationId(),
+                };
+
+                var response = await mediator.Send(request);
+
+                foreach (var item in currencyLineItems)
+                {
+                    var product = response.Products.FirstOrDefault(x => x.Id == item.ProductId);
+                    if (product != null)
+                    {
+                        result.Add(item, product);
+                    }
+                }
+            }
+
+            return result;
+        },
+        keyComparer: AnonymousComparer.Create(((string CurrencyCode, string ProductId) x) => $"{x.ProductId}:{x.CurrencyCode}"));
+
+        return loader;
+    }
+
+    public static IDataLoaderResult<ExpProduct> LoadCartProduct(
+        this IDataLoaderContextAccessor dataLoader,
+        IResolveFieldContext context,
+        IMediator mediator,
+        ICurrencyService currencyService,
+        string loaderKey,
+        (string CurrencyCode, string ProductId) productCurrencyPair)
+    {
+        if (string.IsNullOrEmpty(productCurrencyPair.ProductId) || string.IsNullOrEmpty(productCurrencyPair.CurrencyCode))
+        {
+            return _defaultProductResult;
+        }
+
+        var loader = dataLoader.GetCartCurrencyProductDataLoader(context, mediator, currencyService, loaderKey);
+
+        return loader.LoadAsync(productCurrencyPair);
     }
 }

--- a/src/VirtoCommerce.XCart.Core/Extensions/ResolveFieldContextExtensions.cs
+++ b/src/VirtoCommerce.XCart.Core/Extensions/ResolveFieldContextExtensions.cs
@@ -23,15 +23,12 @@ namespace VirtoCommerce.XCart.Core.Extensions
             return userContext.GetValueForSource<CartAggregate>().Currency;
         }
 
-        /// <summary>
-        /// Returns the currency that matches the line item's <see cref="LineItem.Currency"/> code,
-        /// looked up in the cart's <see cref="CartAggregate.ItemCurrencies"/>.
-        /// Falls back to <see cref="CartAggregate.Currency"/> when no match is found.
-        /// </summary>
-        public static Currency GetLineItemCurrency(this IResolveFieldContext<LineItem> context)
+        public static Currency GetConfiguratonItemCurrency(this IResolveFieldContext<ConfigurationItem> context)
         {
             var cart = context.GetCart();
-            return cart.ItemCurrencies?.FirstOrDefault(x => x.Code.EqualsIgnoreCase(context.Source.Currency)) ?? cart.Currency;
+            var lineItemId = context.Source.LineItemId;
+            var lineItem = cart?.Cart.Items.FirstOrDefault(x => x.Id == lineItemId);
+            return context.GetCurrencyByCode(lineItem?.Currency);
         }
 
         public static Money GetTotal(this IResolveFieldContext<CartAggregate> context, decimal number)

--- a/src/VirtoCommerce.XCart.Core/Extensions/ResolveFieldContextExtensions.cs
+++ b/src/VirtoCommerce.XCart.Core/Extensions/ResolveFieldContextExtensions.cs
@@ -47,8 +47,13 @@ namespace VirtoCommerce.XCart.Core.Extensions
         public static Currency GetConfiguratonItemCurrency(this IResolveFieldContext<ConfigurationItem> context)
         {
             var cart = context.GetCart();
+            if (cart == null)
+            {
+                return null;
+            }
+
             var lineItemId = context.Source.LineItemId;
-            var lineItem = cart?.Cart?.Items?.FirstOrDefault(x => x.Id == lineItemId);
+            var lineItem = cart.Cart?.Items?.FirstOrDefault(x => x.Id == lineItemId);
             if (lineItem == null)
             {
                 return null;

--- a/src/VirtoCommerce.XCart.Core/Extensions/ResolveFieldContextExtensions.cs
+++ b/src/VirtoCommerce.XCart.Core/Extensions/ResolveFieldContextExtensions.cs
@@ -74,6 +74,13 @@ namespace VirtoCommerce.XCart.Core.Extensions
                 : new Money(0.0m, context.Source.Currency);
         }
 
+        public static Money GetTotal(this IResolveFieldContext<CartTotalAggregate> context, decimal number)
+        {
+            return (context.Source.CartAggregate?.HasSelectedLineItems ?? false)
+                ? number.ToMoney(context.Source.Currency)
+                : new Money(0.0m, context.Source.Currency);
+        }
+
         public static T GetCartCommand<T>(this IResolveFieldContext context)
             where T : ICartRequest
         {

--- a/src/VirtoCommerce.XCart.Core/Extensions/ResolveFieldContextExtensions.cs
+++ b/src/VirtoCommerce.XCart.Core/Extensions/ResolveFieldContextExtensions.cs
@@ -76,7 +76,14 @@ namespace VirtoCommerce.XCart.Core.Extensions
 
         public static Money GetTotal(this IResolveFieldContext<CartTotalAggregate> context, decimal number)
         {
-            return (context.Source.CartAggregate?.HasSelectedLineItems ?? false)
+            var total = context.Source;
+
+            if (!total.IsDefaultTotalCurrency)
+            {
+                return number.ToMoney(context.Source.Currency);
+            }
+
+            return (total.CartAggregate?.HasSelectedLineItems ?? false)
                 ? number.ToMoney(context.Source.Currency)
                 : new Money(0.0m, context.Source.Currency);
         }

--- a/src/VirtoCommerce.XCart.Core/Extensions/ResolveFieldContextExtensions.cs
+++ b/src/VirtoCommerce.XCart.Core/Extensions/ResolveFieldContextExtensions.cs
@@ -1,4 +1,6 @@
+using System.Linq;
 using GraphQL;
+using VirtoCommerce.CartModule.Core.Model;
 using VirtoCommerce.CoreModule.Core.Currency;
 using VirtoCommerce.Platform.Core.Common;
 using VirtoCommerce.Xapi.Core.Extensions;
@@ -19,6 +21,28 @@ namespace VirtoCommerce.XCart.Core.Extensions
         public static Currency CartCurrency(this IResolveFieldContext userContext)
         {
             return userContext.GetValueForSource<CartAggregate>().Currency;
+        }
+
+        /// <summary>
+        /// Returns the currency that matches the line item's <see cref="LineItem.Currency"/> code,
+        /// looked up in the cart's <see cref="CartAggregate.ItemCurrencies"/>.
+        /// Falls back to <see cref="CartAggregate.Currency"/> when no match is found.
+        /// </summary>
+        public static Currency GetLineItemCurrency(this IResolveFieldContext<LineItem> context)
+        {
+            var cart = context.GetCart();
+            return cart.ItemCurrencies?.FirstOrDefault(x => x.Code.EqualsIgnoreCase(context.Source.Currency)) ?? cart.Currency;
+        }
+
+        /// <summary>
+        /// Returns the currency that matches the cart total's <see cref="CartTotal.CurrencyCode"/>,
+        /// looked up in the cart's <see cref="CartAggregate.ItemCurrencies"/>.
+        /// Falls back to <see cref="CartAggregate.Currency"/> when no match is found.
+        /// </summary>
+        public static Currency GetCartTotalCurrency(this IResolveFieldContext<CartTotal> context, CartAggregate cartAggregate)
+        {
+            var cart = context.GetCart();
+            return cart.ItemCurrencies?.FirstOrDefault(x => x.Code.EqualsIgnoreCase(context.Source.CurrencyCode)) ?? cart.Currency;
         }
 
         public static Money GetTotal(this IResolveFieldContext<CartAggregate> context, decimal number)

--- a/src/VirtoCommerce.XCart.Core/Extensions/ResolveFieldContextExtensions.cs
+++ b/src/VirtoCommerce.XCart.Core/Extensions/ResolveFieldContextExtensions.cs
@@ -23,12 +23,43 @@ namespace VirtoCommerce.XCart.Core.Extensions
             return userContext.GetValueForSource<CartAggregate>().Currency;
         }
 
+        /// <summary>
+        /// Returns the currency that matches the line item's <see cref="LineItem.Currency"/> code,
+        /// looked up in the cart's <see cref="CartAggregate.AllCurrencies"/>.
+        /// Falls back to <see cref="CartAggregate.Currency"/> if LineItem.Currency is null or empty.
+        /// </summary>
+        public static Currency GetLineItemCurrency(this IResolveFieldContext<LineItem> context)
+        {
+            var cart = context.GetCart();
+            if (cart == null)
+            {
+                return null;
+            }
+
+            if (context.Source.Currency.IsNullOrEmpty())
+            {
+                return cart.Currency;
+            }
+
+            return cart.AllCurrencies?.FirstOrDefault(x => x.Code.EqualsIgnoreCase(context.Source.Currency));
+        }
+
         public static Currency GetConfiguratonItemCurrency(this IResolveFieldContext<ConfigurationItem> context)
         {
             var cart = context.GetCart();
             var lineItemId = context.Source.LineItemId;
-            var lineItem = cart?.Cart.Items.FirstOrDefault(x => x.Id == lineItemId);
-            return context.GetCurrencyByCode(lineItem?.Currency);
+            var lineItem = cart?.Cart?.Items?.FirstOrDefault(x => x.Id == lineItemId);
+            if (lineItem == null)
+            {
+                return null;
+            }
+
+            if (lineItem.Currency.IsNullOrEmpty())
+            {
+                return cart.Currency;
+            }
+
+            return cart.AllCurrencies?.FirstOrDefault(x => x.Code.EqualsIgnoreCase(lineItem.Currency));
         }
 
         public static Money GetTotal(this IResolveFieldContext<CartAggregate> context, decimal number)

--- a/src/VirtoCommerce.XCart.Core/Extensions/ResolveFieldContextExtensions.cs
+++ b/src/VirtoCommerce.XCart.Core/Extensions/ResolveFieldContextExtensions.cs
@@ -34,17 +34,6 @@ namespace VirtoCommerce.XCart.Core.Extensions
             return cart.ItemCurrencies?.FirstOrDefault(x => x.Code.EqualsIgnoreCase(context.Source.Currency)) ?? cart.Currency;
         }
 
-        /// <summary>
-        /// Returns the currency that matches the cart total's <see cref="CartTotal.CurrencyCode"/>,
-        /// looked up in the cart's <see cref="CartAggregate.ItemCurrencies"/>.
-        /// Falls back to <see cref="CartAggregate.Currency"/> when no match is found.
-        /// </summary>
-        public static Currency GetCartTotalCurrency(this IResolveFieldContext<CartTotal> context, CartAggregate cartAggregate)
-        {
-            var cart = context.GetCart();
-            return cart.ItemCurrencies?.FirstOrDefault(x => x.Code.EqualsIgnoreCase(context.Source.CurrencyCode)) ?? cart.Currency;
-        }
-
         public static Money GetTotal(this IResolveFieldContext<CartAggregate> context, decimal number)
         {
             return context.Source.HasSelectedLineItems

--- a/src/VirtoCommerce.XCart.Core/Extensions/RewardExtensions.cs
+++ b/src/VirtoCommerce.XCart.Core/Extensions/RewardExtensions.cs
@@ -198,7 +198,7 @@ namespace VirtoCommerce.XCart.Core.Extensions
                 payment.ApplyRewards(aggregate.Currency, paymentRewards);
             }
 
-            var subTotalExcludeDiscount = shoppingCart.Items.Where(li => li.SelectedForCheckout).Sum(li => (li.ListPrice - li.DiscountAmount) * li.Quantity);
+            var subTotalExcludeDiscount = aggregate.CartCurrencySelectedLineItems.Sum(li => (li.ListPrice - li.DiscountAmount) * li.Quantity);
 
             var cartRewards = rewards.OfType<CartSubtotalReward>();
             foreach (var reward in cartRewards.Where(reward => reward.IsValid))

--- a/src/VirtoCommerce.XCart.Core/Models/NewCartItem.cs
+++ b/src/VirtoCommerce.XCart.Core/Models/NewCartItem.cs
@@ -24,6 +24,11 @@ namespace VirtoCommerce.XCart.Core.Models
         public decimal? Price { get; set; }
 
         /// <summary>
+        /// Overrride currency (can be different from the base cart currency)
+        /// </summary>
+        public string CurrencyCode { get; set; }
+
+        /// <summary>
         /// Comment
         /// </summary>
         public string Comment { get; set; }

--- a/src/VirtoCommerce.XCart.Core/Models/NewCartItem.cs
+++ b/src/VirtoCommerce.XCart.Core/Models/NewCartItem.cs
@@ -26,7 +26,7 @@ namespace VirtoCommerce.XCart.Core.Models
         /// <summary>
         /// Override currency (can be different from the base cart currency)
         /// </summary>
-        public string CurrencyCode { get; set; }
+        public string ItemCurrencyCode { get; set; }
 
         /// <summary>
         /// Comment

--- a/src/VirtoCommerce.XCart.Core/Models/NewCartItem.cs
+++ b/src/VirtoCommerce.XCart.Core/Models/NewCartItem.cs
@@ -24,7 +24,7 @@ namespace VirtoCommerce.XCart.Core.Models
         public decimal? Price { get; set; }
 
         /// <summary>
-        /// Overrride currency (can be different from the base cart currency)
+        /// Override currency (can be different from the base cart currency)
         /// </summary>
         public string CurrencyCode { get; set; }
 

--- a/src/VirtoCommerce.XCart.Core/Schemas/CartConfigurationItemType.cs
+++ b/src/VirtoCommerce.XCart.Core/Schemas/CartConfigurationItemType.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Linq;
 using GraphQL.DataLoader;
 using GraphQL.Resolvers;
@@ -58,8 +57,7 @@ namespace VirtoCommerce.XCart.Core.Schemas
                     var cart = context.GetCart();
                     var lineItemId = context.Source.LineItemId;
                     var lineItem = cart.Cart?.Items.FirstOrDefault(x => x.Id == lineItemId);
-                    var currencyCode = lineItem?.Currency
-                        ?? throw new InvalidOperationException("Line item currency is required to load configuration item product.");
+                    var currencyCode = lineItem?.Currency;
                     return dataLoader.LoadCartProduct(context, mediator, currencyService, "cart_configurationItems_products", (currencyCode, context.Source.ProductId));
                 }),
             };

--- a/src/VirtoCommerce.XCart.Core/Schemas/CartConfigurationItemType.cs
+++ b/src/VirtoCommerce.XCart.Core/Schemas/CartConfigurationItemType.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using GraphQL.DataLoader;
 using GraphQL.Resolvers;
 using GraphQL.Types;
@@ -55,8 +56,10 @@ namespace VirtoCommerce.XCart.Core.Schemas
                 Resolver = new FuncFieldResolver<ConfigurationItem, IDataLoaderResult<ExpProduct>>(context =>
                 {
                     var cart = context.GetCart();
-                    var currencyCode = cart.Currency?.Code
-                        ?? throw new InvalidOperationException("Cart.Currency is required to load configuration item product. A cart without a currency is not supported.");
+                    var lineItemId = context.Source.LineItemId;
+                    var lineItem = cart.Cart?.Items.FirstOrDefault(x => x.Id == lineItemId);
+                    var currencyCode = lineItem?.Currency
+                        ?? throw new InvalidOperationException("Line item currency is required to load configuration item product.");
                     return dataLoader.LoadCartProduct(context, mediator, currencyService, "cart_configurationItems_products", (currencyCode, context.Source.ProductId));
                 }),
             };

--- a/src/VirtoCommerce.XCart.Core/Schemas/CartConfigurationItemType.cs
+++ b/src/VirtoCommerce.XCart.Core/Schemas/CartConfigurationItemType.cs
@@ -1,3 +1,4 @@
+using System;
 using GraphQL.DataLoader;
 using GraphQL.Resolvers;
 using GraphQL.Types;
@@ -52,7 +53,12 @@ namespace VirtoCommerce.XCart.Core.Schemas
                 Name = "product",
                 Type = GraphTypeExtensionHelper.GetActualType<ProductType>(),
                 Resolver = new FuncFieldResolver<ConfigurationItem, IDataLoaderResult<ExpProduct>>(context =>
-                    dataLoader.LoadCartProduct(context, mediator, currencyService, "cart_configurationItems_products", context.Source.ProductId)),
+                {
+                    var cart = context.GetCart();
+                    var currencyCode = cart.Currency?.Code
+                        ?? throw new InvalidOperationException("Cart.Currency is required to load configuration item product. A cart without a currency is not supported.");
+                    return dataLoader.LoadCartProduct(context, mediator, currencyService, "cart_configurationItems_products", (currencyCode, context.Source.ProductId));
+                }),
             };
             AddField(productField);
         }

--- a/src/VirtoCommerce.XCart.Core/Schemas/CartConfigurationItemType.cs
+++ b/src/VirtoCommerce.XCart.Core/Schemas/CartConfigurationItemType.cs
@@ -1,4 +1,3 @@
-using System.Linq;
 using GraphQL.DataLoader;
 using GraphQL.Resolvers;
 using GraphQL.Types;
@@ -34,15 +33,15 @@ namespace VirtoCommerce.XCart.Core.Schemas
 
             Field<NonNullGraphType<MoneyType>>("listPrice")
                 .Description("List price")
-                .Resolve(context => context.Source.ListPrice.ToMoney(context.GetCart().Currency));
+                .Resolve(context => context.Source.ListPrice.ToMoney(context.GetConfiguratonItemCurrency()));
 
             Field<NonNullGraphType<MoneyType>>("salePrice")
                 .Description("Sale price")
-                .Resolve(context => context.Source.SalePrice.ToMoney(context.GetCart().Currency));
+                .Resolve(context => context.Source.SalePrice.ToMoney(context.GetConfiguratonItemCurrency()));
 
             Field<NonNullGraphType<MoneyType>>("extendedPrice")
                 .Description("Extended price")
-                .Resolve(context => context.Source.ExtendedPrice.ToMoney(context.GetCart().Currency));
+                .Resolve(context => context.Source.ExtendedPrice.ToMoney(context.GetConfiguratonItemCurrency()));
 
             ExtendableField<ListGraphType<CartConfigurationItemFileType>>(nameof(ConfigurationItem.Files),
                 resolve: context => context.Source.Files,
@@ -54,11 +53,8 @@ namespace VirtoCommerce.XCart.Core.Schemas
                 Type = GraphTypeExtensionHelper.GetActualType<ProductType>(),
                 Resolver = new FuncFieldResolver<ConfigurationItem, IDataLoaderResult<ExpProduct>>(context =>
                 {
-                    var cart = context.GetCart();
-                    var lineItemId = context.Source.LineItemId;
-                    var lineItem = cart.Cart?.Items.FirstOrDefault(x => x.Id == lineItemId);
-                    var currencyCode = lineItem?.Currency;
-                    return dataLoader.LoadCartProduct(context, mediator, currencyService, "cart_configurationItems_products", (currencyCode, context.Source.ProductId));
+                    var currency = context.GetConfiguratonItemCurrency();
+                    return dataLoader.LoadCartProduct(context, mediator, currencyService, "cart_configurationItems_products", (CurrencyCode: currency?.Code, context.Source.ProductId));
                 }),
             };
             AddField(productField);

--- a/src/VirtoCommerce.XCart.Core/Schemas/CartTotalType.cs
+++ b/src/VirtoCommerce.XCart.Core/Schemas/CartTotalType.cs
@@ -1,6 +1,6 @@
 using GraphQL.Types;
-using VirtoCommerce.Xapi.Core.Extensions;
 using VirtoCommerce.Xapi.Core.Schemas;
+using VirtoCommerce.XCart.Core.Extensions;
 
 namespace VirtoCommerce.XCart.Core.Schemas
 {
@@ -12,19 +12,19 @@ namespace VirtoCommerce.XCart.Core.Schemas
 
             Field<NonNullGraphType<MoneyType>>("total")
                 .Description("Cart total")
-                .Resolve(context => context.Source.CartTotal.Total.ToMoney(context.Source.Currency));
+                .Resolve(context => context.GetTotal(context.Source.CartTotal.Total));
 
             Field<NonNullGraphType<MoneyType>>("subTotal")
                 .Description("Cart subtotal")
-                .Resolve(context => context.Source.CartTotal.SubTotal.ToMoney(context.Source.Currency));
+                .Resolve(context => context.GetTotal(context.Source.CartTotal.SubTotal));
 
             Field<NonNullGraphType<MoneyType>>("taxTotal")
                 .Description("Total tax")
-                .Resolve(context => context.Source.CartTotal.TaxTotal.ToMoney(context.Source.Currency));
+                .Resolve(context => context.GetTotal(context.Source.CartTotal.TaxTotal));
 
             Field<NonNullGraphType<MoneyType>>("discountTotal")
                 .Description("Total discount")
-                .Resolve(context => context.Source.CartTotal.DiscountTotal.ToMoney(context.Source.Currency));
+                .Resolve(context => context.GetTotal(context.Source.CartTotal.DiscountTotal));
         }
     }
 }

--- a/src/VirtoCommerce.XCart.Core/Schemas/CartTotalType.cs
+++ b/src/VirtoCommerce.XCart.Core/Schemas/CartTotalType.cs
@@ -1,0 +1,30 @@
+using GraphQL.Types;
+using VirtoCommerce.Xapi.Core.Extensions;
+using VirtoCommerce.Xapi.Core.Schemas;
+
+namespace VirtoCommerce.XCart.Core.Schemas
+{
+    public class CartTotalType : ExtendableGraphType<CartTotalAggregate>
+    {
+        public CartTotalType()
+        {
+            Field(x => x.IsDefaultTotalCurrency, nullable: false).Description("Is current total in default total currency");
+
+            Field<NonNullGraphType<MoneyType>>("total")
+                .Description("Cart total")
+                .Resolve(context => context.Source.CartTotal.Total.ToMoney(context.Source.Currency));
+
+            Field<NonNullGraphType<MoneyType>>("subTotal")
+                .Description("Cart subtotal")
+                .Resolve(context => context.Source.CartTotal.SubTotal.ToMoney(context.Source.Currency));
+
+            Field<NonNullGraphType<MoneyType>>("taxTotal")
+                .Description("Total tax")
+                .Resolve(context => context.Source.CartTotal.TaxTotal.ToMoney(context.Source.Currency));
+
+            Field<NonNullGraphType<MoneyType>>("discountTotal")
+                .Description("Total discount")
+                .Resolve(context => context.Source.CartTotal.DiscountTotal.ToMoney(context.Source.Currency));
+        }
+    }
+}

--- a/src/VirtoCommerce.XCart.Core/Schemas/CartType.cs
+++ b/src/VirtoCommerce.XCart.Core/Schemas/CartType.cs
@@ -218,6 +218,10 @@ namespace VirtoCommerce.XCart.Core.Schemas
             Field<NonNullGraphType<ListGraphType<NonNullGraphType<ValidationErrorType>>>>("warnings")
                 .Description("A set of temporary warnings for a cart user")
                 .Resolve(context => context.Source.ValidationWarnings);
+
+            ExtendableField<ListGraphType<CartTotalType>>("cartTotals",
+                "Cart totals",
+                resolve: context => context.Source.CartTotals);
         }
     }
 }

--- a/src/VirtoCommerce.XCart.Core/Schemas/CartType.cs
+++ b/src/VirtoCommerce.XCart.Core/Schemas/CartType.cs
@@ -55,10 +55,10 @@ namespace VirtoCommerce.XCart.Core.Schemas
                 .Resolve(context => context.GetTotal(context.Source.Cart.SubTotalWithTax));
             Field<NonNullGraphType<MoneyType>>("extendedPriceTotal")
                 .Description("Total extended price")
-                .Resolve(context => context.Source.SelectedLineItems.Sum(i => i.ExtendedPrice).ToMoney(context.Source.Currency));
+                .Resolve(context => context.Source.CartCurrencySelectedLineItems.Sum(i => i.ExtendedPrice).ToMoney(context.Source.Currency));
             Field<NonNullGraphType<MoneyType>>("extendedPriceTotalWithTax")
                 .Description("Total extended price with tax")
-                .Resolve(context => context.Source.SelectedLineItems.Sum(i => i.ExtendedPriceWithTax).ToMoney(context.Source.Currency));
+                .Resolve(context => context.Source.CartCurrencySelectedLineItems.Sum(i => i.ExtendedPriceWithTax).ToMoney(context.Source.Currency));
             Field<NonNullGraphType<CurrencyType>>("currency")
                 .Description("Currency")
                 .Resolve(context => context.Source.Currency);

--- a/src/VirtoCommerce.XCart.Core/Schemas/InputAddItemType.cs
+++ b/src/VirtoCommerce.XCart.Core/Schemas/InputAddItemType.cs
@@ -10,7 +10,7 @@ namespace VirtoCommerce.XCart.Core.Schemas
             Field<NonNullGraphType<StringGraphType>>("productId").Description("Product ID");
             Field<NonNullGraphType<IntGraphType>>("quantity").Description("Quantity");
             Field<DecimalGraphType>("price").Description("Price");
-            Field<StringGraphType>("itemCurrencyCode").Description("Item currency");
+            Field<StringGraphType>("itemCurrencyCode").Description("Add the product in a different currency");
             Field<StringGraphType>("comment").Description("Comment");
 
             Field<ListGraphType<InputDynamicPropertyValueType>>("dynamicProperties");

--- a/src/VirtoCommerce.XCart.Core/Schemas/InputAddItemType.cs
+++ b/src/VirtoCommerce.XCart.Core/Schemas/InputAddItemType.cs
@@ -10,6 +10,7 @@ namespace VirtoCommerce.XCart.Core.Schemas
             Field<NonNullGraphType<StringGraphType>>("productId").Description("Product ID");
             Field<NonNullGraphType<IntGraphType>>("quantity").Description("Quantity");
             Field<DecimalGraphType>("price").Description("Price");
+            Field<StringGraphType>("itemCurrencyCode").Description("Item currency");
             Field<StringGraphType>("comment").Description("Comment");
 
             Field<ListGraphType<InputDynamicPropertyValueType>>("dynamicProperties");

--- a/src/VirtoCommerce.XCart.Core/Schemas/InputNewCartItemType.cs
+++ b/src/VirtoCommerce.XCart.Core/Schemas/InputNewCartItemType.cs
@@ -12,8 +12,8 @@ namespace VirtoCommerce.XCart.Core.Schemas
             Field(x => x.Quantity, nullable: true).Description("Product quantity");
             Field<DecimalGraphType>("price").Description("Price");
             Field<StringGraphType>("comment").Description("Comment");
-            Field<DateTimeGraphType>("createdDate")
-                .Description("Line item created date override");
+            Field<DateTimeGraphType>("createdDate").Description("Line item created date override");
+            Field<StringGraphType>("currencyCode").Description("Add cart item in a different currency");
 
             Field<ListGraphType<InputDynamicPropertyValueType>>("dynamicProperties");
 

--- a/src/VirtoCommerce.XCart.Core/Schemas/InputNewCartItemType.cs
+++ b/src/VirtoCommerce.XCart.Core/Schemas/InputNewCartItemType.cs
@@ -13,7 +13,7 @@ namespace VirtoCommerce.XCart.Core.Schemas
             Field<DecimalGraphType>("price").Description("Price");
             Field<StringGraphType>("comment").Description("Comment");
             Field<DateTimeGraphType>("createdDate").Description("Line item created date override");
-            Field<StringGraphType>("currencyCode").Description("Add cart item in a different currency");
+            Field<StringGraphType>("itemCurrencyCode").Description("Add the product in a different currency");
 
             Field<ListGraphType<InputDynamicPropertyValueType>>("dynamicProperties");
 

--- a/src/VirtoCommerce.XCart.Core/Schemas/InputUpdateCartQuantityItemType.cs
+++ b/src/VirtoCommerce.XCart.Core/Schemas/InputUpdateCartQuantityItemType.cs
@@ -11,7 +11,7 @@ namespace VirtoCommerce.XCart.Core.Schemas
 
             Field<NonNullGraphType<StringGraphType>>("productId").Description("Product ID");
             Field<NonNullGraphType<IntGraphType>>("quantity").Description("Quantity");
-            Field<StringGraphType>("currencyCode").Description("To add the product in a different currency");
+            Field<StringGraphType>("itemCurrencyCode").Description("Add the product in a different currency");
         }
     }
 }

--- a/src/VirtoCommerce.XCart.Core/Schemas/InputUpdateCartQuantityItemType.cs
+++ b/src/VirtoCommerce.XCart.Core/Schemas/InputUpdateCartQuantityItemType.cs
@@ -1,4 +1,4 @@
-﻿using GraphQL.Types;
+using GraphQL.Types;
 using VirtoCommerce.XCart.Core.Commands;
 
 namespace VirtoCommerce.XCart.Core.Schemas
@@ -11,6 +11,7 @@ namespace VirtoCommerce.XCart.Core.Schemas
 
             Field<NonNullGraphType<StringGraphType>>("productId").Description("Product ID");
             Field<NonNullGraphType<IntGraphType>>("quantity").Description("Quantity");
+            Field<StringGraphType>("currencyCode").Description("To add the product in a different currency");
         }
     }
 }

--- a/src/VirtoCommerce.XCart.Core/Schemas/LineItemType.cs
+++ b/src/VirtoCommerce.XCart.Core/Schemas/LineItemType.cs
@@ -38,10 +38,18 @@ namespace VirtoCommerce.XCart.Core.Schemas
 
             Field<NonNullGraphType<IntGraphType>>("inStockQuantity")
                 .Description("In stock quantity")
-                .Resolve(context => context.GetCart().CartProducts[context.Source.ProductId]?.AvailableQuantity ?? 0);
+                .Resolve(context =>
+                {
+                    var cart = context.GetCart();
+                    return cart.CartProducts[cart.GetCartProductKey(context.Source)]?.AvailableQuantity ?? 0;
+                });
             Field<StringGraphType>("warehouseLocation")
                 .Description("Warehouse location")
-                .Resolve(context => context.GetCart().CartProducts[context.Source.ProductId]?.Inventory?.FulfillmentCenter?.Address?.ToString());
+                .Resolve(context =>
+                {
+                    var cart = context.GetCart();
+                    return cart.CartProducts[cart.GetCartProductKey(context.Source)]?.Inventory?.FulfillmentCenter?.Address?.ToString();
+                });
 
             Field<NonNullGraphType<BooleanGraphType>>("IsValid")
                 .Description("Shows whether this is valid")
@@ -90,52 +98,52 @@ namespace VirtoCommerce.XCart.Core.Schemas
                 .Resolve(context => context.Source.TaxDetails ?? []);
             Field<NonNullGraphType<MoneyType>>("discountAmount")
                 .Description("Discount amount")
-                .Resolve(context => context.Source.DiscountAmount.ToMoney(context.GetCart().Currency));
+                .Resolve(context => context.Source.DiscountAmount.ToMoney(context.GetLineItemCurrency()));
             Field<NonNullGraphType<MoneyType>>("discountAmountWithTax")
                 .Description("Discount amount with tax")
-                .Resolve(context => context.Source.DiscountAmountWithTax.ToMoney(context.GetCart().Currency));
+                .Resolve(context => context.Source.DiscountAmountWithTax.ToMoney(context.GetLineItemCurrency()));
             Field<NonNullGraphType<MoneyType>>("discountTotal")
                 .Description("Total discount")
-                .Resolve(context => context.Source.DiscountTotal.ToMoney(context.GetCart().Currency));
+                .Resolve(context => context.Source.DiscountTotal.ToMoney(context.GetLineItemCurrency()));
             Field<NonNullGraphType<MoneyType>>("discountTotalWithTax")
                 .Description("Total discount with tax")
-                .Resolve(context => context.Source.DiscountTotalWithTax.ToMoney(context.GetCart().Currency));
+                .Resolve(context => context.Source.DiscountTotalWithTax.ToMoney(context.GetLineItemCurrency()));
             Field<NonNullGraphType<MoneyType>>("extendedPrice")
                 .Description("Extended price")
-                .Resolve(context => context.Source.ExtendedPrice.ToMoney(context.GetCart().Currency));
+                .Resolve(context => context.Source.ExtendedPrice.ToMoney(context.GetLineItemCurrency()));
             Field<NonNullGraphType<MoneyType>>("extendedPriceWithTax")
                 .Description("Extended price with tax")
-                .Resolve(context => context.Source.ExtendedPriceWithTax.ToMoney(context.GetCart().Currency));
+                .Resolve(context => context.Source.ExtendedPriceWithTax.ToMoney(context.GetLineItemCurrency()));
             Field<NonNullGraphType<MoneyType>>("listPrice")
                 .Description("List price")
-                .Resolve(context => context.Source.ListPrice.ToMoney(context.GetCart().Currency));
+                .Resolve(context => context.Source.ListPrice.ToMoney(context.GetLineItemCurrency()));
             Field<NonNullGraphType<MoneyType>>("listPriceWithTax")
                 .Description("List price with tax")
-                .Resolve(context => context.Source.ListPriceWithTax.ToMoney(context.GetCart().Currency));
+                .Resolve(context => context.Source.ListPriceWithTax.ToMoney(context.GetLineItemCurrency()));
             Field<NonNullGraphType<MoneyType>>("listTotal")
                 .Description("List total")
-                .Resolve(context => context.Source.ListTotal.ToMoney(context.GetCart().Currency));
+                .Resolve(context => context.Source.ListTotal.ToMoney(context.GetLineItemCurrency()));
             Field<NonNullGraphType<MoneyType>>("listTotalWithTax")
                 .Description("List total with tax")
-                .Resolve(context => context.Source.ListTotalWithTax.ToMoney(context.GetCart().Currency));
+                .Resolve(context => context.Source.ListTotalWithTax.ToMoney(context.GetLineItemCurrency()));
             Field<NonNullGraphType<BooleanGraphType>>("showPlacedPrice")
                 .Description("Indicates whether the PlacedPrice should be visible to the customer")
                 .Resolve(context => context.Source.IsDiscountAmountRounded);
             Field<NonNullGraphType<MoneyType>>("placedPrice")
                 .Description("Placed price")
-                .Resolve(context => context.Source.PlacedPrice.ToMoney(context.GetCart().Currency));
+                .Resolve(context => context.Source.PlacedPrice.ToMoney(context.GetLineItemCurrency()));
             Field<NonNullGraphType<MoneyType>>("placedPriceWithTax")
                 .Description("Placed price with tax")
-                .Resolve(context => context.Source.PlacedPriceWithTax.ToMoney(context.GetCart().Currency));
+                .Resolve(context => context.Source.PlacedPriceWithTax.ToMoney(context.GetLineItemCurrency()));
             Field<NonNullGraphType<MoneyType>>("salePrice")
                 .Description("Sale price")
-                .Resolve(context => context.Source.SalePrice.ToMoney(context.GetCart().Currency));
+                .Resolve(context => context.Source.SalePrice.ToMoney(context.GetLineItemCurrency()));
             Field<NonNullGraphType<MoneyType>>("salePriceWithTax")
                 .Description("Sale price with tax")
-                .Resolve(context => context.Source.SalePriceWithTax.ToMoney(context.GetCart().Currency));
+                .Resolve(context => context.Source.SalePriceWithTax.ToMoney(context.GetLineItemCurrency()));
             Field<NonNullGraphType<MoneyType>>("taxTotal")
                 .Description("Tax total")
-                .Resolve(context => context.Source.TaxTotal.ToMoney(context.GetCart().Currency));
+                .Resolve(context => context.Source.TaxTotal.ToMoney(context.GetLineItemCurrency()));
 
             ExtendableFieldAsync<ListGraphType<DynamicPropertyValueType>>(
                 "dynamicProperties",

--- a/src/VirtoCommerce.XCart.Core/Schemas/LineItemType.cs
+++ b/src/VirtoCommerce.XCart.Core/Schemas/LineItemType.cs
@@ -32,7 +32,7 @@ namespace VirtoCommerce.XCart.Core.Schemas
                 Name = "product",
                 Type = GraphTypeExtensionHelper.GetActualType<ProductType>(),
                 Resolver = new FuncFieldResolver<LineItem, IDataLoaderResult<ExpProduct>>(context =>
-                    dataLoader.LoadCartProduct(context, mediator, currencyService, "cart_lineItems_products", context.Source.ProductId)),
+                    dataLoader.LoadCartProduct(context, mediator, currencyService, "cart_lineItems_products", (CurrencyCode: context.Source.Currency, context.Source.ProductId))),
             };
             AddField(productField);
 

--- a/src/VirtoCommerce.XCart.Core/Schemas/LineItemType.cs
+++ b/src/VirtoCommerce.XCart.Core/Schemas/LineItemType.cs
@@ -90,6 +90,9 @@ namespace VirtoCommerce.XCart.Core.Schemas
             Field(x => x.Width, nullable: true).Description("Width value");
             Field(x => x.FulfillmentCenterId, nullable: true).Description("Line item fulfillment center ID value");
             Field(x => x.FulfillmentCenterName, nullable: true).Description("Line item fulfillment center name value");
+            Field<StringGraphType>("currencyCode")
+                .Description("Line item currency code")
+                .Resolve(context => context.Source.Currency);
             Field<NonNullGraphType<ListGraphType<NonNullGraphType<DiscountType>>>>("discounts")
                 .Description("Discounts")
                 .Resolve(context => context.Source.Discounts ?? []);

--- a/src/VirtoCommerce.XCart.Core/Schemas/LineItemType.cs
+++ b/src/VirtoCommerce.XCart.Core/Schemas/LineItemType.cs
@@ -101,52 +101,52 @@ namespace VirtoCommerce.XCart.Core.Schemas
                 .Resolve(context => context.Source.TaxDetails ?? []);
             Field<NonNullGraphType<MoneyType>>("discountAmount")
                 .Description("Discount amount")
-                .Resolve(context => context.Source.DiscountAmount.ToMoney(context.GetCurrencyByCode(context.Source.Currency)));
+                .Resolve(context => context.Source.DiscountAmount.ToMoney(context.GetLineItemCurrency()));
             Field<NonNullGraphType<MoneyType>>("discountAmountWithTax")
                 .Description("Discount amount with tax")
-                .Resolve(context => context.Source.DiscountAmountWithTax.ToMoney(context.GetCurrencyByCode(context.Source.Currency)));
+                .Resolve(context => context.Source.DiscountAmountWithTax.ToMoney(context.GetLineItemCurrency()));
             Field<NonNullGraphType<MoneyType>>("discountTotal")
                 .Description("Total discount")
-                .Resolve(context => context.Source.DiscountTotal.ToMoney(context.GetCurrencyByCode(context.Source.Currency)));
+                .Resolve(context => context.Source.DiscountTotal.ToMoney(context.GetLineItemCurrency()));
             Field<NonNullGraphType<MoneyType>>("discountTotalWithTax")
                 .Description("Total discount with tax")
-                .Resolve(context => context.Source.DiscountTotalWithTax.ToMoney(context.GetCurrencyByCode(context.Source.Currency)));
+                .Resolve(context => context.Source.DiscountTotalWithTax.ToMoney(context.GetLineItemCurrency()));
             Field<NonNullGraphType<MoneyType>>("extendedPrice")
                 .Description("Extended price")
-                .Resolve(context => context.Source.ExtendedPrice.ToMoney(context.GetCurrencyByCode(context.Source.Currency)));
+                .Resolve(context => context.Source.ExtendedPrice.ToMoney(context.GetLineItemCurrency()));
             Field<NonNullGraphType<MoneyType>>("extendedPriceWithTax")
                 .Description("Extended price with tax")
-                .Resolve(context => context.Source.ExtendedPriceWithTax.ToMoney(context.GetCurrencyByCode(context.Source.Currency)));
+                .Resolve(context => context.Source.ExtendedPriceWithTax.ToMoney(context.GetLineItemCurrency()));
             Field<NonNullGraphType<MoneyType>>("listPrice")
                 .Description("List price")
-                .Resolve(context => context.Source.ListPrice.ToMoney(context.GetCurrencyByCode(context.Source.Currency)));
+                .Resolve(context => context.Source.ListPrice.ToMoney(context.GetLineItemCurrency()));
             Field<NonNullGraphType<MoneyType>>("listPriceWithTax")
                 .Description("List price with tax")
-                .Resolve(context => context.Source.ListPriceWithTax.ToMoney(context.GetCurrencyByCode(context.Source.Currency)));
+                .Resolve(context => context.Source.ListPriceWithTax.ToMoney(context.GetLineItemCurrency()));
             Field<NonNullGraphType<MoneyType>>("listTotal")
                 .Description("List total")
-                .Resolve(context => context.Source.ListTotal.ToMoney(context.GetCurrencyByCode(context.Source.Currency)));
+                .Resolve(context => context.Source.ListTotal.ToMoney(context.GetLineItemCurrency()));
             Field<NonNullGraphType<MoneyType>>("listTotalWithTax")
                 .Description("List total with tax")
-                .Resolve(context => context.Source.ListTotalWithTax.ToMoney(context.GetCurrencyByCode(context.Source.Currency)));
+                .Resolve(context => context.Source.ListTotalWithTax.ToMoney(context.GetLineItemCurrency()));
             Field<NonNullGraphType<BooleanGraphType>>("showPlacedPrice")
                 .Description("Indicates whether the PlacedPrice should be visible to the customer")
                 .Resolve(context => context.Source.IsDiscountAmountRounded);
             Field<NonNullGraphType<MoneyType>>("placedPrice")
                 .Description("Placed price")
-                .Resolve(context => context.Source.PlacedPrice.ToMoney(context.GetCurrencyByCode(context.Source.Currency)));
+                .Resolve(context => context.Source.PlacedPrice.ToMoney(context.GetLineItemCurrency()));
             Field<NonNullGraphType<MoneyType>>("placedPriceWithTax")
                 .Description("Placed price with tax")
-                .Resolve(context => context.Source.PlacedPriceWithTax.ToMoney(context.GetCurrencyByCode(context.Source.Currency)));
+                .Resolve(context => context.Source.PlacedPriceWithTax.ToMoney(context.GetLineItemCurrency()));
             Field<NonNullGraphType<MoneyType>>("salePrice")
                 .Description("Sale price")
-                .Resolve(context => context.Source.SalePrice.ToMoney(context.GetCurrencyByCode(context.Source.Currency)));
+                .Resolve(context => context.Source.SalePrice.ToMoney(context.GetLineItemCurrency()));
             Field<NonNullGraphType<MoneyType>>("salePriceWithTax")
                 .Description("Sale price with tax")
-                .Resolve(context => context.Source.SalePriceWithTax.ToMoney(context.GetCurrencyByCode(context.Source.Currency)));
+                .Resolve(context => context.Source.SalePriceWithTax.ToMoney(context.GetLineItemCurrency()));
             Field<NonNullGraphType<MoneyType>>("taxTotal")
                 .Description("Tax total")
-                .Resolve(context => context.Source.TaxTotal.ToMoney(context.GetCurrencyByCode(context.Source.Currency)));
+                .Resolve(context => context.Source.TaxTotal.ToMoney(context.GetLineItemCurrency()));
 
             ExtendableFieldAsync<ListGraphType<DynamicPropertyValueType>>(
                 "dynamicProperties",

--- a/src/VirtoCommerce.XCart.Core/Schemas/LineItemType.cs
+++ b/src/VirtoCommerce.XCart.Core/Schemas/LineItemType.cs
@@ -101,52 +101,52 @@ namespace VirtoCommerce.XCart.Core.Schemas
                 .Resolve(context => context.Source.TaxDetails ?? []);
             Field<NonNullGraphType<MoneyType>>("discountAmount")
                 .Description("Discount amount")
-                .Resolve(context => context.Source.DiscountAmount.ToMoney(context.GetLineItemCurrency()));
+                .Resolve(context => context.Source.DiscountAmount.ToMoney(context.GetCurrencyByCode(context.Source.Currency)));
             Field<NonNullGraphType<MoneyType>>("discountAmountWithTax")
                 .Description("Discount amount with tax")
-                .Resolve(context => context.Source.DiscountAmountWithTax.ToMoney(context.GetLineItemCurrency()));
+                .Resolve(context => context.Source.DiscountAmountWithTax.ToMoney(context.GetCurrencyByCode(context.Source.Currency)));
             Field<NonNullGraphType<MoneyType>>("discountTotal")
                 .Description("Total discount")
-                .Resolve(context => context.Source.DiscountTotal.ToMoney(context.GetLineItemCurrency()));
+                .Resolve(context => context.Source.DiscountTotal.ToMoney(context.GetCurrencyByCode(context.Source.Currency)));
             Field<NonNullGraphType<MoneyType>>("discountTotalWithTax")
                 .Description("Total discount with tax")
-                .Resolve(context => context.Source.DiscountTotalWithTax.ToMoney(context.GetLineItemCurrency()));
+                .Resolve(context => context.Source.DiscountTotalWithTax.ToMoney(context.GetCurrencyByCode(context.Source.Currency)));
             Field<NonNullGraphType<MoneyType>>("extendedPrice")
                 .Description("Extended price")
-                .Resolve(context => context.Source.ExtendedPrice.ToMoney(context.GetLineItemCurrency()));
+                .Resolve(context => context.Source.ExtendedPrice.ToMoney(context.GetCurrencyByCode(context.Source.Currency)));
             Field<NonNullGraphType<MoneyType>>("extendedPriceWithTax")
                 .Description("Extended price with tax")
-                .Resolve(context => context.Source.ExtendedPriceWithTax.ToMoney(context.GetLineItemCurrency()));
+                .Resolve(context => context.Source.ExtendedPriceWithTax.ToMoney(context.GetCurrencyByCode(context.Source.Currency)));
             Field<NonNullGraphType<MoneyType>>("listPrice")
                 .Description("List price")
-                .Resolve(context => context.Source.ListPrice.ToMoney(context.GetLineItemCurrency()));
+                .Resolve(context => context.Source.ListPrice.ToMoney(context.GetCurrencyByCode(context.Source.Currency)));
             Field<NonNullGraphType<MoneyType>>("listPriceWithTax")
                 .Description("List price with tax")
-                .Resolve(context => context.Source.ListPriceWithTax.ToMoney(context.GetLineItemCurrency()));
+                .Resolve(context => context.Source.ListPriceWithTax.ToMoney(context.GetCurrencyByCode(context.Source.Currency)));
             Field<NonNullGraphType<MoneyType>>("listTotal")
                 .Description("List total")
-                .Resolve(context => context.Source.ListTotal.ToMoney(context.GetLineItemCurrency()));
+                .Resolve(context => context.Source.ListTotal.ToMoney(context.GetCurrencyByCode(context.Source.Currency)));
             Field<NonNullGraphType<MoneyType>>("listTotalWithTax")
                 .Description("List total with tax")
-                .Resolve(context => context.Source.ListTotalWithTax.ToMoney(context.GetLineItemCurrency()));
+                .Resolve(context => context.Source.ListTotalWithTax.ToMoney(context.GetCurrencyByCode(context.Source.Currency)));
             Field<NonNullGraphType<BooleanGraphType>>("showPlacedPrice")
                 .Description("Indicates whether the PlacedPrice should be visible to the customer")
                 .Resolve(context => context.Source.IsDiscountAmountRounded);
             Field<NonNullGraphType<MoneyType>>("placedPrice")
                 .Description("Placed price")
-                .Resolve(context => context.Source.PlacedPrice.ToMoney(context.GetLineItemCurrency()));
+                .Resolve(context => context.Source.PlacedPrice.ToMoney(context.GetCurrencyByCode(context.Source.Currency)));
             Field<NonNullGraphType<MoneyType>>("placedPriceWithTax")
                 .Description("Placed price with tax")
-                .Resolve(context => context.Source.PlacedPriceWithTax.ToMoney(context.GetLineItemCurrency()));
+                .Resolve(context => context.Source.PlacedPriceWithTax.ToMoney(context.GetCurrencyByCode(context.Source.Currency)));
             Field<NonNullGraphType<MoneyType>>("salePrice")
                 .Description("Sale price")
-                .Resolve(context => context.Source.SalePrice.ToMoney(context.GetLineItemCurrency()));
+                .Resolve(context => context.Source.SalePrice.ToMoney(context.GetCurrencyByCode(context.Source.Currency)));
             Field<NonNullGraphType<MoneyType>>("salePriceWithTax")
                 .Description("Sale price with tax")
-                .Resolve(context => context.Source.SalePriceWithTax.ToMoney(context.GetLineItemCurrency()));
+                .Resolve(context => context.Source.SalePriceWithTax.ToMoney(context.GetCurrencyByCode(context.Source.Currency)));
             Field<NonNullGraphType<MoneyType>>("taxTotal")
                 .Description("Tax total")
-                .Resolve(context => context.Source.TaxTotal.ToMoney(context.GetLineItemCurrency()));
+                .Resolve(context => context.Source.TaxTotal.ToMoney(context.GetCurrencyByCode(context.Source.Currency)));
 
             ExtendableFieldAsync<ListGraphType<DynamicPropertyValueType>>(
                 "dynamicProperties",

--- a/src/VirtoCommerce.XCart.Core/Services/ICartProductService.cs
+++ b/src/VirtoCommerce.XCart.Core/Services/ICartProductService.cs
@@ -13,5 +13,17 @@ namespace VirtoCommerce.XCart.Core.Services
         /// <param name="ids">Product ids</param>
         /// <returns>List of <see cref="CartProduct"/></returns>
         Task<IList<CartProduct>> GetCartProductsByIdsAsync(CartAggregate aggregate, IList<string> ids);
+
+        /// <summary>
+        /// Load products with their inventory data and prices for the given currency/product pairs.
+        /// Supports the same product in several currencies — each pair yields a distinct <see cref="CartProduct"/>
+        /// loaded for its currency.
+        /// </summary>
+        /// <param name="aggregate">Cart data to use</param>
+        /// <param name="currencyProductIdPairs">Pairs of (currencyCode, productId). An empty currencyCode falls back to the cart's currency.</param>
+        /// <returns>
+        /// Products keyed by <see cref="CartAggregate.GetCartProductKey(string, string)"/> ("{productId}:{CURRENCYCODE}").
+        /// </returns>
+        Task<IDictionary<string, CartProduct>> GetCartProductsAsync(CartAggregate aggregate, IList<(string CurrencyCode, string ProductId)> currencyProductIdPairs);
     }
 }

--- a/src/VirtoCommerce.XCart.Core/Services/ICartProductService.cs
+++ b/src/VirtoCommerce.XCart.Core/Services/ICartProductService.cs
@@ -22,7 +22,7 @@ namespace VirtoCommerce.XCart.Core.Services
         /// <param name="aggregate">Cart data to use</param>
         /// <param name="currencyProductIdPairs">Pairs of (currencyCode, productId). An empty currencyCode falls back to the cart's currency.</param>
         /// <returns>
-        /// Products keyed by <see cref="CartAggregate.GetCartProductKey(string, string)"/> ("{productId}:{CURRENCYCODE}").
+        /// Products keyed by <see cref="CartAggregate.FormatGetCartProductKey(string, string)"/> ("{productId}:{CURRENCYCODE}").
         /// </returns>
         Task<IDictionary<string, CartProduct>> GetCartProductsAsync(CartAggregate aggregate, IList<(string CurrencyCode, string ProductId)> currencyProductIdPairs);
     }

--- a/src/VirtoCommerce.XCart.Core/Validators/CartLineItemPriceChangedValidationContext.cs
+++ b/src/VirtoCommerce.XCart.Core/Validators/CartLineItemPriceChangedValidationContext.cs
@@ -7,6 +7,7 @@ namespace VirtoCommerce.XCart.Core.Validators
     public class CartLineItemPriceChangedValidationContext
     {
         public LineItem LineItem { get; set; }
+        public CartAggregate CartAggregate { get; set; }
         public IDictionary<string, CartProduct> CartProducts { get; set; } = new Dictionary<string, CartProduct>();
     }
 }

--- a/src/VirtoCommerce.XCart.Core/Validators/CartLineItemPriceChangedValidator.cs
+++ b/src/VirtoCommerce.XCart.Core/Validators/CartLineItemPriceChangedValidator.cs
@@ -14,7 +14,11 @@ namespace VirtoCommerce.XCart.Core.Validators
             {
                 var lineItem = lineItemContext.LineItem;
 
-                if (lineItemContext.CartProducts.TryGetValue(CartAggregate.GetCartProductKey(lineItem.ProductId, lineItem.Currency), out var cartProduct) &&
+                var productPairKey = lineItemContext.CartAggregate != null ?
+                    lineItemContext.CartAggregate.GetCartProductKey(lineItem) :
+                    CartAggregate.GetCartProductKey(lineItem.ProductId, lineItem.Currency);
+
+                if (lineItemContext.CartProducts.TryGetValue(productPairKey, out var cartProduct) &&
                     cartProduct?.Price != null)
                 {
                     var tierPrice = cartProduct.Price.GetTierPrice(lineItem.Quantity);

--- a/src/VirtoCommerce.XCart.Core/Validators/CartLineItemPriceChangedValidator.cs
+++ b/src/VirtoCommerce.XCart.Core/Validators/CartLineItemPriceChangedValidator.cs
@@ -14,7 +14,7 @@ namespace VirtoCommerce.XCart.Core.Validators
             {
                 var lineItem = lineItemContext.LineItem;
 
-                if (lineItemContext.CartProducts.TryGetValue(lineItem.ProductId, out var cartProduct) &&
+                if (lineItemContext.CartProducts.TryGetValue(CartAggregate.GetCartProductKey(lineItem.ProductId, lineItem.Currency), out var cartProduct) &&
                     cartProduct?.Price != null)
                 {
                     var tierPrice = cartProduct.Price.GetTierPrice(lineItem.Quantity);

--- a/src/VirtoCommerce.XCart.Core/Validators/CartLineItemPriceChangedValidator.cs
+++ b/src/VirtoCommerce.XCart.Core/Validators/CartLineItemPriceChangedValidator.cs
@@ -16,7 +16,7 @@ namespace VirtoCommerce.XCart.Core.Validators
 
                 var productPairKey = lineItemContext.CartAggregate != null ?
                     lineItemContext.CartAggregate.GetCartProductKey(lineItem) :
-                    CartAggregate.GetCartProductKey(lineItem.ProductId, lineItem.Currency);
+                    CartAggregate.FormatGetCartProductKey(lineItem.ProductId, lineItem.Currency);
 
                 if (lineItemContext.CartProducts.TryGetValue(productPairKey, out var cartProduct) &&
                     cartProduct?.Price != null)

--- a/src/VirtoCommerce.XCart.Core/Validators/CartLineItemValidator.cs
+++ b/src/VirtoCommerce.XCart.Core/Validators/CartLineItemValidator.cs
@@ -16,9 +16,7 @@ namespace VirtoCommerce.XCart.Core.Validators
             {
                 var lineItem = lineItemContext.LineItem;
                 var allCartProducts = lineItemContext.AllCartProducts;
-                // The same product may appear in several currencies, so match by currency first and fall back to id-only.
-                var cartProduct = allCartProducts.FirstOrDefault(x => x.Id.EqualsIgnoreCase(lineItem.ProductId) && x.Price?.Currency?.Code.EqualsIgnoreCase(lineItem.Currency) == true)
-                    ?? allCartProducts.FirstOrDefault(x => x.Id.EqualsIgnoreCase(lineItem.ProductId));
+                var cartProduct = GetCartProduct(lineItem, allCartProducts);
 
                 var minQuantity = cartProduct?.GetMinQuantity();
 
@@ -47,6 +45,13 @@ namespace VirtoCommerce.XCart.Core.Validators
                     ValidateMinMaxQuantity(context, lineItem, cartProduct);
                 }
             });
+        }
+
+        private static CartProduct GetCartProduct(LineItem lineItem, System.Collections.Generic.IEnumerable<CartProduct> allCartProducts)
+        {
+            // The same product may appear in several currencies, so match by currency first and fall back to id-only.
+            return allCartProducts.FirstOrDefault(x => x.Id.EqualsIgnoreCase(lineItem.ProductId) && x.Price?.Currency?.Code.EqualsIgnoreCase(lineItem.Currency) == true)
+                ?? allCartProducts.FirstOrDefault(x => x.Id.EqualsIgnoreCase(lineItem.ProductId));
         }
 
         private void ValidateMinMaxQuantity(ValidationContext<LineItemValidationContext> context, LineItem lineItem, CartProduct cartProduct)

--- a/src/VirtoCommerce.XCart.Core/Validators/CartLineItemValidator.cs
+++ b/src/VirtoCommerce.XCart.Core/Validators/CartLineItemValidator.cs
@@ -16,7 +16,9 @@ namespace VirtoCommerce.XCart.Core.Validators
             {
                 var lineItem = lineItemContext.LineItem;
                 var allCartProducts = lineItemContext.AllCartProducts;
-                var cartProduct = allCartProducts.FirstOrDefault(x => x.Id.EqualsIgnoreCase(lineItem.ProductId));
+                // The same product may appear in several currencies, so match by currency first and fall back to id-only.
+                var cartProduct = allCartProducts.FirstOrDefault(x => x.Id.EqualsIgnoreCase(lineItem.ProductId) && x.Price?.Currency?.Code.EqualsIgnoreCase(lineItem.Currency) == true)
+                    ?? allCartProducts.FirstOrDefault(x => x.Id.EqualsIgnoreCase(lineItem.ProductId));
 
                 var minQuantity = cartProduct?.GetMinQuantity();
 

--- a/src/VirtoCommerce.XCart.Core/Validators/CartValidationContextFactory.cs
+++ b/src/VirtoCommerce.XCart.Core/Validators/CartValidationContextFactory.cs
@@ -30,13 +30,13 @@ namespace VirtoCommerce.XCart.Core.Validators
         {
             var availPaymentsTask = _availMethods.GetAvailablePaymentMethodsAsync(cartAggregate);
             var availShippingRatesTask = _availMethods.GetAvailableShippingRatesAsync(cartAggregate);
-            var cartProductsTask = _cartProducts.GetCartProductsByIdsAsync(cartAggregate, cartAggregate.Cart.Items.Select(x => x.ProductId).ToArray());
+            var cartProductsTask = _cartProducts.GetCartProductsAsync(cartAggregate, cartAggregate.Cart.Items.Select(x => (x.Currency, x.ProductId)).ToList());
             var configurationsTask = LoadProductConfigurationsAsync(cartAggregate);
             await Task.WhenAll(availPaymentsTask, availShippingRatesTask, cartProductsTask, configurationsTask);
 
             var context = AbstractTypeFactory<CartValidationContext>.TryCreateInstance();
             context.CartAggregate = cartAggregate;
-            context.AllCartProducts = cartProductsTask.Result;
+            context.AllCartProducts = cartProductsTask.Result.Values;
             context.AvailPaymentMethods = availPaymentsTask.Result;
             context.AvailShippingRates = availShippingRatesTask.Result;
             context.ProductConfigurations = configurationsTask.Result;

--- a/src/VirtoCommerce.XCart.Core/VirtoCommerce.XCart.Core.csproj
+++ b/src/VirtoCommerce.XCart.Core/VirtoCommerce.XCart.Core.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="FluentValidation" Version="12.1.1" />
-    <PackageReference Include="VirtoCommerce.CartModule.Core" Version="3.1004.0-alpha.787-vcst-5101" />
+    <PackageReference Include="VirtoCommerce.CartModule.Core" Version="3.1005.0" />
     <PackageReference Include="VirtoCommerce.CatalogModule.Core" Version="3.1025.0" />
     <PackageReference Include="VirtoCommerce.FileExperienceApi.Core" Version="3.1000.0" />
     <PackageReference Include="VirtoCommerce.InventoryModule.Core" Version="3.1000.0" />

--- a/src/VirtoCommerce.XCart.Core/VirtoCommerce.XCart.Core.csproj
+++ b/src/VirtoCommerce.XCart.Core/VirtoCommerce.XCart.Core.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="FluentValidation" Version="12.1.1" />
     <PackageReference Include="VirtoCommerce.CatalogModule.Core" Version="3.1020.0" />
-    <PackageReference Include="VirtoCommerce.CartModule.Core" Version="3.1002.0" />
+    <PackageReference Include="VirtoCommerce.CartModule.Core" Version="3.1004.0-alpha.787-vcst-5101" />
     <PackageReference Include="VirtoCommerce.FileExperienceApi.Core" Version="3.1000.0" />
     <PackageReference Include="VirtoCommerce.InventoryModule.Core" Version="3.1000.0" />
     <PackageReference Include="VirtoCommerce.MarketingModule.Core" Version="3.1000.0" />

--- a/src/VirtoCommerce.XCart.Data/Commands/AddCartItemCommandHandler.cs
+++ b/src/VirtoCommerce.XCart.Data/Commands/AddCartItemCommandHandler.cs
@@ -42,7 +42,8 @@ namespace VirtoCommerce.XCart.Data.Commands
 
         protected virtual async Task AddItemToCartAsync(AddCartItemCommand request, CartAggregate cartAggregate, CancellationToken cancellationToken)
         {
-            var product = (await _cartProductService.GetCartProductsByIdsAsync(cartAggregate, [request.ProductId])).FirstOrDefault();
+            var itemCurrencyCode = !request.ItemCurrencyCode.IsNullOrEmpty() ? request.ItemCurrencyCode : cartAggregate.Currency.Code;
+            var product = (await _cartProductService.GetCartProductsAsync(cartAggregate, [(itemCurrencyCode, request.ProductId)])).Values.FirstOrDefault();
 
             var newItem = new NewCartItem(request.ProductId, request.Quantity)
             {

--- a/src/VirtoCommerce.XCart.Data/Commands/AddCartItemCommandHandler.cs
+++ b/src/VirtoCommerce.XCart.Data/Commands/AddCartItemCommandHandler.cs
@@ -52,7 +52,7 @@ namespace VirtoCommerce.XCart.Data.Commands
                 Price = request.Price,
                 CartProduct = product,
                 CreatedDate = request.CreatedDate,
-                CurrencyCode = itemCurrencyCode,
+                ItemCurrencyCode = itemCurrencyCode,
             };
 
             var configurations = await _productConfigurationSearchService.SearchNoCloneAsync(new ProductConfigurationSearchCriteria

--- a/src/VirtoCommerce.XCart.Data/Commands/AddCartItemCommandHandler.cs
+++ b/src/VirtoCommerce.XCart.Data/Commands/AddCartItemCommandHandler.cs
@@ -52,6 +52,7 @@ namespace VirtoCommerce.XCart.Data.Commands
                 Price = request.Price,
                 CartProduct = product,
                 CreatedDate = request.CreatedDate,
+                CurrencyCode = itemCurrencyCode,
             };
 
             var configurations = await _productConfigurationSearchService.SearchNoCloneAsync(new ProductConfigurationSearchCriteria
@@ -67,7 +68,7 @@ namespace VirtoCommerce.XCart.Data.Commands
                 createConfigurableProductCommand.UserId = request.UserId;
                 createConfigurableProductCommand.OrganizationId = request.OrganizationId;
                 createConfigurableProductCommand.CultureName = request.CultureName;
-                createConfigurableProductCommand.CurrencyCode = request.CurrencyCode;
+                createConfigurableProductCommand.CurrencyCode = itemCurrencyCode;
                 createConfigurableProductCommand.ConfigurableProductId = request.ProductId;
                 createConfigurableProductCommand.ConfigurationSections = request.ConfigurationSections;
                 createConfigurableProductCommand.CartId = cartAggregate.Cart.Id;

--- a/src/VirtoCommerce.XCart.Data/Commands/AddCartItemsCommandHandler.cs
+++ b/src/VirtoCommerce.XCart.Data/Commands/AddCartItemsCommandHandler.cs
@@ -111,7 +111,7 @@ namespace VirtoCommerce.XCart.Data.Commands
 
         private static string GetNewItemCurrencyCode(NewCartItem item, CartAggregate cartAggregate)
         {
-            return !item.CurrencyCode.IsNullOrEmpty() ? item.CurrencyCode : cartAggregate.Currency.Code;
+            return !item.ItemCurrencyCode.IsNullOrEmpty() ? item.ItemCurrencyCode : cartAggregate.Currency.Code;
         }
     }
 }

--- a/src/VirtoCommerce.XCart.Data/Commands/AddCartItemsCommandHandler.cs
+++ b/src/VirtoCommerce.XCart.Data/Commands/AddCartItemsCommandHandler.cs
@@ -51,7 +51,12 @@ namespace VirtoCommerce.XCart.Data.Commands
 
             var productIds = request.CartItems.Select(x => x.ProductId).Distinct().ToArray();
 
-            var productsTask = _cartProductService.GetCartProductsByIdsAsync(cartAggregate, productIds);
+            var productPairs = request.CartItems.Select(x =>
+            {
+                var itemCurrencyCode = GetNewItemCurrencyCode(x, cartAggregate);
+                return (itemCurrencyCode, x.ProductId);
+            }).Distinct().ToList();
+            var productsTask = _cartProductService.GetCartProductsAsync(cartAggregate, productPairs);
 
             var criteria = AbstractTypeFactory<ProductConfigurationSearchCriteria>.TryCreateInstance();
             criteria.ProductIds = productIds;
@@ -61,12 +66,13 @@ namespace VirtoCommerce.XCart.Data.Commands
 
             await Task.WhenAll(productsTask, configurationsTask);
 
-            var productsByIds = productsTask.Result.ToDictionary(x => x.Id);
+            var products = productsTask.Result;
             var activeConfigByProductId = configurationsTask.Result.DistinctBy(x => x.ProductId).ToDictionary(x => x.ProductId);
 
             foreach (var item in request.CartItems)
             {
-                if (!productsByIds.TryGetValue(item.ProductId, out var product))
+                var itemCurrencyCode = GetNewItemCurrencyCode(item, cartAggregate);
+                if (!products.TryGetValue(CartAggregate.GetCartProductKey(item.ProductId, itemCurrencyCode), out var product))
                 {
                     var error = CartErrorDescriber.ProductUnavailableError(nameof(CatalogProduct), item.ProductId);
                     cartAggregate.OperationValidationErrors.Add(error);
@@ -84,6 +90,11 @@ namespace VirtoCommerce.XCart.Data.Commands
                     await cartAggregate.AddItemAsync(item);
                 }
             }
+        }
+
+        private static string GetNewItemCurrencyCode(NewCartItem item, CartAggregate cartAggregate)
+        {
+            return !item.CurrencyCode.IsNullOrEmpty() ? item.CurrencyCode : cartAggregate.Currency.Code;
         }
 
         protected virtual async Task AddConfiguredItemAsync(AddCartItemsCommand request, NewCartItem item, CartAggregate cartAggregate, CancellationToken cancellationToken)

--- a/src/VirtoCommerce.XCart.Data/Commands/AddCartItemsCommandHandler.cs
+++ b/src/VirtoCommerce.XCart.Data/Commands/AddCartItemsCommandHandler.cs
@@ -92,11 +92,6 @@ namespace VirtoCommerce.XCart.Data.Commands
             }
         }
 
-        private static string GetNewItemCurrencyCode(NewCartItem item, CartAggregate cartAggregate)
-        {
-            return !item.CurrencyCode.IsNullOrEmpty() ? item.CurrencyCode : cartAggregate.Currency.Code;
-        }
-
         protected virtual async Task AddConfiguredItemAsync(AddCartItemsCommand request, NewCartItem item, CartAggregate cartAggregate, CancellationToken cancellationToken)
         {
             var command = AbstractTypeFactory<CreateConfiguredLineItemCommand>.TryCreateInstance();
@@ -104,7 +99,7 @@ namespace VirtoCommerce.XCart.Data.Commands
             command.UserId = request.UserId;
             command.OrganizationId = request.OrganizationId;
             command.CultureName = request.CultureName;
-            command.CurrencyCode = request.CurrencyCode;
+            command.CurrencyCode = GetNewItemCurrencyCode(item, cartAggregate);
             command.ConfigurableProductId = item.ProductId;
             command.ConfigurationSections = item.ConfigurationSections;
             command.CartId = cartAggregate.Cart.Id;
@@ -112,6 +107,11 @@ namespace VirtoCommerce.XCart.Data.Commands
             var result = await _mediator.Send(command, cancellationToken);
 
             await cartAggregate.AddConfiguredItemAsync(item, result.Item);
+        }
+
+        private static string GetNewItemCurrencyCode(NewCartItem item, CartAggregate cartAggregate)
+        {
+            return !item.CurrencyCode.IsNullOrEmpty() ? item.CurrencyCode : cartAggregate.Currency.Code;
         }
     }
 }

--- a/src/VirtoCommerce.XCart.Data/Commands/AddCartItemsCommandHandler.cs
+++ b/src/VirtoCommerce.XCart.Data/Commands/AddCartItemsCommandHandler.cs
@@ -72,7 +72,7 @@ namespace VirtoCommerce.XCart.Data.Commands
             foreach (var item in request.CartItems)
             {
                 var itemCurrencyCode = GetNewItemCurrencyCode(item, cartAggregate);
-                if (!products.TryGetValue(CartAggregate.GetCartProductKey(item.ProductId, itemCurrencyCode), out var product))
+                if (!products.TryGetValue(cartAggregate.GetCartProductKey(item.ProductId, itemCurrencyCode), out var product))
                 {
                     var error = CartErrorDescriber.ProductUnavailableError(nameof(CatalogProduct), item.ProductId);
                     cartAggregate.OperationValidationErrors.Add(error);

--- a/src/VirtoCommerce.XCart.Data/Commands/AddWishlistItemCommandHandler.cs
+++ b/src/VirtoCommerce.XCart.Data/Commands/AddWishlistItemCommandHandler.cs
@@ -46,7 +46,7 @@ namespace VirtoCommerce.XCart.Data.Commands
             var productConfiguration = await GetProductConfiguration(request);
             if (productConfiguration?.IsActive == true)
             {
-                var cartProduct = (await _cartProductService.GetCartProductsByIdsAsync(cartAggregate, [request.ProductId])).FirstOrDefault();
+                var cartProduct = (await _cartProductService.GetCartProductsAsync(cartAggregate, [(cartAggregate.Currency.Code, request.ProductId)])).Values.FirstOrDefault();
                 newItem.CartProduct = cartProduct;
 
                 var createConfigurableProductCommand = AbstractTypeFactory<CreateConfiguredLineItemCommand>.TryCreateInstance();

--- a/src/VirtoCommerce.XCart.Data/Commands/ChangeCartCurrencyCommandHandler.cs
+++ b/src/VirtoCommerce.XCart.Data/Commands/ChangeCartCurrencyCommandHandler.cs
@@ -180,7 +180,7 @@ namespace VirtoCommerce.XCart.Data.Commands
         {
             var targetCurrency = ResolveTargetCurrency(configurationLineItem.Currency, currentCurrencyCartAggregate, newCurrencyCartAggregate);
 
-            if (!configProducts.TryGetValue(CartAggregate.GetCartProductKey(configurationLineItem.ProductId, targetCurrency.Code), out var configurableProduct))
+            if (!configProducts.TryGetValue(newCurrencyCartAggregate.GetCartProductKey(configurationLineItem.ProductId, targetCurrency.Code), out var configurableProduct))
             {
                 return null;
             }
@@ -195,23 +195,23 @@ namespace VirtoCommerce.XCart.Data.Commands
                 switch (configurationItem.Type)
                 {
                     case ConfigurationSectionTypeProduct or ConfigurationSectionTypeVariation:
-                    {
-                        if (configProducts.TryGetValue(CartAggregate.GetCartProductKey(configurationItem.ProductId, targetCurrency.Code), out var product))
                         {
-                            container.AddProductSectionLineItem(product, configurationItem);
-                        }
+                            if (configProducts.TryGetValue(newCurrencyCartAggregate.GetCartProductKey(configurationItem.ProductId, targetCurrency.Code), out var product))
+                            {
+                                container.AddProductSectionLineItem(product, configurationItem);
+                            }
 
-                        break;
-                    }
+                            break;
+                        }
                     case ConfigurationSectionTypeText:
                         container.AddTextSectionLineItem(configurationItem);
                         break;
                     case ConfigurationSectionTypeFile:
-                    {
-                        var files = await CopyConfigurationFiles(configurationItem, currentCurrencyCartAggregate.Cart);
-                        container.AddFileSectionLineItem(configurationItem, files);
-                        break;
-                    }
+                        {
+                            var files = await CopyConfigurationFiles(configurationItem, currentCurrencyCartAggregate.Cart);
+                            container.AddFileSectionLineItem(configurationItem, files);
+                            break;
+                        }
                 }
             }
 

--- a/src/VirtoCommerce.XCart.Data/Commands/ChangeCartCurrencyCommandHandler.cs
+++ b/src/VirtoCommerce.XCart.Data/Commands/ChangeCartCurrencyCommandHandler.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using VirtoCommerce.CartModule.Core.Model;
+using VirtoCommerce.CoreModule.Core.Currency;
 using VirtoCommerce.FileExperienceApi.Core.Extensions;
 using VirtoCommerce.FileExperienceApi.Core.Services;
 using VirtoCommerce.Platform.Core.Common;
@@ -72,6 +73,7 @@ namespace VirtoCommerce.XCart.Data.Commands
                 var newCartItems = ordinaryItems
                     .Select(x => new NewCartItem(x.ProductId, x.Quantity)
                     {
+                        CurrencyCode = ResolveTargetCurrency(x.Currency, currentCurrencyCartAggregate, newCurrencyCartAggregate).Code,
                         IgnoreValidationErrors = true,
                         CreatedDate = x.CreatedDate,
                         Comment = x.Note,
@@ -94,6 +96,18 @@ namespace VirtoCommerce.XCart.Data.Commands
             await CopyConfiguredItems(currentCurrencyCartAggregate, newCurrencyCartAggregate);
         }
 
+        /// <summary>
+        /// Resolves the target currency for a copied line item.
+        /// Items in the source cart's base currency are converted to the new cart's currency;
+        /// items in their own (non-base) currency keep it.
+        /// </summary>
+        protected virtual Currency ResolveTargetCurrency(string itemCurrencyCode, CartAggregate currentCurrencyCartAggregate, CartAggregate newCurrencyCartAggregate)
+        {
+            return itemCurrencyCode.EqualsIgnoreCase(currentCurrencyCartAggregate.Cart.Currency)
+                ? newCurrencyCartAggregate.Currency
+                : currentCurrencyCartAggregate.GetCurrencyByCode(itemCurrencyCode);
+        }
+
         protected virtual async Task CopyConfiguredItems(CartAggregate currentCurrencyCartAggregate, CartAggregate newCurrencyCartAggregate)
         {
             var configuredItems = currentCurrencyCartAggregate.LineItems
@@ -105,17 +119,21 @@ namespace VirtoCommerce.XCart.Data.Commands
                 return;
             }
 
-            var configProductsIds = configuredItems
-                            .Where(x => !x.ConfigurationItems.IsNullOrEmpty())
-                            .SelectMany(x => x.ConfigurationItems.Select(y => y.ProductId))
-                            .Where(x => !string.IsNullOrEmpty(x))
-                            .Distinct()
-                            .ToList();
+            var configProductPairs = configuredItems
+                .SelectMany(item =>
+                {
+                    var targetCurrencyCode = ResolveTargetCurrency(item.Currency, currentCurrencyCartAggregate, newCurrencyCartAggregate).Code;
+                    var productIds = (item.ConfigurationItems ?? [])
+                        .Select(c => c.ProductId)
+                        .Where(id => !string.IsNullOrEmpty(id))
+                        .Append(item.ProductId);
 
-            configProductsIds.AddRange(configuredItems.Select(x => x.ProductId));
+                    return productIds.Select(id => (targetCurrencyCode, id));
+                })
+                .Distinct()
+                .ToList();
 
-            var configProducts = (await _cartProductService.GetCartProductsByIdsAsync(newCurrencyCartAggregate, configProductsIds))
-                .ToDictionary(x => x.Id);
+            var configProducts = await _cartProductService.GetCartProductsAsync(newCurrencyCartAggregate, configProductPairs);
 
             foreach (var configurationLineItem in configuredItems)
             {
@@ -149,17 +167,19 @@ namespace VirtoCommerce.XCart.Data.Commands
 
         protected virtual async Task<ConfiguredLineItemContainer> CreateConfiguredLineItemContainerAsync(
             LineItem configurationLineItem,
-            Dictionary<string, CartProduct> configProducts,
+            IDictionary<string, CartProduct> configProducts,
             CartAggregate currentCurrencyCartAggregate,
             CartAggregate newCurrencyCartAggregate)
         {
-            if (!configProducts.TryGetValue(configurationLineItem.ProductId, out var configurableProduct))
+            var targetCurrency = ResolveTargetCurrency(configurationLineItem.Currency, currentCurrencyCartAggregate, newCurrencyCartAggregate);
+
+            if (!configProducts.TryGetValue(CartAggregate.GetCartProductKey(configurationLineItem.ProductId, targetCurrency.Code), out var configurableProduct))
             {
                 return null;
             }
 
             var container = AbstractTypeFactory<ConfiguredLineItemContainer>.TryCreateInstance();
-            container.Currency = newCurrencyCartAggregate.Currency;
+            container.Currency = targetCurrency;
             container.Store = newCurrencyCartAggregate.Store;
             container.ConfigurableProduct = configurableProduct;
 
@@ -169,7 +189,7 @@ namespace VirtoCommerce.XCart.Data.Commands
                 {
                     case ConfigurationSectionTypeProduct or ConfigurationSectionTypeVariation:
                     {
-                        if (configProducts.TryGetValue(configurationItem.ProductId, out var product))
+                        if (configProducts.TryGetValue(CartAggregate.GetCartProductKey(configurationItem.ProductId, targetCurrency.Code), out var product))
                         {
                             container.AddProductSectionLineItem(product, configurationItem);
                         }

--- a/src/VirtoCommerce.XCart.Data/Commands/ChangeCartCurrencyCommandHandler.cs
+++ b/src/VirtoCommerce.XCart.Data/Commands/ChangeCartCurrencyCommandHandler.cs
@@ -73,7 +73,7 @@ namespace VirtoCommerce.XCart.Data.Commands
                 var newCartItems = ordinaryItems
                     .Select(x => new NewCartItem(x.ProductId, x.Quantity)
                     {
-                        CurrencyCode = ResolveTargetCurrency(x.Currency, currentCurrencyCartAggregate, newCurrencyCartAggregate).Code,
+                        ItemCurrencyCode = ResolveTargetCurrency(x.Currency, currentCurrencyCartAggregate, newCurrencyCartAggregate).Code,
                         IgnoreValidationErrors = true,
                         CreatedDate = x.CreatedDate,
                         Comment = x.Note,

--- a/src/VirtoCommerce.XCart.Data/Commands/ChangeCartItemCommentCommandHandler.cs
+++ b/src/VirtoCommerce.XCart.Data/Commands/ChangeCartItemCommentCommandHandler.cs
@@ -25,7 +25,7 @@ namespace VirtoCommerce.XCart.Data.Commands
             var lineItem = cartAggregate.Cart.Items.FirstOrDefault(x => x.Id.Equals(request.LineItemId));
 
             if (lineItem != null &&
-                (await _cartProductService.GetCartProductsByIdsAsync(cartAggregate, new[] { lineItem.ProductId })).FirstOrDefault() == null)
+                (await _cartProductService.GetCartProductsAsync(cartAggregate, [(lineItem.Currency, lineItem.ProductId)])).Values.FirstOrDefault() == null)
             {
                 return cartAggregate;
             }

--- a/src/VirtoCommerce.XCart.Data/Commands/ChangeCartItemQuantityCommandHandler.cs
+++ b/src/VirtoCommerce.XCart.Data/Commands/ChangeCartItemQuantityCommandHandler.cs
@@ -33,7 +33,7 @@ namespace VirtoCommerce.XCart.Data.Commands
             CartProduct product = null;
             if (lineItem != null)
             {
-                product = (await _cartProductService.GetCartProductsByIdsAsync(cartAggregate, new[] { lineItem.ProductId })).FirstOrDefault();
+                product = (await _cartProductService.GetCartProductsAsync(cartAggregate, [(lineItem.Currency, lineItem.ProductId)])).Values.FirstOrDefault();
             }
 
             await cartAggregate.ChangeItemQuantityAsync(new ItemQtyAdjustment

--- a/src/VirtoCommerce.XCart.Data/Commands/ChangeCartItemsQuantityCommandHandler.cs
+++ b/src/VirtoCommerce.XCart.Data/Commands/ChangeCartItemsQuantityCommandHandler.cs
@@ -47,14 +47,12 @@ namespace VirtoCommerce.XCart.Data.Commands
             }
 
             // load products for line items
-            var productIds = quantityAdjustments.Select(x => x.LineItem.ProductId).ToArray();
-            var productsByIds =
-                (await _cartProductService.GetCartProductsByIdsAsync(cartAggregate, productIds))
-                .ToDictionary(x => x.Id);
+            var currencyProductByIds = quantityAdjustments.Select(x => (x.LineItem.Currency, x.LineItem.ProductId)).ToArray();
+            var productsByIds = await _cartProductService.GetCartProductsAsync(cartAggregate, currencyProductByIds);
 
             foreach (var adjustment in quantityAdjustments)
             {
-                if (productsByIds.TryGetValue(adjustment.LineItem.ProductId, out var product))
+                if (productsByIds.TryGetValue(cartAggregate.GetCartProductKey(adjustment.LineItem), out var product))
                 {
                     adjustment.CartProduct = product;
 

--- a/src/VirtoCommerce.XCart.Data/Commands/UpdateCartQuantityCommandHandler.cs
+++ b/src/VirtoCommerce.XCart.Data/Commands/UpdateCartQuantityCommandHandler.cs
@@ -68,10 +68,8 @@ namespace VirtoCommerce.XCart.Data.Commands
 
             var newCartItems = new List<NewCartItem>();
 
-            foreach (var task in productTasks.OfType<Task<ProductsByCurrencyResult>>())
+            foreach (var productsByCurrency in productTasks.OfType<Task<ProductsByCurrencyResult>>().Select(x => x.Result))
             {
-                var productsByCurrency = task.Result;
-
                 foreach (var product in productsByCurrency.Products)
                 {
                     var requestItem = requestItems.FirstOrDefault(x => x.ProductId == product.Id && x.CurrencyCode.EqualsIgnoreCase(productsByCurrency.CurrencyCode));

--- a/src/VirtoCommerce.XCart.Data/Commands/UpdateCartQuantityCommandHandler.cs
+++ b/src/VirtoCommerce.XCart.Data/Commands/UpdateCartQuantityCommandHandler.cs
@@ -36,7 +36,7 @@ namespace VirtoCommerce.XCart.Data.Commands
             var requestItems = CombineRequestItems(request);
 
             var requestItemsByCurrency = requestItems
-                .GroupBy(x => x.CurrencyCode)
+                .GroupBy(x => x.ItemCurrencyCode)
                 .ToDictionary(x => x.Key, x => x.ToArray());
 
             var productTasks = new List<Task>();
@@ -63,7 +63,7 @@ namespace VirtoCommerce.XCart.Data.Commands
 
             foreach (var requestItem in requestItems.Where(x => x.Quantity == 0))
             {
-                await cartAggregate.RemoveItemsByProductIdAndCurrencyAsync(requestItem.ProductId, requestItem.CurrencyCode);
+                await cartAggregate.RemoveItemsByProductIdAndCurrencyAsync(requestItem.ProductId, requestItem.ItemCurrencyCode);
             }
 
             var newCartItems = new List<NewCartItem>();
@@ -72,13 +72,13 @@ namespace VirtoCommerce.XCart.Data.Commands
             {
                 foreach (var product in productsByCurrency.Products)
                 {
-                    var requestItem = requestItems.FirstOrDefault(x => x.ProductId == product.Id && x.CurrencyCode.EqualsIgnoreCase(productsByCurrency.CurrencyCode));
+                    var requestItem = requestItems.FirstOrDefault(x => x.ProductId == product.Id && x.ItemCurrencyCode.EqualsIgnoreCase(productsByCurrency.CurrencyCode));
                     if (requestItem != null)
                     {
                         newCartItems.Add(new NewCartItem(product.Id, requestItem.Quantity)
                         {
                             CartProduct = product,
-                            CurrencyCode = productsByCurrency.CurrencyCode,
+                            ItemCurrencyCode = productsByCurrency.CurrencyCode,
                             IgnoreValidationErrors = true,
                             OverrideQuantity = true,
                         });
@@ -133,12 +133,12 @@ namespace VirtoCommerce.XCart.Data.Commands
 
             foreach (var item in request.Items)
             {
-                if (item.CurrencyCode.IsNullOrEmpty())
+                if (item.ItemCurrencyCode.IsNullOrEmpty())
                 {
-                    item.CurrencyCode = request.CurrencyCode;
+                    item.ItemCurrencyCode = request.CurrencyCode;
                 }
 
-                var resultItem = result.FirstOrDefault(x => x.ProductId == item.ProductId && x.CurrencyCode.EqualsIgnoreCase(item.CurrencyCode));
+                var resultItem = result.FirstOrDefault(x => x.ProductId == item.ProductId && x.ItemCurrencyCode.EqualsIgnoreCase(item.ItemCurrencyCode));
                 if (resultItem != null)
                 {
                     resultItem.Quantity += item.Quantity;
@@ -149,7 +149,7 @@ namespace VirtoCommerce.XCart.Data.Commands
                     {
                         ProductId = item.ProductId,
                         Quantity = item.Quantity,
-                        CurrencyCode = item.CurrencyCode,
+                        ItemCurrencyCode = item.ItemCurrencyCode,
                     });
                 }
             }

--- a/src/VirtoCommerce.XCart.Data/Commands/UpdateCartQuantityCommandHandler.cs
+++ b/src/VirtoCommerce.XCart.Data/Commands/UpdateCartQuantityCommandHandler.cs
@@ -34,35 +34,64 @@ namespace VirtoCommerce.XCart.Data.Commands
         public override async Task<CartAggregate> Handle(UpdateCartQuantityCommand request, CancellationToken cancellationToken)
         {
             var requestItems = CombineRequestItems(request);
-            var nonZeroQuantityProductIds = requestItems
-                .Where(x => x.Quantity > 0)
-                .Select(x => x.ProductId)
-                .ToArray();
 
-            var productsTask = LoadCartProductsAsync(request, nonZeroQuantityProductIds);
+            var requestItemsByCurrency = requestItems
+                .GroupBy(x => x.CurrencyCode)
+                .ToDictionary(x => x.Key, x => x.ToArray());
+
+            var productTasks = new List<Task>();
+            foreach (var currencyRequestItemsPair in requestItemsByCurrency)
+            {
+                var nonZeroQuantityProductIdsByCurrency = currencyRequestItemsPair.Value
+                    .Where(x => x.Quantity > 0)
+                    .Select(x => x.ProductId)
+                    .ToArray();
+
+                var currencyRequest = (UpdateCartQuantityCommand)request.Clone();
+                currencyRequest.CurrencyCode = currencyRequestItemsPair.Key;
+                var currencyProductTask = LoadCartProductsAsync(currencyRequest, nonZeroQuantityProductIdsByCurrency);
+
+                productTasks.Add(currencyProductTask);
+            }
+
             var cartAggregateTask = GetOrCreateCartFromCommandAsync(request);
-            await Task.WhenAll(productsTask, cartAggregateTask);
+
+            var allTasks = new List<Task>(productTasks) { cartAggregateTask };
+            await Task.WhenAll(allTasks);
 
             var cartAggregate = cartAggregateTask.Result;
-            var products = productsTask.Result;
+
+            //// set default cart currency to all products without explicitly defined currency
+            //foreach (var requestItem in requestItems.Where(x => x.CurrencyCode.IsNullOrEmpty()))
+            //{
+            //    requestItem.CurrencyCode = cartAggregate.Currency.Code;
+            //}
 
             foreach (var requestItem in requestItems.Where(x => x.Quantity == 0))
             {
-                await cartAggregate.RemoveItemsByProductIdAsync(requestItem.ProductId);
+                //await cartAggregate.RemoveItemsByProductIdAsync(requestItem.ProductId); // also need to account currencyCode
+                await cartAggregate.RemoveItemsByProductIdAndCurrencyAsync(requestItem.ProductId, requestItem.CurrencyCode);
             }
 
             var newCartItems = new List<NewCartItem>();
-            foreach (var product in products)
+
+            foreach (var task in productTasks.OfType<Task<ProductsByCurrencyResult>>())
             {
-                var requestItem = requestItems.FirstOrDefault(x => x.ProductId == product.Id);
-                if (requestItem != null)
+                var productsByCurrency = task.Result;
+
+                foreach (var product in productsByCurrency.Products)
                 {
-                    newCartItems.Add(new NewCartItem(product.Id, requestItem.Quantity)
+                    var requestItem = requestItems.FirstOrDefault(x => x.ProductId == product.Id && x.CurrencyCode.EqualsIgnoreCase(productsByCurrency.CurrencyCode));
+                    if (requestItem != null)
                     {
-                        CartProduct = product,
-                        IgnoreValidationErrors = true,
-                        OverrideQuantity = true,
-                    });
+                        newCartItems.Add(new NewCartItem(product.Id, requestItem.Quantity)
+                        {
+                            CartProduct = product,
+                            CurrencyCode = productsByCurrency.CurrencyCode,
+                            IgnoreValidationErrors = true,
+                            OverrideQuantity = true,
+                        });
+                    }
                 }
             }
 
@@ -74,12 +103,17 @@ namespace VirtoCommerce.XCart.Data.Commands
             return await SaveCartAsync(cartAggregate);
         }
 
-        protected virtual async Task<IList<CartProduct>> LoadCartProductsAsync(UpdateCartQuantityCommand request, string[] productIds)
+        protected virtual async Task<ProductsByCurrencyResult> LoadCartProductsAsync(UpdateCartQuantityCommand request, string[] productIds)
         {
             var productRequest = GetCartProductsRequest(request, productIds);
 
             var products = await _cartProductsLoaderService.GetCartProductsAsync(productRequest);
-            return products;
+
+            return new ProductsByCurrencyResult
+            {
+                CurrencyCode = productRequest.CurrencyCode,
+                Products = products,
+            };
         }
 
         protected virtual CartProductsRequest GetCartProductsRequest(UpdateCartQuantityCommand request, string[] productIds)
@@ -108,6 +142,11 @@ namespace VirtoCommerce.XCart.Data.Commands
 
             foreach (var item in request.Items)
             {
+                if (item.CurrencyCode.IsNullOrEmpty())
+                {
+                    item.CurrencyCode = request.CurrencyCode;
+                }
+
                 var a = result.FirstOrDefault(x => x.ProductId == item.ProductId);
                 if (a != null)
                 {
@@ -118,12 +157,20 @@ namespace VirtoCommerce.XCart.Data.Commands
                     result.Add(new UpdateCartQuantityItem
                     {
                         ProductId = item.ProductId,
-                        Quantity = item.Quantity
+                        Quantity = item.Quantity,
+                        CurrencyCode = item.CurrencyCode,
                     });
                 }
             }
 
             return result;
+        }
+
+        public class ProductsByCurrencyResult
+        {
+            public string CurrencyCode { get; set; }
+
+            public IList<CartProduct> Products { get; set; }
         }
     }
 }

--- a/src/VirtoCommerce.XCart.Data/Commands/UpdateCartQuantityCommandHandler.cs
+++ b/src/VirtoCommerce.XCart.Data/Commands/UpdateCartQuantityCommandHandler.cs
@@ -61,15 +61,8 @@ namespace VirtoCommerce.XCart.Data.Commands
 
             var cartAggregate = cartAggregateTask.Result;
 
-            //// set default cart currency to all products without explicitly defined currency
-            //foreach (var requestItem in requestItems.Where(x => x.CurrencyCode.IsNullOrEmpty()))
-            //{
-            //    requestItem.CurrencyCode = cartAggregate.Currency.Code;
-            //}
-
             foreach (var requestItem in requestItems.Where(x => x.Quantity == 0))
             {
-                //await cartAggregate.RemoveItemsByProductIdAsync(requestItem.ProductId); // also need to account currencyCode
                 await cartAggregate.RemoveItemsByProductIdAndCurrencyAsync(requestItem.ProductId, requestItem.CurrencyCode);
             }
 
@@ -147,10 +140,10 @@ namespace VirtoCommerce.XCart.Data.Commands
                     item.CurrencyCode = request.CurrencyCode;
                 }
 
-                var a = result.FirstOrDefault(x => x.ProductId == item.ProductId);
-                if (a != null)
+                var resultItem = result.FirstOrDefault(x => x.ProductId == item.ProductId && x.CurrencyCode.EqualsIgnoreCase(item.CurrencyCode));
+                if (resultItem != null)
                 {
-                    a.Quantity += item.Quantity;
+                    resultItem.Quantity += item.Quantity;
                 }
                 else
                 {

--- a/src/VirtoCommerce.XCart.Data/Commands/UpdateWishlistItemsCommandHandler.cs
+++ b/src/VirtoCommerce.XCart.Data/Commands/UpdateWishlistItemsCommandHandler.cs
@@ -30,7 +30,7 @@ namespace VirtoCommerce.XCart.Data.Commands
                 var lineItem = cartAggregate.Cart.Items.FirstOrDefault(x => x.Id.Equals(item.LineItemId));
                 if (lineItem != null)
                 {
-                    var product = (await _cartProductService.GetCartProductsByIdsAsync(cartAggregate, new[] { lineItem.ProductId })).FirstOrDefault();
+                    var product = (await _cartProductService.GetCartProductsAsync(cartAggregate, [(lineItem.Currency, lineItem.ProductId)])).Values.FirstOrDefault();
 
                     await cartAggregate.ChangeItemQuantityAsync(new ItemQtyAdjustment
                     {

--- a/src/VirtoCommerce.XCart.Data/Mapping/CartMappingProfile.cs
+++ b/src/VirtoCommerce.XCart.Data/Mapping/CartMappingProfile.cs
@@ -42,6 +42,11 @@ namespace VirtoCommerce.XCart.Data.Mapping
                 }
                 lineItem.Name = cartProduct.GetName(cultureName);
 
+                if (context.Items.TryGetValue("currencyCode", out var currencyCodeValue))
+                {
+                    lineItem.Currency = currencyCodeValue as string;
+                }
+
                 lineItem.CatalogId = cartProduct.Product.CatalogId;
                 lineItem.CategoryId = cartProduct.Product.CategoryId;
                 lineItem.DynamicProperties = [];
@@ -208,7 +213,7 @@ namespace VirtoCommerce.XCart.Data.Mapping
                 foreach (var lineItem in cartAggr.SelectedLineItems)
                 {
                     var promoEntry = context.Mapper.Map<ProductPromoEntry>(lineItem);
-                    var cartProduct = cartAggr.CartProducts[lineItem.ProductId];
+                    var cartProduct = cartAggr.CartProducts[cartAggr.GetCartProductKey(lineItem)];
                     if (cartProduct != null)
                     {
                         promoEntry.InStockQuantity = (int)(cartProduct.Inventory?.InStockQuantity ?? 0);

--- a/src/VirtoCommerce.XCart.Data/Mapping/CartMappingProfile.cs
+++ b/src/VirtoCommerce.XCart.Data/Mapping/CartMappingProfile.cs
@@ -210,7 +210,8 @@ namespace VirtoCommerce.XCart.Data.Mapping
 
                 promoEvalcontext.CartPromoEntries = new List<ProductPromoEntry>();
 
-                foreach (var lineItem in cartAggr.SelectedLineItems)
+                // Tax and Promotion are computed only on primary-currency lines
+                foreach (var lineItem in cartAggr.CartCurrencySelectedLineItems)
                 {
                     var promoEntry = context.Mapper.Map<ProductPromoEntry>(lineItem);
                     var cartProduct = cartAggr.CartProducts[cartAggr.GetCartProductKey(lineItem)];
@@ -267,7 +268,8 @@ namespace VirtoCommerce.XCart.Data.Mapping
                 taxEvalcontext.CustomerId = cartAggr.Cart.CustomerId;
                 taxEvalcontext.Currency = cartAggr.Cart.Currency;
 
-                foreach (var lineItem in cartAggr.SelectedLineItems)
+                // Tax and Promotion are computed only on primary-currency lines
+                foreach (var lineItem in cartAggr.CartCurrencySelectedLineItems)
                 {
                     var taxLine = AbstractTypeFactory<TaxLine>.TryCreateInstance();
                     taxLine.Id = lineItem.Id;

--- a/src/VirtoCommerce.XCart.Data/Services/CartAggregateRepository.cs
+++ b/src/VirtoCommerce.XCart.Data/Services/CartAggregateRepository.cs
@@ -31,7 +31,7 @@ namespace VirtoCommerce.XCart.Data.Services
     public class CartAggregateRepository : ICartAggregateRepository
     {
         private readonly Func<CartAggregate> _cartAggregateFactory;
-        private readonly ICartProductsLoaderService _cartProductsLoaderService;
+        private readonly ICartProductService _cartProductsService;
         private readonly IShoppingCartSearchService _shoppingCartSearchService;
         private readonly IShoppingCartService _shoppingCartService;
         private readonly ICurrencyService _currencyService;
@@ -48,7 +48,7 @@ namespace VirtoCommerce.XCart.Data.Services
             ICurrencyService currencyService,
             IMemberResolver memberResolver,
             IStoreService storeService,
-            ICartProductsLoaderService cartProductsLoaderService,
+            ICartProductService cartProductsService,
             IPlatformMemoryCache platformMemoryCache,
             IFileUploadService fileUploadService)
         {
@@ -58,7 +58,7 @@ namespace VirtoCommerce.XCart.Data.Services
             _currencyService = currencyService;
             _memberResolver = memberResolver;
             _storeService = storeService;
-            _cartProductsLoaderService = cartProductsLoaderService;
+            _cartProductsService = cartProductsService;
             _platformMemoryCache = platformMemoryCache;
             _fileUploadService = fileUploadService;
         }
@@ -283,11 +283,10 @@ namespace VirtoCommerce.XCart.Data.Services
             language = !string.IsNullOrEmpty(cart.LanguageCode) ? cart.LanguageCode : store.DefaultLanguage;
             var currency = allCurrencies.GetCurrencyForLanguage(cart.Currency, language);
 
-            // find all cart currencies
-            var itemCurrencyCodes = cart.Items?.Select(x => x.Currency).Where(x => !x.EqualsIgnoreCase(cart.Currency)).ToArray();
-            var itemCurrencies = itemCurrencyCodes?.Select(x => allCurrencies.GetCurrencyForLanguage(x, language)).ToList();
-            itemCurrencies ??= new List<Currency>();
-            itemCurrencies.Add(currency);
+            // Preload all available currencies — extras are harmless and avoid having to refresh the list on each item add.
+            var itemCurrencies = allCurrencies
+                .Select(x => allCurrencies.GetCurrencyForLanguage(x.Code, language))
+                .ToList();
 
             var member = await _memberResolver.ResolveMemberByIdAsync(cart.CustomerId);
             var aggregate = _cartAggregateFactory();
@@ -305,22 +304,11 @@ namespace VirtoCommerce.XCart.Data.Services
 
                 if (aggregate.ProductsIncludeFields == null || aggregate.ProductsIncludeFields.FirstOrDefault() != "__none")
                 {
-                    // Group line items by currency so we can issue one product request per currency.
-                    // A single product can appear in several currencies — each currency yields a distinct CartProduct.
-                    var productIdsByCurrency = aggregate.Cart.Items
-                        .GroupBy(x => !string.IsNullOrEmpty(x.Currency) ? x.Currency : aggregate.Currency.Code, StringComparer.OrdinalIgnoreCase)
-                        .ToDictionary(g => g.Key, g => g.Select(x => x.ProductId).Distinct().ToArray(), StringComparer.OrdinalIgnoreCase);
-
-                    foreach (var (currencyCode, productIds) in productIdsByCurrency)
+                    var productPairs = aggregate.Cart.Items.Select(x => (x.Currency, x.ProductId)).Distinct().ToList();
+                    var products = await _cartProductsService.GetCartProductsAsync(aggregate, productPairs);
+                    foreach (var product in products)
                     {
-                        var productRequest = GetCartProductsRequest(aggregate, currencyCode, productIds);
-                        var cartProducts = await _cartProductsLoaderService.GetCartProductsAsync(productRequest);
-
-                        //Populate aggregate.CartProducts with the products data, keyed by productId + currency
-                        foreach (var cartProduct in cartProducts ?? [])
-                        {
-                            aggregate.CartProducts[CartAggregate.GetCartProductKey(cartProduct.Id, currencyCode)] = cartProduct;
-                        }
+                        aggregate.CartProducts[product.Key] = product.Value;
                     }
                 }
 
@@ -398,43 +386,6 @@ namespace VirtoCommerce.XCart.Data.Services
 
                 await _fileUploadService.SaveChangesAsync(files);
             }
-        }
-
-        private static CartProductsRequest GetCartProductsRequest(CartAggregate aggregate, string currencyCode, string[] productIds)
-        {
-            var productRequest = AbstractTypeFactory<CartProductsRequest>.TryCreateInstance();
-
-            productRequest.LoadPrice = true;
-            productRequest.LoadInventory = true;
-            productRequest.EvaluatePromotions = false;
-
-            productRequest.StoreId = aggregate.Store.Id;
-            productRequest.UserId = aggregate.Cart.CustomerId;
-            productRequest.OrganizationId = aggregate.Cart.OrganizationId;
-            productRequest.CultureName = aggregate.Cart.LanguageCode;
-            productRequest.CurrencyCode = currencyCode;
-
-            productRequest.ProductIds = productIds;
-            productRequest.ProductsIncludeFields = GetIncludeFields(aggregate);
-
-            return productRequest;
-        }
-
-        private static List<string> GetIncludeFields(CartAggregate request)
-        {
-            var includeFields = new string[]
-            {
-                "__object",
-                "price",
-                "availabilityData",
-                "images",
-                "properties",
-                "description",
-                "slug",
-                "outlines"
-            };
-
-            return new List<string>(includeFields).Union(request.ProductsIncludeFields ?? []).ToList();
         }
     }
 }

--- a/src/VirtoCommerce.XCart.Data/Services/CartAggregateRepository.cs
+++ b/src/VirtoCommerce.XCart.Data/Services/CartAggregateRepository.cs
@@ -31,7 +31,7 @@ namespace VirtoCommerce.XCart.Data.Services
     public class CartAggregateRepository : ICartAggregateRepository
     {
         private readonly Func<CartAggregate> _cartAggregateFactory;
-        private readonly ICartProductService _cartProductsService;
+        private readonly ICartProductsLoaderService _cartProductsLoaderService;
         private readonly IShoppingCartSearchService _shoppingCartSearchService;
         private readonly IShoppingCartService _shoppingCartService;
         private readonly ICurrencyService _currencyService;
@@ -48,7 +48,7 @@ namespace VirtoCommerce.XCart.Data.Services
             ICurrencyService currencyService,
             IMemberResolver memberResolver,
             IStoreService storeService,
-            ICartProductService cartProductsService,
+            ICartProductsLoaderService cartProductsLoaderService,
             IPlatformMemoryCache platformMemoryCache,
             IFileUploadService fileUploadService)
         {
@@ -58,7 +58,7 @@ namespace VirtoCommerce.XCart.Data.Services
             _currencyService = currencyService;
             _memberResolver = memberResolver;
             _storeService = storeService;
-            _cartProductsService = cartProductsService;
+            _cartProductsLoaderService = cartProductsLoaderService;
             _platformMemoryCache = platformMemoryCache;
             _fileUploadService = fileUploadService;
         }
@@ -283,6 +283,13 @@ namespace VirtoCommerce.XCart.Data.Services
             language = !string.IsNullOrEmpty(cart.LanguageCode) ? cart.LanguageCode : store.DefaultLanguage;
             var currency = allCurrencies.GetCurrencyForLanguage(cart.Currency, language);
 
+            // find all cart currencies
+            //var itemCurrencies = new List<Currency>();
+            var itemCurrencyCodes = cart.Items?.Select(x => x.Currency).Where(x => !x.EqualsIgnoreCase(cart.Currency)).ToArray();
+            var itemCurrencies = itemCurrencyCodes?.Select(x => allCurrencies.GetCurrencyForLanguage(x, language)).ToList();
+            itemCurrencies ??= new List<Currency>();
+            itemCurrencies.Add(currency);
+
             var member = await _memberResolver.ResolveMemberByIdAsync(cart.CustomerId);
             var aggregate = _cartAggregateFactory();
 
@@ -290,26 +297,38 @@ namespace VirtoCommerce.XCart.Data.Services
             {
                 aggregate.GrabCart(cart, store, member, currency);
 
+                // init cart currencies
+                aggregate.ItemCurrencies = itemCurrencies;
+
                 //Load cart products explicitly if no validation is requested
                 aggregate.ProductsIncludeFields = productsIncludeFields;
                 aggregate.ResponseGroup = responseGroup;
 
-                var cartProducts = default(IList<CartProduct>);
                 if (aggregate.ProductsIncludeFields == null || aggregate.ProductsIncludeFields.FirstOrDefault() != "__none")
                 {
-                    cartProducts = await _cartProductsService.GetCartProductsByIdsAsync(aggregate, aggregate.Cart.Items.Select(x => x.ProductId).ToArray());
-                }
+                    // Group line items by currency so we can issue one product request per currency.
+                    // A single product can appear in several currencies — each currency yields a distinct CartProduct.
+                    var productIdsByCurrency = aggregate.Cart.Items
+                        .GroupBy(x => !string.IsNullOrEmpty(x.Currency) ? x.Currency : aggregate.Currency.Code, StringComparer.OrdinalIgnoreCase)
+                        .ToDictionary(g => g.Key, g => g.Select(x => x.ProductId).Distinct().ToArray(), StringComparer.OrdinalIgnoreCase);
 
-                //Populate aggregate.CartProducts with the  products data for all cart  line items
-                foreach (var cartProduct in cartProducts ?? [])
-                {
-                    aggregate.CartProducts[cartProduct.Id] = cartProduct;
+                    foreach (var (currencyCode, productIds) in productIdsByCurrency)
+                    {
+                        var productRequest = GetCartProductsRequest(aggregate, currencyCode, productIds);
+                        var cartProducts = await _cartProductsLoaderService.GetCartProductsAsync(productRequest);
+
+                        //Populate aggregate.CartProducts with the products data, keyed by productId + currency
+                        foreach (var cartProduct in cartProducts ?? [])
+                        {
+                            aggregate.CartProducts[CartAggregate.GetCartProductKey(cartProduct.Id, currencyCode)] = cartProduct;
+                        }
+                    }
                 }
 
                 var validator = AbstractTypeFactory<CartLineItemPriceChangedValidator>.TryCreateInstance();
                 foreach (var lineItem in aggregate.LineItems)
                 {
-                    var cartProduct = aggregate.CartProducts[lineItem.ProductId];
+                    var cartProduct = aggregate.CartProducts[aggregate.GetCartProductKey(lineItem)];
                     if (cartProduct == null)
                     {
                         continue;
@@ -380,6 +399,43 @@ namespace VirtoCommerce.XCart.Data.Services
 
                 await _fileUploadService.SaveChangesAsync(files);
             }
+        }
+
+        private static CartProductsRequest GetCartProductsRequest(CartAggregate aggregate, string currencyCode, string[] productIds)
+        {
+            var productRequest = AbstractTypeFactory<CartProductsRequest>.TryCreateInstance();
+
+            productRequest.LoadPrice = true;
+            productRequest.LoadInventory = true;
+            productRequest.EvaluatePromotions = false;
+
+            productRequest.StoreId = aggregate.Store.Id;
+            productRequest.UserId = aggregate.Cart.CustomerId;
+            productRequest.OrganizationId = aggregate.Cart.OrganizationId;
+            productRequest.CultureName = aggregate.Cart.LanguageCode;
+            productRequest.CurrencyCode = currencyCode;
+
+            productRequest.ProductIds = productIds;
+            productRequest.ProductsIncludeFields = GetIncludeFields(aggregate);
+
+            return productRequest;
+        }
+
+        private static List<string> GetIncludeFields(CartAggregate request)
+        {
+            var includeFields = new string[]
+            {
+                "__object",
+                "price",
+                "availabilityData",
+                "images",
+                "properties",
+                "description",
+                "slug",
+                "outlines"
+            };
+
+            return new List<string>(includeFields).Union(request.ProductsIncludeFields ?? []).ToList();
         }
     }
 }

--- a/src/VirtoCommerce.XCart.Data/Services/CartAggregateRepository.cs
+++ b/src/VirtoCommerce.XCart.Data/Services/CartAggregateRepository.cs
@@ -284,7 +284,6 @@ namespace VirtoCommerce.XCart.Data.Services
             var currency = allCurrencies.GetCurrencyForLanguage(cart.Currency, language);
 
             // find all cart currencies
-            //var itemCurrencies = new List<Currency>();
             var itemCurrencyCodes = cart.Items?.Select(x => x.Currency).Where(x => !x.EqualsIgnoreCase(cart.Currency)).ToArray();
             var itemCurrencies = itemCurrencyCodes?.Select(x => allCurrencies.GetCurrencyForLanguage(x, language)).ToList();
             itemCurrencies ??= new List<Currency>();

--- a/src/VirtoCommerce.XCart.Data/Services/CartAggregateRepository.cs
+++ b/src/VirtoCommerce.XCart.Data/Services/CartAggregateRepository.cs
@@ -296,7 +296,7 @@ namespace VirtoCommerce.XCart.Data.Services
                 aggregate.GrabCart(cart, store, member, currency);
 
                 // init cart currencies
-                aggregate.ItemCurrencies = itemCurrencies;
+                aggregate.AllCurrencies = itemCurrencies;
 
                 //Load cart products explicitly if no validation is requested
                 aggregate.ProductsIncludeFields = productsIncludeFields;

--- a/src/VirtoCommerce.XCart.Data/Services/CartAggregateRepository.cs
+++ b/src/VirtoCommerce.XCart.Data/Services/CartAggregateRepository.cs
@@ -325,6 +325,7 @@ namespace VirtoCommerce.XCart.Data.Services
                     var lineItemContext = new CartLineItemPriceChangedValidationContext
                     {
                         LineItem = lineItem,
+                        CartAggregate = aggregate,
                         CartProducts = aggregate.CartProducts,
                     };
 

--- a/src/VirtoCommerce.XCart.Data/Services/CartProductService.cs
+++ b/src/VirtoCommerce.XCart.Data/Services/CartProductService.cs
@@ -4,7 +4,6 @@ using System.Linq;
 using System.Threading.Tasks;
 using AutoMapper;
 using MediatR;
-using StackExchange.Redis;
 using VirtoCommerce.CatalogModule.Core.Model;
 using VirtoCommerce.CatalogModule.Core.Services;
 using VirtoCommerce.InventoryModule.Core.Model.Search;

--- a/src/VirtoCommerce.XCart.Data/Services/CartProductService.cs
+++ b/src/VirtoCommerce.XCart.Data/Services/CartProductService.cs
@@ -109,7 +109,7 @@ namespace VirtoCommerce.XCart.Data.Services
                 }
 
                 //Populate aggregate.CartProducts with the products data, keyed by productId + currency
-                foreach (var cartProduct in cartProducts ?? [])
+                foreach (var cartProduct in cartProducts)
                 {
                     result[CartAggregate.GetCartProductKey(cartProduct.Id, currencyCode)] = cartProduct;
                 }

--- a/src/VirtoCommerce.XCart.Data/Services/CartProductService.cs
+++ b/src/VirtoCommerce.XCart.Data/Services/CartProductService.cs
@@ -110,7 +110,7 @@ namespace VirtoCommerce.XCart.Data.Services
                 //Populate aggregate.CartProducts with the products data, keyed by productId + currency
                 foreach (var cartProduct in cartProducts)
                 {
-                    result[CartAggregate.GetCartProductKey(cartProduct.Id, currencyCode)] = cartProduct;
+                    result[aggregate.GetCartProductKey(cartProduct.Id, currencyCode)] = cartProduct;
                 }
             }
 

--- a/src/VirtoCommerce.XCart.Data/Services/CartProductService.cs
+++ b/src/VirtoCommerce.XCart.Data/Services/CartProductService.cs
@@ -1,8 +1,10 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using AutoMapper;
 using MediatR;
+using StackExchange.Redis;
 using VirtoCommerce.CatalogModule.Core.Model;
 using VirtoCommerce.CatalogModule.Core.Services;
 using VirtoCommerce.InventoryModule.Core.Model.Search;
@@ -86,6 +88,34 @@ namespace VirtoCommerce.XCart.Data.Services
             }
 
             return cartProducts;
+        }
+
+        public async Task<IDictionary<string, CartProduct>> GetCartProductsAsync(CartAggregate aggregate, IList<(string CurrencyCode, string ProductId)> currencyProductIdPairs)
+        {
+            var result = new Dictionary<string, CartProduct>();
+
+            var productIdsByCurrency = currencyProductIdPairs
+                .GroupBy(x => !x.CurrencyCode.IsNullOrEmpty() ? x.CurrencyCode : aggregate.Currency.Code, StringComparer.OrdinalIgnoreCase)
+                .ToDictionary(g => g.Key, g => g.Select(x => x.ProductId).Distinct().ToArray(), StringComparer.OrdinalIgnoreCase);
+
+            foreach (var (currencyCode, productIds) in productIdsByCurrency)
+            {
+                var cartProducts = await GetCartProductsAsync(productIds, aggregate.Store.Id, currencyCode, aggregate.Cart.CustomerId, aggregate.Cart.OrganizationId, GetIncludeFields(aggregate.ProductsIncludeFields));
+
+                var productsToLoadDependencies = cartProducts.Where(x => x.LoadDependencies).ToList();
+                if (productsToLoadDependencies.Count != 0)
+                {
+                    await Task.WhenAll(LoadDependencies(aggregate, productsToLoadDependencies));
+                }
+
+                //Populate aggregate.CartProducts with the products data, keyed by productId + currency
+                foreach (var cartProduct in cartProducts ?? [])
+                {
+                    result[CartAggregate.GetCartProductKey(cartProduct.Id, currencyCode)] = cartProduct;
+                }
+            }
+
+            return result;
         }
 
         /// <summary>

--- a/src/VirtoCommerce.XCart.Data/VirtoCommerce.XCart.Data.csproj
+++ b/src/VirtoCommerce.XCart.Data/VirtoCommerce.XCart.Data.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
@@ -9,7 +9,7 @@
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="VirtoCommerce.Platform.Security" Version="3.1002.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Security" Version="3.1007.10" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.XCart.Core\VirtoCommerce.XCart.Core.csproj" />

--- a/src/VirtoCommerce.XCart.Web/module.manifest
+++ b/src/VirtoCommerce.XCart.Web/module.manifest
@@ -4,10 +4,10 @@
   <version>3.1014.0</version>
   <version-tag></version-tag>
 
-  <platformVersion>3.1002.0</platformVersion>
+  <platformVersion>3.1007.10</platformVersion>
   <dependencies>
     <dependency id="VirtoCommerce.Catalog" version="3.1020.0" />
-    <dependency id="VirtoCommerce.Cart" version="3.1002.0" />
+    <dependency id="VirtoCommerce.Cart" version="3.1004.0-alpha.787-vcst-5101" />
     <dependency id="VirtoCommerce.FileExperienceApi" version="3.1000.0" />
     <dependency id="VirtoCommerce.Inventory" version="3.1000.0" />
     <dependency id="VirtoCommerce.Marketing" version="3.1000.0" />

--- a/src/VirtoCommerce.XCart.Web/module.manifest
+++ b/src/VirtoCommerce.XCart.Web/module.manifest
@@ -7,7 +7,7 @@
 
   <platformVersion>3.1017.0</platformVersion>
   <dependencies>
-    <dependency id="VirtoCommerce.Cart" version="3.1004.0-alpha.787-vcst-5101" />
+    <dependency id="VirtoCommerce.Cart" version="3.1005.0" />
     <dependency id="VirtoCommerce.Catalog" version="3.1025.0" />
     <dependency id="VirtoCommerce.FileExperienceApi" version="3.1000.0" />
     <dependency id="VirtoCommerce.Inventory" version="3.1000.0" />

--- a/tests/VirtoCommerce.XCart.Tests/Aggregates/CartAggregateTests.cs
+++ b/tests/VirtoCommerce.XCart.Tests/Aggregates/CartAggregateTests.cs
@@ -935,7 +935,9 @@ namespace VirtoCommerce.XCart.Tests.Aggregates
         {
             // Arrange
             var cartAggregate = GetValidCartAggregate();
-            cartAggregate.Cart.Items = new List<LineItem> { _fixture.Create<LineItem>() };
+            var lineItem = _fixture.Create<LineItem>();
+            lineItem.SelectedForCheckout = true;
+            cartAggregate.Cart.Items = [lineItem];
 
             var coupon = _fixture.Create<string>();
             var context = new PromotionEvaluationContext
@@ -979,7 +981,9 @@ namespace VirtoCommerce.XCart.Tests.Aggregates
         {
             // Arrange
             var cartAggregate = GetValidCartAggregate();
-            cartAggregate.Cart.Items = new List<LineItem> { _fixture.Create<LineItem>() };
+            var lineItem = _fixture.Create<LineItem>();
+            lineItem.SelectedForCheckout = true;
+            cartAggregate.Cart.Items = [lineItem];
 
             var context = new PromotionEvaluationContext();
 

--- a/tests/VirtoCommerce.XCart.Tests/Aggregates/CartAggregateTests.cs
+++ b/tests/VirtoCommerce.XCart.Tests/Aggregates/CartAggregateTests.cs
@@ -135,8 +135,8 @@ namespace VirtoCommerce.XCart.Tests.Aggregates
 
                     return new Dictionary<string, CartProduct>
                     {
-                        { CartAggregate.GetCartProductKey(cartProduct1.Id, "USD"), cartProduct1 },
-                        { CartAggregate.GetCartProductKey(cartProduct2.Id, "USD"), cartProduct2 }
+                        { CartAggregate.FormatGetCartProductKey(cartProduct1.Id, "USD"), cartProduct1 },
+                        { CartAggregate.FormatGetCartProductKey(cartProduct2.Id, "USD"), cartProduct2 }
                     };
                 });
 
@@ -197,7 +197,7 @@ namespace VirtoCommerce.XCart.Tests.Aggregates
             var product = new CartProduct(new CatalogProduct { Id = "prod-1", IsActive = true, IsBuyable = true });
             var products = new Dictionary<string, CartProduct>
             {
-                { CartAggregate.GetCartProductKey(product.Id, "USD"), product },
+                { CartAggregate.FormatGetCartProductKey(product.Id, "USD"), product },
             };
 
             _cartProductServiceMock
@@ -1256,7 +1256,7 @@ namespace VirtoCommerce.XCart.Tests.Aggregates
 
             var products = new Dictionary<string, CartProduct>
             {
-                { CartAggregate.GetCartProductKey(cartProduct.Id, "USD"), cartProduct }
+                { CartAggregate.FormatGetCartProductKey(cartProduct.Id, "USD"), cartProduct }
             };
 
             // Setup mock to return variation product when requested
@@ -1339,7 +1339,7 @@ namespace VirtoCommerce.XCart.Tests.Aggregates
 
             var products = new Dictionary<string, CartProduct>
             {
-                { CartAggregate.GetCartProductKey(cartProduct.Id, "USD"), cartProduct }
+                { CartAggregate.FormatGetCartProductKey(cartProduct.Id, "USD"), cartProduct }
             };
 
             // Setup mock to return variation product when requested
@@ -1423,7 +1423,7 @@ namespace VirtoCommerce.XCart.Tests.Aggregates
 
             var products = new Dictionary<string, CartProduct>
             {
-                { CartAggregate.GetCartProductKey(cartProduct.Id, "USD"), cartProduct }
+                { CartAggregate.FormatGetCartProductKey(cartProduct.Id, "USD"), cartProduct }
             };
 
             // Setup mock to return product when requested
@@ -1540,12 +1540,12 @@ namespace VirtoCommerce.XCart.Tests.Aggregates
 
                     if (productPairs.Any(x => x.ProductId == "shirt-size-M"))
                     {
-                        products.Add(CartAggregate.GetCartProductKey(cartProducts[0].Id, "USD"), cartProducts[0]);
+                        products.Add(CartAggregate.FormatGetCartProductKey(cartProducts[0].Id, "USD"), cartProducts[0]);
                     }
 
                     if (productPairs.Any(x => x.ProductId == "shirt-size-L"))
                     {
-                        products.Add(CartAggregate.GetCartProductKey(cartProducts[1].Id, "USD"), cartProducts[1]);
+                        products.Add(CartAggregate.FormatGetCartProductKey(cartProducts[1].Id, "USD"), cartProducts[1]);
                     }
 
                     return products;
@@ -1687,7 +1687,7 @@ namespace VirtoCommerce.XCart.Tests.Aggregates
 
             var products = new Dictionary<string, CartProduct>
             {
-                { CartAggregate.GetCartProductKey(cartProduct.Id, "USD"), cartProduct }
+                { CartAggregate.FormatGetCartProductKey(cartProduct.Id, "USD"), cartProduct }
             };
 
             // Add configurable product to CartProducts
@@ -1830,12 +1830,12 @@ namespace VirtoCommerce.XCart.Tests.Aggregates
 
                      if (productPairs.Any(x => x.ProductId == "shirt-size-M"))
                      {
-                         products.Add(CartAggregate.GetCartProductKey(cartProducts[0].Id, "USD"), cartProducts[0]);
+                         products.Add(CartAggregate.FormatGetCartProductKey(cartProducts[0].Id, "USD"), cartProducts[0]);
                      }
 
                      if (productPairs.Any(x => x.ProductId == "shirt-size-L"))
                      {
-                         products.Add(CartAggregate.GetCartProductKey(cartProducts[1].Id, "USD"), cartProducts[1]);
+                         products.Add(CartAggregate.FormatGetCartProductKey(cartProducts[1].Id, "USD"), cartProducts[1]);
                      }
 
                      return products;
@@ -1933,7 +1933,7 @@ namespace VirtoCommerce.XCart.Tests.Aggregates
 
             var products = new Dictionary<string, CartProduct>
             {
-                { CartAggregate.GetCartProductKey(cartProduct.Id, "USD"), cartProduct }
+                { CartAggregate.FormatGetCartProductKey(cartProduct.Id, "USD"), cartProduct }
             };
 
             // Setup mock to return product
@@ -2000,7 +2000,7 @@ namespace VirtoCommerce.XCart.Tests.Aggregates
 
             var products = new Dictionary<string, CartProduct>
             {
-                { CartAggregate.GetCartProductKey(cartProduct.Id, "USD"), cartProduct }
+                { CartAggregate.FormatGetCartProductKey(cartProduct.Id, "USD"), cartProduct }
             };
 
             // Setup mock to return product
@@ -2273,12 +2273,12 @@ namespace VirtoCommerce.XCart.Tests.Aggregates
 
                     if (productPairs.Any(x => x.ProductId == "shirt-size-M"))
                     {
-                        products.Add(CartAggregate.GetCartProductKey(cartProducts[0].Id, "USD"), cartProducts[0]);
+                        products.Add(CartAggregate.FormatGetCartProductKey(cartProducts[0].Id, "USD"), cartProducts[0]);
                     }
 
                     if (productPairs.Any(x => x.ProductId == "color-blue"))
                     {
-                        products.Add(CartAggregate.GetCartProductKey(cartProducts[1].Id, "USD"), cartProducts[1]);
+                        products.Add(CartAggregate.FormatGetCartProductKey(cartProducts[1].Id, "USD"), cartProducts[1]);
                     }
 
                     return products;
@@ -2388,12 +2388,12 @@ namespace VirtoCommerce.XCart.Tests.Aggregates
 
                     if (productPairs.Any(x => x.ProductId == "shirt-size-M"))
                     {
-                        products.Add(CartAggregate.GetCartProductKey(cartProducts[0].Id, "USD"), cartProducts[0]);
+                        products.Add(CartAggregate.FormatGetCartProductKey(cartProducts[0].Id, "USD"), cartProducts[0]);
                     }
 
                     if (productPairs.Any(x => x.ProductId == "shirt-size-L"))
                     {
-                        products.Add(CartAggregate.GetCartProductKey(cartProducts[1].Id, "USD"), cartProducts[1]);
+                        products.Add(CartAggregate.FormatGetCartProductKey(cartProducts[1].Id, "USD"), cartProducts[1]);
                     }
 
                     return products;
@@ -2633,7 +2633,7 @@ namespace VirtoCommerce.XCart.Tests.Aggregates
             });
             var products = new Dictionary<string, CartProduct>
             {
-                { CartAggregate.GetCartProductKey(remainingProduct.Id, "USD"), remainingProduct }
+                { CartAggregate.FormatGetCartProductKey(remainingProduct.Id, "USD"), remainingProduct }
             };
 
             // Setup mock to return remaining products after removal

--- a/tests/VirtoCommerce.XCart.Tests/Aggregates/CartAggregateTests.cs
+++ b/tests/VirtoCommerce.XCart.Tests/Aggregates/CartAggregateTests.cs
@@ -101,10 +101,6 @@ namespace VirtoCommerce.XCart.Tests.Aggregates
             var shoppingCart = _fixture.Create<ShoppingCart>();
             shoppingCart.Items = Enumerable.Empty<LineItem>().ToList();
 
-            _cartProductServiceMock
-                .Setup(x => x.GetCartProductsByIdsAsync(It.IsAny<CartAggregate>(), new[] { productId }))
-                .ReturnsAsync(new List<CartProduct> { new(new CatalogProduct()) });
-
             // Act
             var aggregateAfterAddItem = await _aggregate.AddItemAsync(newCartItem);
 
@@ -131,14 +127,18 @@ namespace VirtoCommerce.XCart.Tests.Aggregates
             var newCartItems = new List<NewCartItem> { newCartItem1, newCartItem2 };
 
             _cartProductServiceMock
-                .Setup(x => x.GetCartProductsByIdsAsync(It.IsAny<CartAggregate>(), new[] { productId1, productId2 }))
-                .ReturnsAsync(
-                    new List<CartProduct>
-                    {
-                        new(new CatalogProduct { Id = productId1, IsActive = true, IsBuyable = true }),
-                        new(new CatalogProduct { Id = productId2, IsActive = true, IsBuyable = true }),
-                    });
+                .Setup(x => x.GetCartProductsAsync(It.IsAny<CartAggregate>(), It.IsAny<IList<(string CurrencyCode, string ProductId)>>()))
+                .ReturnsAsync((CartAggregate _, IList<(string CurrencyCode, string ProductId)> productPairs) =>
+                {
+                    var cartProduct1 = new CartProduct(new CatalogProduct { Id = productId1, IsActive = true, IsBuyable = true });
+                    var cartProduct2 = new CartProduct(new CatalogProduct { Id = productId2, IsActive = true, IsBuyable = true });
 
+                    return new Dictionary<string, CartProduct>
+                    {
+                        { CartAggregate.GetCartProductKey(cartProduct1.Id, "USD"), cartProduct1 },
+                        { CartAggregate.GetCartProductKey(cartProduct2.Id, "USD"), cartProduct2 }
+                    };
+                });
 
             _mapperMock
                 .Setup(m => m.Map(It.IsAny<CartProduct>(), It.IsAny<Action<IMappingOperationOptions<object, LineItem>>>()))
@@ -166,8 +166,8 @@ namespace VirtoCommerce.XCart.Tests.Aggregates
             var newCartItems = new List<NewCartItem> { new("missing-product", 1) };
 
             _cartProductServiceMock
-                .Setup(x => x.GetCartProductsByIdsAsync(It.IsAny<CartAggregate>(), It.IsAny<IList<string>>()))
-                .ReturnsAsync(new List<CartProduct>());
+                .Setup(x => x.GetCartProductsAsync(It.IsAny<CartAggregate>(), It.IsAny<IList<(string CurrencyCode, string ProductId)>>()))
+                .ReturnsAsync(new Dictionary<string, CartProduct>());
 
             var cartAggregate = GetValidCartAggregate();
             cartAggregate.ValidationRuleSet = ["default"];
@@ -195,9 +195,14 @@ namespace VirtoCommerce.XCart.Tests.Aggregates
             };
 
             var product = new CartProduct(new CatalogProduct { Id = "prod-1", IsActive = true, IsBuyable = true });
+            var products = new Dictionary<string, CartProduct>
+            {
+                { CartAggregate.GetCartProductKey(product.Id, "USD"), product },
+            };
+
             _cartProductServiceMock
-                .Setup(x => x.GetCartProductsByIdsAsync(It.IsAny<CartAggregate>(), It.IsAny<IList<string>>()))
-                .ReturnsAsync(new List<CartProduct> { product });
+                .Setup(x => x.GetCartProductsAsync(It.IsAny<CartAggregate>(), It.IsAny<IList<(string CurrencyCode, string ProductId)>>()))
+                .ReturnsAsync(products);
 
             _mapperMock
                 .Setup(m => m.Map(It.IsAny<CartProduct>(), It.IsAny<Action<IMappingOperationOptions<object, LineItem>>>()))
@@ -575,7 +580,7 @@ namespace VirtoCommerce.XCart.Tests.Aggregates
             sourceAggregate.Cart.Shipments = Enumerable.Empty<Shipment>().ToList();
             sourceAggregate.Cart.Payments = Enumerable.Empty<Payment>().ToList();
 
-            var currencyCode = "CommonCurrencyCode";
+            var currencyCode = "USD";
 
             var sourceProduct1 = _fixture.Create<CartProduct>();
             var sourceProduct2 = _fixture.Create<CartProduct>();
@@ -1208,6 +1213,7 @@ namespace VirtoCommerce.XCart.Tests.Aggregates
                 ProductId = "configurable-product",
                 IsConfigured = true,
                 ConfigurationItems = new List<ConfigurationItem>(),
+                Currency = "USD",
             };
             cartAggregate.Cart.Items.Add(lineItem);
 
@@ -1244,9 +1250,18 @@ namespace VirtoCommerce.XCart.Tests.Aggregates
                 },
             };
 
+            var products = new Dictionary<string, CartProduct>
+            {
+                { CartAggregate.GetCartProductKey(cartProduct.Id, "USD"), cartProduct }
+            };
+
             // Setup mock to return variation product when requested
-            _cartProductServiceMock.Setup(x => x.GetCartProductsByIdsAsync(It.IsAny<CartAggregate>(), It.IsAny<string[]>()))
-                .ReturnsAsync((CartAggregate _, string[] ids) => ids.Contains("shirt-size-M") ? [cartProduct] : Array.Empty<CartProduct>());
+            _cartProductServiceMock
+                .Setup(x => x.GetCartProductsAsync(It.IsAny<CartAggregate>(), It.IsAny<IList<(string CurrencyCode, string ProductId)>>()))
+                .ReturnsAsync((CartAggregate _, IList<(string CurrencyCode, string ProductId)> productPairs) =>
+                {
+                    return productPairs.Any(x => x.ProductId == "shirt-size-M") ? products : [];
+                });
 
             // Act
             await cartAggregate.AddConfigurationItemAsync(lineItem.Id, configSection);
@@ -1281,6 +1296,7 @@ namespace VirtoCommerce.XCart.Tests.Aggregates
                 ProductId = "configurable-product",
                 IsConfigured = true,
                 ConfigurationItems = new List<ConfigurationItem> { existingConfigItem },
+                Currency = "USD",
             };
             cartAggregate.Cart.Items.Add(lineItem);
 
@@ -1317,9 +1333,19 @@ namespace VirtoCommerce.XCart.Tests.Aggregates
                 },
             };
 
+            var products = new Dictionary<string, CartProduct>
+            {
+                { CartAggregate.GetCartProductKey(cartProduct.Id, "USD"), cartProduct }
+            };
+
             // Setup mock to return variation product when requested
-            _cartProductServiceMock.Setup(x => x.GetCartProductsByIdsAsync(It.IsAny<CartAggregate>(), It.IsAny<string[]>()))
-                .ReturnsAsync((CartAggregate _, string[] ids) => ids.Contains("shirt-size-M") ? [cartProduct] : Array.Empty<CartProduct>());
+            _cartProductServiceMock
+                .Setup(x => x.GetCartProductsAsync(It.IsAny<CartAggregate>(), It.IsAny<IList<(string CurrencyCode, string ProductId)>>()))
+                .ReturnsAsync((CartAggregate _, IList<(string CurrencyCode, string ProductId)> productPairs) =>
+                {
+                    return productPairs.Any(x => x.ProductId == "shirt-size-M") ? products : [];
+                });
+
 
             // Act
             await cartAggregate.AddConfigurationItemAsync(lineItem.Id, configSection);
@@ -1354,6 +1380,7 @@ namespace VirtoCommerce.XCart.Tests.Aggregates
                 ProductId = "configurable-product",
                 IsConfigured = true,
                 ConfigurationItems = new List<ConfigurationItem> { existingConfigItem },
+                Currency = "USD",
             };
             cartAggregate.Cart.Items.Add(lineItem);
 
@@ -1390,9 +1417,18 @@ namespace VirtoCommerce.XCart.Tests.Aggregates
                 },
             };
 
+            var products = new Dictionary<string, CartProduct>
+            {
+                { CartAggregate.GetCartProductKey(cartProduct.Id, "USD"), cartProduct }
+            };
+
             // Setup mock to return product when requested
-            _cartProductServiceMock.Setup(x => x.GetCartProductsByIdsAsync(It.IsAny<CartAggregate>(), It.IsAny<string[]>()))
-                .ReturnsAsync((CartAggregate _, string[] ids) => ids.Contains("new-color") || ids.Contains("old-color") ? [cartProduct] : Array.Empty<CartProduct>());
+            _cartProductServiceMock
+                .Setup(x => x.GetCartProductsAsync(It.IsAny<CartAggregate>(), It.IsAny<IList<(string CurrencyCode, string ProductId)>>()))
+                .ReturnsAsync((CartAggregate _, IList<(string CurrencyCode, string ProductId)> productPairs) =>
+                {
+                    return productPairs.Any(x => x.ProductId == "new-color" || x.ProductId == "old-color") ? products : [];
+                });
 
             // Act
             await cartAggregate.AddConfigurationItemAsync(lineItem.Id, configSection);
@@ -1441,6 +1477,7 @@ namespace VirtoCommerce.XCart.Tests.Aggregates
                 ProductId = "configurable-product",
                 IsConfigured = true,
                 ConfigurationItems = new List<ConfigurationItem>(),
+                Currency = "USD",
             };
             cartAggregate.Cart.Items.Add(lineItem);
 
@@ -1490,25 +1527,24 @@ namespace VirtoCommerce.XCart.Tests.Aggregates
                 }),
             };
 
-            // Add configurable product to CartProducts
-            cartAggregate.CartProducts[cartAggregate.GetCartProductKey(lineItem)] = configurableProduct;
-
             // Setup mock to return products when requested
-            _cartProductServiceMock.Setup(x => x.GetCartProductsByIdsAsync(It.IsAny<CartAggregate>(), It.IsAny<string[]>()))
-                .ReturnsAsync((CartAggregate _, string[] ids) =>
+            _cartProductServiceMock
+                .Setup(x => x.GetCartProductsAsync(It.IsAny<CartAggregate>(), It.IsAny<IList<(string CurrencyCode, string ProductId)>>()))
+                .ReturnsAsync((CartAggregate _, IList<(string CurrencyCode, string ProductId)> productPairs) =>
                 {
-                    var result = new List<CartProduct>();
-                    if (ids.Contains("shirt-size-M"))
+                    var products = new Dictionary<string, CartProduct>();
+
+                    if (productPairs.Any(x => x.ProductId == "shirt-size-M"))
                     {
-                        result.Add(cartProducts[0]);
+                        products.Add(CartAggregate.GetCartProductKey(cartProducts[0].Id, "USD"), cartProducts[0]);
                     }
 
-                    if (ids.Contains("shirt-size-L"))
+                    if (productPairs.Any(x => x.ProductId == "shirt-size-L"))
                     {
-                        result.Add(cartProducts[1]);
+                        products.Add(CartAggregate.GetCartProductKey(cartProducts[1].Id, "USD"), cartProducts[1]);
                     }
 
-                    return result.ToArray();
+                    return products;
                 });
 
             // Act
@@ -1623,6 +1659,7 @@ namespace VirtoCommerce.XCart.Tests.Aggregates
                 ProductId = "configurable-product",
                 IsConfigured = true,
                 ConfigurationItems = new List<ConfigurationItem> { configItem },
+                Currency = "USD",
             };
             cartAggregate.Cart.Items.Add(lineItem);
 
@@ -1644,12 +1681,21 @@ namespace VirtoCommerce.XCart.Tests.Aggregates
                 CategoryId = "category1",
             });
 
+            var products = new Dictionary<string, CartProduct>
+            {
+                { CartAggregate.GetCartProductKey(cartProduct.Id, "USD"), cartProduct }
+            };
+
             // Add configurable product to CartProducts
             cartAggregate.CartProducts[cartAggregate.GetCartProductKey(lineItem)] = configurableProduct;
 
             // Setup mock to return product when requested
-            _cartProductServiceMock.Setup(x => x.GetCartProductsByIdsAsync(It.IsAny<CartAggregate>(), It.IsAny<string[]>()))
-                .ReturnsAsync((CartAggregate _, string[] ids) => ids.Contains("shirt-size-M") ? [cartProduct] : Array.Empty<CartProduct>());
+            _cartProductServiceMock
+                .Setup(x => x.GetCartProductsAsync(It.IsAny<CartAggregate>(), It.IsAny<IList<(string CurrencyCode, string ProductId)>>()))
+                .ReturnsAsync((CartAggregate _, IList<(string CurrencyCode, string ProductId)> productPairs) =>
+                {
+                    return productPairs.Any(x => x.ProductId == "shirt-size-M") ? products : [];
+                });
 
             var configSection = new ProductConfigurationSection
             {
@@ -1679,10 +1725,6 @@ namespace VirtoCommerce.XCart.Tests.Aggregates
                 ConfigurationItems = new List<ConfigurationItem>(),
             };
             cartAggregate.Cart.Items.Add(lineItem);
-
-            // Setup mock to return empty array (product not available)
-            _cartProductServiceMock.Setup(x => x.GetCartProductsByIdsAsync(It.IsAny<CartAggregate>(), It.IsAny<string[]>()))
-                .ReturnsAsync(Array.Empty<CartProduct>());
 
             var configSection = new ProductConfigurationSection
             {
@@ -1741,6 +1783,7 @@ namespace VirtoCommerce.XCart.Tests.Aggregates
                 ProductId = "configurable-product",
                 IsConfigured = true,
                 ConfigurationItems = configItems,
+                Currency = "USD",
             };
             cartAggregate.Cart.Items.Add(lineItem);
 
@@ -1775,22 +1818,24 @@ namespace VirtoCommerce.XCart.Tests.Aggregates
             };
 
             // Setup mock to return products when requested
-            _cartProductServiceMock.Setup(x => x.GetCartProductsByIdsAsync(It.IsAny<CartAggregate>(), It.IsAny<string[]>()))
-                .ReturnsAsync((CartAggregate _, string[] ids) =>
-                {
-                    var result = new List<CartProduct>();
-                    if (ids.Contains("shirt-size-M"))
-                    {
-                        result.Add(cartProducts[0]);
-                    }
+            _cartProductServiceMock
+                 .Setup(x => x.GetCartProductsAsync(It.IsAny<CartAggregate>(), It.IsAny<IList<(string CurrencyCode, string ProductId)>>()))
+                 .ReturnsAsync((CartAggregate _, IList<(string CurrencyCode, string ProductId)> productPairs) =>
+                 {
+                     var products = new Dictionary<string, CartProduct>();
 
-                    if (ids.Contains("shirt-size-L"))
-                    {
-                        result.Add(cartProducts[1]);
-                    }
+                     if (productPairs.Any(x => x.ProductId == "shirt-size-M"))
+                     {
+                         products.Add(CartAggregate.GetCartProductKey(cartProducts[0].Id, "USD"), cartProducts[0]);
+                     }
 
-                    return result.ToArray();
-                });
+                     if (productPairs.Any(x => x.ProductId == "shirt-size-L"))
+                     {
+                         products.Add(CartAggregate.GetCartProductKey(cartProducts[1].Id, "USD"), cartProducts[1]);
+                     }
+
+                     return products;
+                 });
 
             var configSections = new List<ProductConfigurationSection>
             {
@@ -1857,6 +1902,7 @@ namespace VirtoCommerce.XCart.Tests.Aggregates
                 ProductId = "configurable-product",
                 IsConfigured = true,
                 ConfigurationItems = new List<ConfigurationItem>(),
+                Currency = "USD",
             };
             cartAggregate.Cart.Items.Add(lineItem);
 
@@ -1881,9 +1927,18 @@ namespace VirtoCommerce.XCart.Tests.Aggregates
                 CategoryId = "category1",
             });
 
+            var products = new Dictionary<string, CartProduct>
+            {
+                { CartAggregate.GetCartProductKey(cartProduct.Id, "USD"), cartProduct }
+            };
+
             // Setup mock to return product
-            _cartProductServiceMock.Setup(x => x.GetCartProductsByIdsAsync(It.IsAny<CartAggregate>(), It.IsAny<string[]>()))
-                .ReturnsAsync((CartAggregate _, string[] ids) => ids.Contains("shirt-size-M") ? [cartProduct] : Array.Empty<CartProduct>());
+            _cartProductServiceMock
+                .Setup(x => x.GetCartProductsAsync(It.IsAny<CartAggregate>(), It.IsAny<IList<(string CurrencyCode, string ProductId)>>()))
+                .ReturnsAsync((CartAggregate _, IList<(string CurrencyCode, string ProductId)> productPairs) =>
+                {
+                    return productPairs.Any(x => x.ProductId == "shirt-size-M") ? products : [];
+                });
 
             var configSections = new List<ProductConfigurationSection>
             {
@@ -1914,6 +1969,7 @@ namespace VirtoCommerce.XCart.Tests.Aggregates
                 ProductId = "configurable-product",
                 IsConfigured = true,
                 ConfigurationItems = new List<ConfigurationItem>(),
+                Currency = "USD",
             };
             cartAggregate.Cart.Items.Add(lineItem);
 
@@ -1938,9 +1994,18 @@ namespace VirtoCommerce.XCart.Tests.Aggregates
                 CategoryId = "category1",
             });
 
+            var products = new Dictionary<string, CartProduct>
+            {
+                { CartAggregate.GetCartProductKey(cartProduct.Id, "USD"), cartProduct }
+            };
+
             // Setup mock to return product
-            _cartProductServiceMock.Setup(x => x.GetCartProductsByIdsAsync(It.IsAny<CartAggregate>(), It.IsAny<string[]>()))
-                .ReturnsAsync((CartAggregate _, string[] ids) => ids.Contains("shirt-size-M") ? [cartProduct] : Array.Empty<CartProduct>());
+            _cartProductServiceMock
+                .Setup(x => x.GetCartProductsAsync(It.IsAny<CartAggregate>(), It.IsAny<IList<(string CurrencyCode, string ProductId)>>()))
+                .ReturnsAsync((CartAggregate _, IList<(string CurrencyCode, string ProductId)> productPairs) =>
+                {
+                    return productPairs.Any(x => x.ProductId == "shirt-size-M") ? products : [];
+                });
 
             var configSections = new List<ProductConfigurationSection>
             {
@@ -2162,6 +2227,7 @@ namespace VirtoCommerce.XCart.Tests.Aggregates
                 ProductId = "configurable-product",
                 IsConfigured = true,
                 ConfigurationItems = new List<ConfigurationItem>(),
+                Currency = "USD",
             };
             cartAggregate.Cart.Items.Add(lineItem);
 
@@ -2195,21 +2261,23 @@ namespace VirtoCommerce.XCart.Tests.Aggregates
                 }),
             };
 
-            _cartProductServiceMock.Setup(x => x.GetCartProductsByIdsAsync(It.IsAny<CartAggregate>(), It.IsAny<string[]>()))
-                .ReturnsAsync((CartAggregate _, string[] ids) =>
+            _cartProductServiceMock
+                .Setup(x => x.GetCartProductsAsync(It.IsAny<CartAggregate>(), It.IsAny<IList<(string CurrencyCode, string ProductId)>>()))
+                .ReturnsAsync((CartAggregate _, IList<(string CurrencyCode, string ProductId)> productPairs) =>
                 {
-                    var result = new List<CartProduct>();
-                    if (ids.Contains("shirt-size-M"))
+                    var products = new Dictionary<string, CartProduct>();
+
+                    if (productPairs.Any(x => x.ProductId == "shirt-size-M"))
                     {
-                        result.Add(cartProducts[0]);
+                        products.Add(CartAggregate.GetCartProductKey(cartProducts[0].Id, "USD"), cartProducts[0]);
                     }
 
-                    if (ids.Contains("color-blue"))
+                    if (productPairs.Any(x => x.ProductId == "color-blue"))
                     {
-                        result.Add(cartProducts[1]);
+                        products.Add(CartAggregate.GetCartProductKey(cartProducts[1].Id, "USD"), cartProducts[1]);
                     }
 
-                    return result.ToArray();
+                    return products;
                 });
 
             var configSections = new List<ProductConfigurationSection>
@@ -2274,6 +2342,7 @@ namespace VirtoCommerce.XCart.Tests.Aggregates
                 ProductId = "configurable-product",
                 IsConfigured = true,
                 ConfigurationItems = existingConfigItems,
+                Currency = "USD",
             };
             cartAggregate.Cart.Items.Add(lineItem);
 
@@ -2307,21 +2376,23 @@ namespace VirtoCommerce.XCart.Tests.Aggregates
                 }),
             };
 
-            _cartProductServiceMock.Setup(x => x.GetCartProductsByIdsAsync(It.IsAny<CartAggregate>(), It.IsAny<string[]>()))
-                .ReturnsAsync((CartAggregate _, string[] ids) =>
+            _cartProductServiceMock
+                .Setup(x => x.GetCartProductsAsync(It.IsAny<CartAggregate>(), It.IsAny<IList<(string CurrencyCode, string ProductId)>>()))
+                .ReturnsAsync((CartAggregate _, IList<(string CurrencyCode, string ProductId)> productPairs) =>
                 {
-                    var result = new List<CartProduct>();
-                    if (ids.Contains("shirt-size-M"))
+                    var products = new Dictionary<string, CartProduct>();
+
+                    if (productPairs.Any(x => x.ProductId == "shirt-size-M"))
                     {
-                        result.Add(cartProducts[0]);
+                        products.Add(CartAggregate.GetCartProductKey(cartProducts[0].Id, "USD"), cartProducts[0]);
                     }
 
-                    if (ids.Contains("shirt-size-L"))
+                    if (productPairs.Any(x => x.ProductId == "shirt-size-L"))
                     {
-                        result.Add(cartProducts[1]);
+                        products.Add(CartAggregate.GetCartProductKey(cartProducts[1].Id, "USD"), cartProducts[1]);
                     }
 
-                    return result.ToArray();
+                    return products;
                 });
 
             var configSections = new List<ProductConfigurationSection>
@@ -2556,10 +2627,18 @@ namespace VirtoCommerce.XCart.Tests.Aggregates
                 CatalogId = "catalog1",
                 CategoryId = "category1",
             });
+            var products = new Dictionary<string, CartProduct>
+            {
+                { CartAggregate.GetCartProductKey(remainingProduct.Id, "USD"), remainingProduct }
+            };
 
             // Setup mock to return remaining products after removal
-            _cartProductServiceMock.Setup(x => x.GetCartProductsByIdsAsync(It.IsAny<CartAggregate>(), It.IsAny<string[]>()))
-                .ReturnsAsync((CartAggregate _, string[] ids) => ids.Contains("shirt-size-XL") ? [remainingProduct] : Array.Empty<CartProduct>());
+            _cartProductServiceMock
+                .Setup(x => x.GetCartProductsAsync(It.IsAny<CartAggregate>(), It.IsAny<IList<(string CurrencyCode, string ProductId)>>()))
+                .ReturnsAsync((CartAggregate _, IList<(string CurrencyCode, string ProductId)> productPairs) =>
+                {
+                    return productPairs.Any(x => x.ProductId == "shirt-size-XL") ? products : [];
+                });
 
             // Act
             await cartAggregate.RemoveConfigurationItemsAsync(lineItem.Id, configSections);
@@ -2713,9 +2792,6 @@ namespace VirtoCommerce.XCart.Tests.Aggregates
                 Type = "Variation",
                 Option = new ConfigurableProductOption { ProductId = "unavailable-product", Quantity = 1 },
             };
-
-            _cartProductServiceMock.Setup(x => x.GetCartProductsByIdsAsync(It.IsAny<CartAggregate>(), It.IsAny<string[]>()))
-                .ReturnsAsync([]);
 
             // Act
             await cartAggregate.AddConfigurationItemAsync(lineItem.Id, configSection);
@@ -2940,15 +3016,16 @@ namespace VirtoCommerce.XCart.Tests.Aggregates
             };
             cartAggregate.Cart.Items.Add(lineItem);
 
-            _cartProductServiceMock.Setup(x => x.GetCartProductsByIdsAsync(It.IsAny<CartAggregate>(), It.IsAny<IList<string>>()))
-                .ReturnsAsync([]);
+            _cartProductServiceMock
+                .Setup(x => x.GetCartProductsAsync(It.IsAny<CartAggregate>(), It.IsAny<IList<(string CurrencyCode, string ProductId)>>()))
+                .ReturnsAsync(new Dictionary<string, CartProduct>());
 
             // Act
             await cartAggregate.ChangeConfigurationItemSelectedAsync(lineItem.Id, VariationSectionRef("size", "p1"), false);
 
             // Assert
             configItem.SelectedForCheckout.Should().BeFalse();
-            _cartProductServiceMock.Verify(x => x.GetCartProductsByIdsAsync(cartAggregate, It.IsAny<IList<string>>()), Times.Once);
+            _cartProductServiceMock.Verify(x => x.GetCartProductsAsync(cartAggregate, It.IsAny<IList<(string CurrencyCode, string ProductId)>>()), Times.Once);
         }
 
         [Fact]
@@ -2965,9 +3042,6 @@ namespace VirtoCommerce.XCart.Tests.Aggregates
                 ConfigurationItems = new List<ConfigurationItem> { textConfigItem },
             };
             cartAggregate.Cart.Items.Add(lineItem);
-
-            _cartProductServiceMock.Setup(x => x.GetCartProductsByIdsAsync(It.IsAny<CartAggregate>(), It.IsAny<IList<string>>()))
-                .ReturnsAsync([]);
 
             var textSection = new ProductConfigurationSection { SectionId = "label", Type = "Text" };
 
@@ -2995,8 +3069,9 @@ namespace VirtoCommerce.XCart.Tests.Aggregates
             };
             cartAggregate.Cart.Items.Add(lineItem);
 
-            _cartProductServiceMock.Setup(x => x.GetCartProductsByIdsAsync(It.IsAny<CartAggregate>(), It.IsAny<IList<string>>()))
-                .ReturnsAsync([]);
+            _cartProductServiceMock
+                .Setup(x => x.GetCartProductsAsync(It.IsAny<CartAggregate>(), It.IsAny<IList<(string CurrencyCode, string ProductId)>>()))
+                .ReturnsAsync(new Dictionary<string, CartProduct>());
 
             // Act
             await cartAggregate.ChangeConfigurationItemsSelectedAsync(
@@ -3032,8 +3107,9 @@ namespace VirtoCommerce.XCart.Tests.Aggregates
                 ConfigurationItems = new List<ConfigurationItem> { configInOther },
             });
 
-            _cartProductServiceMock.Setup(x => x.GetCartProductsByIdsAsync(It.IsAny<CartAggregate>(), It.IsAny<IList<string>>()))
-                .ReturnsAsync([]);
+            _cartProductServiceMock
+                .Setup(x => x.GetCartProductsAsync(It.IsAny<CartAggregate>(), It.IsAny<IList<(string CurrencyCode, string ProductId)>>()))
+                .ReturnsAsync(new Dictionary<string, CartProduct>());
 
             // Act — section ref matches both lineItems' configItems, but lineItemId scopes the lookup.
             await cartAggregate.ChangeConfigurationItemsSelectedAsync("target-line", [VariationSectionRef("size", "p1")], false);
@@ -3054,7 +3130,7 @@ namespace VirtoCommerce.XCart.Tests.Aggregates
 
             // Assert
             cartAggregate.OperationValidationErrors.Should().Contain(x => x.ErrorCode == "CONFIGURED_LINE_ITEM_NOT_FOUND");
-            _cartProductServiceMock.Verify(x => x.GetCartProductsByIdsAsync(It.IsAny<CartAggregate>(), It.IsAny<IList<string>>()), Times.Never);
+            _cartProductServiceMock.Verify(x => x.GetCartProductsAsync(It.IsAny<CartAggregate>(), It.IsAny<IList<(string CurrencyCode, string ProductId)>>()), Times.Never);
         }
 
         [Fact]
@@ -3077,7 +3153,7 @@ namespace VirtoCommerce.XCart.Tests.Aggregates
 
             // Assert
             configItem.SelectedForCheckout.Should().BeFalse();
-            _cartProductServiceMock.Verify(x => x.GetCartProductsByIdsAsync(It.IsAny<CartAggregate>(), It.IsAny<IList<string>>()), Times.Never);
+            _cartProductServiceMock.Verify(x => x.GetCartProductsAsync(It.IsAny<CartAggregate>(), It.IsAny<IList<(string CurrencyCode, string ProductId)>>()), Times.Never);
         }
 
         [Fact]
@@ -3100,7 +3176,7 @@ namespace VirtoCommerce.XCart.Tests.Aggregates
 
             // Assert
             configItem.SelectedForCheckout.Should().BeTrue("no item matched, nothing should change");
-            _cartProductServiceMock.Verify(x => x.GetCartProductsByIdsAsync(It.IsAny<CartAggregate>(), It.IsAny<IList<string>>()), Times.Never);
+            _cartProductServiceMock.Verify(x => x.GetCartProductsAsync(It.IsAny<CartAggregate>(), It.IsAny<IList<(string CurrencyCode, string ProductId)>>()), Times.Never);
         }
 
         [Fact]
@@ -3123,7 +3199,7 @@ namespace VirtoCommerce.XCart.Tests.Aggregates
 
             // Assert
             configItem.SelectedForCheckout.Should().BeTrue("empty section list must not flip anything");
-            _cartProductServiceMock.Verify(x => x.GetCartProductsByIdsAsync(It.IsAny<CartAggregate>(), It.IsAny<IList<string>>()), Times.Never);
+            _cartProductServiceMock.Verify(x => x.GetCartProductsAsync(It.IsAny<CartAggregate>(), It.IsAny<IList<(string CurrencyCode, string ProductId)>>()), Times.Never);
         }
 
         [Fact]
@@ -3142,8 +3218,9 @@ namespace VirtoCommerce.XCart.Tests.Aggregates
             };
             cartAggregate.Cart.Items.Add(lineItem);
 
-            _cartProductServiceMock.Setup(x => x.GetCartProductsByIdsAsync(It.IsAny<CartAggregate>(), It.IsAny<IList<string>>()))
-                .ReturnsAsync([]);
+            _cartProductServiceMock
+                .Setup(x => x.GetCartProductsAsync(It.IsAny<CartAggregate>(), It.IsAny<IList<(string CurrencyCode, string ProductId)>>()))
+                .ReturnsAsync(new Dictionary<string, CartProduct>());
 
             // Act
             await cartAggregate.ChangeAllConfigurationItemsSelectedAsync(lineItem.Id, false);
@@ -3151,7 +3228,7 @@ namespace VirtoCommerce.XCart.Tests.Aggregates
             // Assert
             configA.SelectedForCheckout.Should().BeFalse();
             configB.SelectedForCheckout.Should().BeFalse();
-            _cartProductServiceMock.Verify(x => x.GetCartProductsByIdsAsync(cartAggregate, It.IsAny<IList<string>>()), Times.Once);
+            _cartProductServiceMock.Verify(x => x.GetCartProductsAsync(cartAggregate, It.IsAny<IList<(string CurrencyCode, string ProductId)>>()), Times.Once);
         }
 
         [Fact]
@@ -3165,7 +3242,7 @@ namespace VirtoCommerce.XCart.Tests.Aggregates
 
             // Assert
             cartAggregate.OperationValidationErrors.Should().Contain(x => x.ErrorCode == "CONFIGURED_LINE_ITEM_NOT_FOUND");
-            _cartProductServiceMock.Verify(x => x.GetCartProductsByIdsAsync(It.IsAny<CartAggregate>(), It.IsAny<IList<string>>()), Times.Never);
+            _cartProductServiceMock.Verify(x => x.GetCartProductsAsync(It.IsAny<CartAggregate>(), It.IsAny<IList<(string CurrencyCode, string ProductId)>>()), Times.Never);
         }
 
         [Fact]
@@ -3188,7 +3265,7 @@ namespace VirtoCommerce.XCart.Tests.Aggregates
             await cartAggregate.ChangeAllConfigurationItemsSelectedAsync(lineItem.Id, false);
 
             // Assert
-            _cartProductServiceMock.Verify(x => x.GetCartProductsByIdsAsync(It.IsAny<CartAggregate>(), It.IsAny<IList<string>>()), Times.Never);
+            _cartProductServiceMock.Verify(x => x.GetCartProductsAsync(It.IsAny<CartAggregate>(), It.IsAny<IList<(string CurrencyCode, string ProductId)>>()), Times.Never);
         }
 
         #endregion ChangeConfigurationItemSelected

--- a/tests/VirtoCommerce.XCart.Tests/Aggregates/CartAggregateTests.cs
+++ b/tests/VirtoCommerce.XCart.Tests/Aggregates/CartAggregateTests.cs
@@ -575,14 +575,13 @@ namespace VirtoCommerce.XCart.Tests.Aggregates
             sourceAggregate.Cart.Shipments = Enumerable.Empty<Shipment>().ToList();
             sourceAggregate.Cart.Payments = Enumerable.Empty<Payment>().ToList();
 
+            var currencyCode = "CommonCurrencyCode";
+
             var sourceProduct1 = _fixture.Create<CartProduct>();
             var sourceProduct2 = _fixture.Create<CartProduct>();
 
             sourceProduct1.Id = "source1";
             sourceProduct2.Id = "source2";
-
-            sourceAggregate.CartProducts.Add(sourceProduct1.Id, sourceProduct1);
-            sourceAggregate.CartProducts.Add(sourceProduct2.Id, sourceProduct2);
 
             var sourceLineItem1 = _fixture.Create<LineItem>();
             sourceLineItem1.ProductId = sourceProduct1.Id;
@@ -592,7 +591,12 @@ namespace VirtoCommerce.XCart.Tests.Aggregates
             sourceLineItem2.ProductId = sourceProduct2.Id;
             sourceLineItem2.IsConfigured = false;
 
+            sourceLineItem1.Currency = sourceLineItem2.Currency = currencyCode;
+
             sourceAggregate.Cart.Items = new List<LineItem> { sourceLineItem1, sourceLineItem2 };
+
+            sourceAggregate.CartProducts.Add(sourceAggregate.GetCartProductKey(sourceLineItem1), sourceProduct1);
+            sourceAggregate.CartProducts.Add(sourceAggregate.GetCartProductKey(sourceLineItem2), sourceProduct2);
 
             var destinationAggregate = GetValidCartAggregate();
 
@@ -607,6 +611,8 @@ namespace VirtoCommerce.XCart.Tests.Aggregates
             destinationLineItem2.ProductId = sourceProduct2.Id;
             destinationLineItem2.IsConfigured = false;
             var quantity = destinationLineItem2.Quantity;
+
+            destinationLineItem1.Currency = destinationLineItem2.Currency = currencyCode;
 
             destinationAggregate.Cart.Items = new List<LineItem> { destinationLineItem1, destinationLineItem2 };
 
@@ -762,7 +768,6 @@ namespace VirtoCommerce.XCart.Tests.Aggregates
 
             var sharedProduct = _fixture.Create<CartProduct>();
             sharedProduct.Id = "shared-product";
-            sourceAggregate.CartProducts.Add(sharedProduct.Id, sharedProduct);
 
             var sourceConfiguredItem = _fixture.Create<LineItem>();
             sourceConfiguredItem.ProductId = sharedProduct.Id;
@@ -774,6 +779,7 @@ namespace VirtoCommerce.XCart.Tests.Aggregates
             var sourceQuantity = sourceConfiguredItem.Quantity;
 
             sourceAggregate.Cart.Items = new List<LineItem> { sourceConfiguredItem };
+            sourceAggregate.CartProducts.Add(sourceAggregate.GetCartProductKey(sourceConfiguredItem), sharedProduct);
 
             var destinationAggregate = GetValidCartAggregate();
 
@@ -811,7 +817,6 @@ namespace VirtoCommerce.XCart.Tests.Aggregates
 
             var sharedProduct = _fixture.Create<CartProduct>();
             sharedProduct.Id = "shared-product";
-            sourceAggregate.CartProducts.Add(sharedProduct.Id, sharedProduct);
 
             var sourceConfiguredItem = _fixture.Create<LineItem>();
             sourceConfiguredItem.ProductId = sharedProduct.Id;
@@ -823,6 +828,7 @@ namespace VirtoCommerce.XCart.Tests.Aggregates
             var sourceQuantity = sourceConfiguredItem.Quantity;
 
             sourceAggregate.Cart.Items = new List<LineItem> { sourceConfiguredItem };
+            sourceAggregate.CartProducts.Add(sourceAggregate.GetCartProductKey(sourceConfiguredItem), sharedProduct);
 
             var destinationAggregate = GetValidCartAggregate();
 
@@ -858,7 +864,6 @@ namespace VirtoCommerce.XCart.Tests.Aggregates
 
             var sharedProduct = _fixture.Create<CartProduct>();
             sharedProduct.Id = "shared-product";
-            sourceAggregate.CartProducts.Add(sharedProduct.Id, sharedProduct);
 
             var sourceSimpleItem = _fixture.Create<LineItem>();
             sourceSimpleItem.ProductId = sharedProduct.Id;
@@ -867,6 +872,7 @@ namespace VirtoCommerce.XCart.Tests.Aggregates
             var sourceQuantity = sourceSimpleItem.Quantity;
 
             sourceAggregate.Cart.Items = new List<LineItem> { sourceSimpleItem };
+            sourceAggregate.CartProducts.Add(sourceAggregate.GetCartProductKey(sourceSimpleItem), sharedProduct);
 
             var destinationAggregate = GetValidCartAggregate();
 
@@ -1224,7 +1230,7 @@ namespace VirtoCommerce.XCart.Tests.Aggregates
             });
 
             // Add configurable product to CartProducts
-            cartAggregate.CartProducts["configurable-product"] = configurableProduct;
+            cartAggregate.CartProducts[cartAggregate.GetCartProductKey(lineItem)] = configurableProduct;
 
             var configSection = new ProductConfigurationSection
             {
@@ -1297,7 +1303,7 @@ namespace VirtoCommerce.XCart.Tests.Aggregates
             });
 
             // Add configurable product to CartProducts
-            cartAggregate.CartProducts["configurable-product"] = configurableProduct;
+            cartAggregate.CartProducts[cartAggregate.GetCartProductKey(lineItem)] = configurableProduct;
 
             var configSection = new ProductConfigurationSection
             {
@@ -1370,7 +1376,7 @@ namespace VirtoCommerce.XCart.Tests.Aggregates
             });
 
             // Add configurable product to CartProducts
-            cartAggregate.CartProducts["configurable-product"] = configurableProduct;
+            cartAggregate.CartProducts[cartAggregate.GetCartProductKey(lineItem)] = configurableProduct;
 
             var configSection = new ProductConfigurationSection
             {
@@ -1448,7 +1454,7 @@ namespace VirtoCommerce.XCart.Tests.Aggregates
             });
 
             // Add configurable product to CartProducts
-            cartAggregate.CartProducts["configurable-product"] = configurableProduct;
+            cartAggregate.CartProducts[cartAggregate.GetCartProductKey(lineItem)] = configurableProduct;
 
             var configSections = new List<ProductConfigurationSection>
             {
@@ -1485,7 +1491,7 @@ namespace VirtoCommerce.XCart.Tests.Aggregates
             };
 
             // Add configurable product to CartProducts
-            cartAggregate.CartProducts["configurable-product"] = configurableProduct;
+            cartAggregate.CartProducts[cartAggregate.GetCartProductKey(lineItem)] = configurableProduct;
 
             // Setup mock to return products when requested
             _cartProductServiceMock.Setup(x => x.GetCartProductsByIdsAsync(It.IsAny<CartAggregate>(), It.IsAny<string[]>()))
@@ -1639,7 +1645,7 @@ namespace VirtoCommerce.XCart.Tests.Aggregates
             });
 
             // Add configurable product to CartProducts
-            cartAggregate.CartProducts["configurable-product"] = configurableProduct;
+            cartAggregate.CartProducts[cartAggregate.GetCartProductKey(lineItem)] = configurableProduct;
 
             // Setup mock to return product when requested
             _cartProductServiceMock.Setup(x => x.GetCartProductsByIdsAsync(It.IsAny<CartAggregate>(), It.IsAny<string[]>()))
@@ -1748,7 +1754,7 @@ namespace VirtoCommerce.XCart.Tests.Aggregates
             });
 
             // Add configurable product to CartProducts
-            cartAggregate.CartProducts["configurable-product"] = configurableProduct;
+            cartAggregate.CartProducts[cartAggregate.GetCartProductKey(lineItem)] = configurableProduct;
 
             var cartProducts = new[]
             {
@@ -1864,7 +1870,7 @@ namespace VirtoCommerce.XCart.Tests.Aggregates
             });
 
             // Add configurable product to CartProducts
-            cartAggregate.CartProducts["configurable-product"] = configurableProduct;
+            cartAggregate.CartProducts[cartAggregate.GetCartProductKey(lineItem)] = configurableProduct;
 
             var cartProduct = new CartProduct(new CatalogProduct
             {
@@ -1921,7 +1927,7 @@ namespace VirtoCommerce.XCart.Tests.Aggregates
             });
 
             // Add configurable product to CartProducts
-            cartAggregate.CartProducts["configurable-product"] = configurableProduct;
+            cartAggregate.CartProducts[cartAggregate.GetCartProductKey(lineItem)] = configurableProduct;
 
             var cartProduct = new CartProduct(new CatalogProduct
             {
@@ -2077,7 +2083,7 @@ namespace VirtoCommerce.XCart.Tests.Aggregates
             });
 
             // Add configurable product to CartProducts
-            cartAggregate.CartProducts["configurable-product"] = configurableProduct;
+            cartAggregate.CartProducts[cartAggregate.GetCartProductKey(lineItem)] = configurableProduct;
 
             var configSections = new List<ProductConfigurationSection>
             {
@@ -2169,7 +2175,7 @@ namespace VirtoCommerce.XCart.Tests.Aggregates
             });
 
             // Add configurable product to CartProducts
-            cartAggregate.CartProducts["configurable-product"] = configurableProduct;
+            cartAggregate.CartProducts[cartAggregate.GetCartProductKey(lineItem)] = configurableProduct;
 
             var cartProducts = new[]
             {
@@ -2281,7 +2287,7 @@ namespace VirtoCommerce.XCart.Tests.Aggregates
             });
 
             // Add configurable product to CartProducts
-            cartAggregate.CartProducts["configurable-product"] = configurableProduct;
+            cartAggregate.CartProducts[cartAggregate.GetCartProductKey(lineItem)] = configurableProduct;
 
             var cartProducts = new[]
             {
@@ -2524,7 +2530,7 @@ namespace VirtoCommerce.XCart.Tests.Aggregates
             });
 
             // Add configurable product to CartProducts
-            cartAggregate.CartProducts["configurable-product"] = configurableProduct;
+            cartAggregate.CartProducts[cartAggregate.GetCartProductKey(lineItem)] = configurableProduct;
 
             var configSections = new List<ProductConfigurationSection>
             {
@@ -2596,7 +2602,7 @@ namespace VirtoCommerce.XCart.Tests.Aggregates
             });
 
             // Add configurable product to CartProducts
-            cartAggregate.CartProducts["configurable-product"] = configurableProduct;
+            cartAggregate.CartProducts[cartAggregate.GetCartProductKey(lineItem)] = configurableProduct;
 
             var configSection = new ProductConfigurationSection
             {

--- a/tests/VirtoCommerce.XCart.Tests/Handlers/AddCartItemCommandHandlerTests.cs
+++ b/tests/VirtoCommerce.XCart.Tests/Handlers/AddCartItemCommandHandlerTests.cs
@@ -1,6 +1,5 @@
 using System.Collections.Generic;
 using System.Linq;
-using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using MediatR;
@@ -10,7 +9,6 @@ using VirtoCommerce.CatalogModule.Core.Model;
 using VirtoCommerce.CatalogModule.Core.Model.Configuration;
 using VirtoCommerce.CatalogModule.Core.Model.Search;
 using VirtoCommerce.CatalogModule.Core.Search;
-using VirtoCommerce.Platform.Core.Common;
 using VirtoCommerce.XCart.Core;
 using VirtoCommerce.XCart.Core.Commands;
 using VirtoCommerce.XCart.Core.Models;
@@ -58,9 +56,14 @@ namespace VirtoCommerce.XCart.Tests.Handlers
                 .ReturnsAsync(cartAggregateMock.Object);
 
             var product = new CartProduct(new CatalogProduct { Id = "prod-1", IsActive = true, IsBuyable = true });
+            var products = new Dictionary<string, CartProduct>
+            {
+                { CartAggregate.GetCartProductKey(product.Id, "USD"), product }
+            };
+
             _cartProductServiceMock
-                .Setup(x => x.GetCartProductsByIdsAsync(It.IsAny<CartAggregate>(), It.Is<IList<string>>(ids => ids.Contains("prod-1"))))
-                .ReturnsAsync(new List<CartProduct> { product });
+                .Setup(x => x.GetCartProductsAsync(It.IsAny<CartAggregate>(), It.Is<IList<(string CurrencyCode, string ProductId)>>(productPairs => productPairs.Any(y => y.ProductId == "prod-1"))))
+                .ReturnsAsync(products);
 
             // No active configuration
             _configSearchServiceMock
@@ -73,6 +76,7 @@ namespace VirtoCommerce.XCart.Tests.Handlers
                 CartId = "cart-1",
                 ProductId = "prod-1",
                 Quantity = 2,
+                ItemCurrencyCode = "USD",
             };
 
             // Act
@@ -93,9 +97,14 @@ namespace VirtoCommerce.XCart.Tests.Handlers
                 .ReturnsAsync(cartAggregateMock.Object);
 
             var product = new CartProduct(new CatalogProduct { Id = "prod-1", IsActive = true, IsBuyable = true });
+            var products = new Dictionary<string, CartProduct>
+            {
+                { CartAggregate.GetCartProductKey(product.Id, "USD"), product }
+            };
+
             _cartProductServiceMock
-                .Setup(x => x.GetCartProductsByIdsAsync(It.IsAny<CartAggregate>(), It.IsAny<IList<string>>()))
-                .ReturnsAsync(new List<CartProduct> { product });
+                .Setup(x => x.GetCartProductsAsync(It.IsAny<CartAggregate>(), It.IsAny<IList<(string CurrencyCode, string ProductId)>>()))
+                .ReturnsAsync(products);
 
             // Active configuration exists
             var config = new ProductConfiguration { ProductId = "prod-1", IsActive = true };
@@ -117,6 +126,7 @@ namespace VirtoCommerce.XCart.Tests.Handlers
                 ProductId = "prod-1",
                 Quantity = 1,
                 ConfigurationSections = [],
+                ItemCurrencyCode = "USD",
             };
 
             // Act

--- a/tests/VirtoCommerce.XCart.Tests/Handlers/AddCartItemCommandHandlerTests.cs
+++ b/tests/VirtoCommerce.XCart.Tests/Handlers/AddCartItemCommandHandlerTests.cs
@@ -58,7 +58,7 @@ namespace VirtoCommerce.XCart.Tests.Handlers
             var product = new CartProduct(new CatalogProduct { Id = "prod-1", IsActive = true, IsBuyable = true });
             var products = new Dictionary<string, CartProduct>
             {
-                { CartAggregate.GetCartProductKey(product.Id, "USD"), product }
+                { CartAggregate.FormatGetCartProductKey(product.Id, "USD"), product }
             };
 
             _cartProductServiceMock
@@ -99,7 +99,7 @@ namespace VirtoCommerce.XCart.Tests.Handlers
             var product = new CartProduct(new CatalogProduct { Id = "prod-1", IsActive = true, IsBuyable = true });
             var products = new Dictionary<string, CartProduct>
             {
-                { CartAggregate.GetCartProductKey(product.Id, "USD"), product }
+                { CartAggregate.FormatGetCartProductKey(product.Id, "USD"), product }
             };
 
             _cartProductServiceMock

--- a/tests/VirtoCommerce.XCart.Tests/Handlers/AddCartItemsCommandHandlerTests.cs
+++ b/tests/VirtoCommerce.XCart.Tests/Handlers/AddCartItemsCommandHandlerTests.cs
@@ -77,7 +77,7 @@ namespace VirtoCommerce.XCart.Tests.Handlers
             var request = new AddCartItemsCommand
             {
                 CartId = "cart-1",
-                CartItems = [new("prod-1", 1) { CurrencyCode = "USD" }, new("prod-2", 2) { CurrencyCode = "USD" }],
+                CartItems = [new("prod-1", 1) { ItemCurrencyCode = "USD" }, new("prod-2", 2) { ItemCurrencyCode = "USD" }],
             };
 
             // Act
@@ -125,7 +125,7 @@ namespace VirtoCommerce.XCart.Tests.Handlers
                 CartId = "cart-1",
                 StoreId = "store-1",
                 UserId = "user-1",
-                CartItems = [new("prod-1", 1) { CurrencyCode = "USD" }],
+                CartItems = [new("prod-1", 1) { ItemCurrencyCode = "USD" }],
             };
 
             // Act
@@ -176,7 +176,7 @@ namespace VirtoCommerce.XCart.Tests.Handlers
             {
                 CartId = "cart-1",
                 StoreId = "store-1",
-                CartItems = [new("configurable-1", 1) { CurrencyCode = "USD" }, new("regular-1", 2) { CurrencyCode = "USD" }],
+                CartItems = [new("configurable-1", 1) { ItemCurrencyCode = "USD" }, new("regular-1", 2) { ItemCurrencyCode = "USD" }],
             };
 
             // Act
@@ -208,7 +208,7 @@ namespace VirtoCommerce.XCart.Tests.Handlers
             var request = new AddCartItemsCommand
             {
                 CartId = "cart-1",
-                CartItems = [new("missing-prod", 1) { CurrencyCode = "USD" }],
+                CartItems = [new("missing-prod", 1) { ItemCurrencyCode = "USD" }],
             };
 
             // Act
@@ -256,7 +256,7 @@ namespace VirtoCommerce.XCart.Tests.Handlers
             {
                 CartId = "cart-1",
                 StoreId = "store-1",
-                CartItems = [new("prod-1", 1) { CurrencyCode = "USD" }], // no ConfigurationSections set
+                CartItems = [new("prod-1", 1) { ItemCurrencyCode = "USD" }], // no ConfigurationSections set
             };
 
             // Act

--- a/tests/VirtoCommerce.XCart.Tests/Handlers/AddCartItemsCommandHandlerTests.cs
+++ b/tests/VirtoCommerce.XCart.Tests/Handlers/AddCartItemsCommandHandlerTests.cs
@@ -42,6 +42,12 @@ namespace VirtoCommerce.XCart.Tests.Handlers
             var cartProperty = typeof(CartAggregate).GetProperty(nameof(CartAggregate.Cart));
             cartProperty.SetValue(mock.Object, new ShoppingCart { Id = "cart-1" });
 
+            mock.Setup(x => x.GetCartProductKey(It.IsAny<string>(), It.IsAny<string>()))
+                .Returns((string productId, string currencyCode) =>
+                {
+                    return CartAggregate.FormatGetCartProductKey(productId, currencyCode);
+                });
+
             return mock;
         }
 
@@ -63,8 +69,8 @@ namespace VirtoCommerce.XCart.Tests.Handlers
 
                     return new Dictionary<string, CartProduct>
                     {
-                        { CartAggregate.GetCartProductKey(cartProduct1.Id, "USD"), cartProduct1 },
-                        { CartAggregate.GetCartProductKey(cartProduct2.Id, "USD"), cartProduct2 },
+                        { CartAggregate.FormatGetCartProductKey(cartProduct1.Id, "USD"), cartProduct1 },
+                        { CartAggregate.FormatGetCartProductKey(cartProduct2.Id, "USD"), cartProduct2 },
                     };
                 });
 
@@ -106,7 +112,7 @@ namespace VirtoCommerce.XCart.Tests.Handlers
 
                     return new Dictionary<string, CartProduct>
                     {
-                        { CartAggregate.GetCartProductKey(cartProduct.Id, "USD"), cartProduct },
+                        { CartAggregate.FormatGetCartProductKey(cartProduct.Id, "USD"), cartProduct },
                     };
                 });
 
@@ -157,8 +163,8 @@ namespace VirtoCommerce.XCart.Tests.Handlers
 
                     return new Dictionary<string, CartProduct>
                     {
-                        { CartAggregate.GetCartProductKey(cartProduct1.Id, "USD"), cartProduct1 },
-                        { CartAggregate.GetCartProductKey(cartProduct2.Id, "USD"), cartProduct2 },
+                        { CartAggregate.FormatGetCartProductKey(cartProduct1.Id, "USD"), cartProduct1 },
+                        { CartAggregate.FormatGetCartProductKey(cartProduct2.Id, "USD"), cartProduct2 },
                     };
                 });
 
@@ -238,7 +244,7 @@ namespace VirtoCommerce.XCart.Tests.Handlers
 
                     return new Dictionary<string, CartProduct>
                     {
-                        { CartAggregate.GetCartProductKey(cartProduct.Id, "USD"), cartProduct },
+                        { CartAggregate.FormatGetCartProductKey(cartProduct.Id, "USD"), cartProduct },
                     };
                 });
 

--- a/tests/VirtoCommerce.XCart.Tests/Handlers/AddCartItemsCommandHandlerTests.cs
+++ b/tests/VirtoCommerce.XCart.Tests/Handlers/AddCartItemsCommandHandlerTests.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using MediatR;
@@ -9,7 +8,6 @@ using VirtoCommerce.CatalogModule.Core.Model;
 using VirtoCommerce.CatalogModule.Core.Model.Configuration;
 using VirtoCommerce.CatalogModule.Core.Model.Search;
 using VirtoCommerce.CatalogModule.Core.Search;
-using VirtoCommerce.Platform.Core.Common;
 using VirtoCommerce.XCart.Core;
 using VirtoCommerce.XCart.Core.Commands;
 using VirtoCommerce.XCart.Core.Models;
@@ -57,11 +55,17 @@ namespace VirtoCommerce.XCart.Tests.Handlers
                 .ReturnsAsync(cartAggregateMock.Object);
 
             _cartProductServiceMock
-                .Setup(x => x.GetCartProductsByIdsAsync(It.IsAny<CartAggregate>(), It.IsAny<IList<string>>()))
-                .ReturnsAsync(new List<CartProduct>
+                .Setup(x => x.GetCartProductsAsync(It.IsAny<CartAggregate>(), It.IsAny<IList<(string CurrencyCode, string ProductId)>>()))
+                .ReturnsAsync((CartAggregate _, IList<(string CurrencyCode, string ProductId)> productPairs) =>
                 {
-                    new(new CatalogProduct { Id = "prod-1" }),
-                    new(new CatalogProduct { Id = "prod-2" }),
+                    var cartProduct1 = new CartProduct(new CatalogProduct { Id = "prod-1" });
+                    var cartProduct2 = new CartProduct(new CatalogProduct { Id = "prod-2" });
+
+                    return new Dictionary<string, CartProduct>
+                    {
+                        { CartAggregate.GetCartProductKey(cartProduct1.Id, "USD"), cartProduct1 },
+                        { CartAggregate.GetCartProductKey(cartProduct2.Id, "USD"), cartProduct2 },
+                    };
                 });
 
             // No configurations
@@ -73,7 +77,7 @@ namespace VirtoCommerce.XCart.Tests.Handlers
             var request = new AddCartItemsCommand
             {
                 CartId = "cart-1",
-                CartItems = [new("prod-1", 1), new("prod-2", 2)],
+                CartItems = [new("prod-1", 1) { CurrencyCode = "USD" }, new("prod-2", 2) { CurrencyCode = "USD" }],
             };
 
             // Act
@@ -89,13 +93,22 @@ namespace VirtoCommerce.XCart.Tests.Handlers
         {
             // Arrange
             var cartAggregateMock = CreateCartAggregateMock();
+
             _cartAggregateRepositoryMock
                 .Setup(x => x.GetCartByIdAsync(It.IsAny<string>(), It.IsAny<string>()))
                 .ReturnsAsync(cartAggregateMock.Object);
 
             _cartProductServiceMock
-                .Setup(x => x.GetCartProductsByIdsAsync(It.IsAny<CartAggregate>(), It.IsAny<IList<string>>()))
-                .ReturnsAsync(new List<CartProduct> { new(new CatalogProduct { Id = "prod-1" }) });
+                .Setup(x => x.GetCartProductsAsync(It.IsAny<CartAggregate>(), It.IsAny<IList<(string CurrencyCode, string ProductId)>>()))
+                .ReturnsAsync((CartAggregate _, IList<(string CurrencyCode, string ProductId)> productPairs) =>
+                {
+                    var cartProduct = new CartProduct(new CatalogProduct { Id = "prod-1", });
+
+                    return new Dictionary<string, CartProduct>
+                    {
+                        { CartAggregate.GetCartProductKey(cartProduct.Id, "USD"), cartProduct },
+                    };
+                });
 
             var config = new ProductConfiguration { ProductId = "prod-1", IsActive = true };
             _configSearchServiceMock
@@ -112,7 +125,7 @@ namespace VirtoCommerce.XCart.Tests.Handlers
                 CartId = "cart-1",
                 StoreId = "store-1",
                 UserId = "user-1",
-                CartItems = [new("prod-1", 1)],
+                CartItems = [new("prod-1", 1) { CurrencyCode = "USD" }],
             };
 
             // Act
@@ -136,11 +149,17 @@ namespace VirtoCommerce.XCart.Tests.Handlers
                 .ReturnsAsync(cartAggregateMock.Object);
 
             _cartProductServiceMock
-                .Setup(x => x.GetCartProductsByIdsAsync(It.IsAny<CartAggregate>(), It.IsAny<IList<string>>()))
-                .ReturnsAsync(new List<CartProduct>
+                .Setup(x => x.GetCartProductsAsync(It.IsAny<CartAggregate>(), It.IsAny<IList<(string CurrencyCode, string ProductId)>>()))
+                .ReturnsAsync((CartAggregate _, IList<(string CurrencyCode, string ProductId)> productPairs) =>
                 {
-                    new(new CatalogProduct { Id = "configurable-1" }),
-                    new(new CatalogProduct { Id = "regular-1" }),
+                    var cartProduct1 = new CartProduct(new CatalogProduct { Id = "configurable-1" });
+                    var cartProduct2 = new CartProduct(new CatalogProduct { Id = "regular-1" });
+
+                    return new Dictionary<string, CartProduct>
+                    {
+                        { CartAggregate.GetCartProductKey(cartProduct1.Id, "USD"), cartProduct1 },
+                        { CartAggregate.GetCartProductKey(cartProduct2.Id, "USD"), cartProduct2 },
+                    };
                 });
 
             var config = new ProductConfiguration { ProductId = "configurable-1", IsActive = true };
@@ -157,7 +176,7 @@ namespace VirtoCommerce.XCart.Tests.Handlers
             {
                 CartId = "cart-1",
                 StoreId = "store-1",
-                CartItems = [new("configurable-1", 1), new("regular-1", 2)],
+                CartItems = [new("configurable-1", 1) { CurrencyCode = "USD" }, new("regular-1", 2) { CurrencyCode = "USD" }],
             };
 
             // Act
@@ -178,8 +197,8 @@ namespace VirtoCommerce.XCart.Tests.Handlers
                 .ReturnsAsync(cartAggregateMock.Object);
 
             _cartProductServiceMock
-                .Setup(x => x.GetCartProductsByIdsAsync(It.IsAny<CartAggregate>(), It.IsAny<IList<string>>()))
-                .ReturnsAsync(new List<CartProduct>()); // no products found
+                .Setup(x => x.GetCartProductsAsync(It.IsAny<CartAggregate>(), It.IsAny<IList<(string CurrencyCode, string ProductId)>>()))
+                .ReturnsAsync(new Dictionary<string, CartProduct>()); // no products found
 
             _configSearchServiceMock
                 .Setup(x => x.SearchAsync(It.IsAny<ProductConfigurationSearchCriteria>(), It.IsAny<bool>()))
@@ -189,7 +208,7 @@ namespace VirtoCommerce.XCart.Tests.Handlers
             var request = new AddCartItemsCommand
             {
                 CartId = "cart-1",
-                CartItems = [new("missing-prod", 1)],
+                CartItems = [new("missing-prod", 1) { CurrencyCode = "USD" }],
             };
 
             // Act
@@ -212,8 +231,16 @@ namespace VirtoCommerce.XCart.Tests.Handlers
                 .ReturnsAsync(cartAggregateMock.Object);
 
             _cartProductServiceMock
-                .Setup(x => x.GetCartProductsByIdsAsync(It.IsAny<CartAggregate>(), It.IsAny<IList<string>>()))
-                .ReturnsAsync(new List<CartProduct> { new(new CatalogProduct { Id = "prod-1" }) });
+                .Setup(x => x.GetCartProductsAsync(It.IsAny<CartAggregate>(), It.IsAny<IList<(string CurrencyCode, string ProductId)>>()))
+                .ReturnsAsync((CartAggregate _, IList<(string CurrencyCode, string ProductId)> productPairs) =>
+                {
+                    var cartProduct = new CartProduct(new CatalogProduct { Id = "prod-1", });
+
+                    return new Dictionary<string, CartProduct>
+                    {
+                        { CartAggregate.GetCartProductKey(cartProduct.Id, "USD"), cartProduct },
+                    };
+                });
 
             var config = new ProductConfiguration { ProductId = "prod-1", IsActive = true };
             _configSearchServiceMock
@@ -229,7 +256,7 @@ namespace VirtoCommerce.XCart.Tests.Handlers
             {
                 CartId = "cart-1",
                 StoreId = "store-1",
-                CartItems = [new("prod-1", 1)], // no ConfigurationSections set
+                CartItems = [new("prod-1", 1) { CurrencyCode = "USD" }], // no ConfigurationSections set
             };
 
             // Act

--- a/tests/VirtoCommerce.XCart.Tests/Handlers/MoveWishListItemCommandHandlerTests.cs
+++ b/tests/VirtoCommerce.XCart.Tests/Handlers/MoveWishListItemCommandHandlerTests.cs
@@ -83,7 +83,7 @@ namespace VirtoCommerce.XCart.Tests.Handlers
 
                     return new Dictionary<string, CartProduct>
                     {
-                        { CartAggregate.GetCartProductKey(productId, lineItem.Currency), cartProduct },
+                        { CartAggregate.FormatGetCartProductKey(productId, lineItem.Currency), cartProduct },
                     };
                 });
 

--- a/tests/VirtoCommerce.XCart.Tests/Handlers/MoveWishListItemCommandHandlerTests.cs
+++ b/tests/VirtoCommerce.XCart.Tests/Handlers/MoveWishListItemCommandHandlerTests.cs
@@ -76,8 +76,16 @@ namespace VirtoCommerce.XCart.Tests.Handlers
 
             var productId = lineItem.ProductId;
             _cartProductServiceMock
-                .Setup(x => x.GetCartProductsByIdsAsync(It.IsAny<CartAggregate>(), new[] { productId }))
-                .ReturnsAsync(new List<CartProduct> { new CartProduct(new CatalogProduct { Id = productId }) });
+                .Setup(x => x.GetCartProductsAsync(It.IsAny<CartAggregate>(), It.IsAny<IList<(string CurrencyCode, string ProductId)>>()))
+                .ReturnsAsync((CartAggregate _, IList<(string CurrencyCode, string ProductId)> productPairs) =>
+                {
+                    var cartProduct = new CartProduct(new CatalogProduct { Id = productId, });
+
+                    return new Dictionary<string, CartProduct>
+                    {
+                        { CartAggregate.GetCartProductKey(productId, lineItem.Currency), cartProduct },
+                    };
+                });
 
             _mapperMock
                 .Setup(m => m.Map(It.IsAny<CartProduct>(), It.IsAny<Action<IMappingOperationOptions<object, LineItem>>>()))

--- a/tests/VirtoCommerce.XCart.Tests/Helpers/XCartMoqHelper.cs
+++ b/tests/VirtoCommerce.XCart.Tests/Helpers/XCartMoqHelper.cs
@@ -41,7 +41,6 @@ namespace VirtoCommerce.XCart.Tests.Helpers
         protected readonly CartValidationContext _context = new CartValidationContext();
 
         protected readonly Mock<ICartProductService> _cartProductServiceMock;
-        protected readonly Mock<ICartProductsLoaderService> _cartProductsLoaderServiceMock;
         protected readonly Mock<ICurrencyService> _currencyServiceMock;
         protected readonly Mock<IMarketingPromoEvaluator> _marketingPromoEvaluatorMock;
         protected readonly Mock<IPaymentMethodsSearchService> _paymentMethodsSearchServiceMock;
@@ -121,6 +120,7 @@ namespace VirtoCommerce.XCart.Tests.Helpers
 
             _fixture.Register(() => _fixture.Build<LineItem>()
                                             .Without(x => x.DynamicProperties)
+                                            .With(x => x.Currency, CURRENCY_CODE)
                                             .With(x => x.IsReadOnly, false)
                                             .With(x => x.IsGift, false)
                                             .With(x => x.Quantity, InStockQuantity)
@@ -156,7 +156,6 @@ namespace VirtoCommerce.XCart.Tests.Helpers
                .Create());
 
             _cartProductServiceMock = new Mock<ICartProductService>();
-            _cartProductsLoaderServiceMock = new Mock<ICartProductsLoaderService>();
 
             _currencyServiceMock = new Mock<ICurrencyService>();
             _currencyServiceMock

--- a/tests/VirtoCommerce.XCart.Tests/Helpers/XCartMoqHelper.cs
+++ b/tests/VirtoCommerce.XCart.Tests/Helpers/XCartMoqHelper.cs
@@ -41,6 +41,7 @@ namespace VirtoCommerce.XCart.Tests.Helpers
         protected readonly CartValidationContext _context = new CartValidationContext();
 
         protected readonly Mock<ICartProductService> _cartProductServiceMock;
+        protected readonly Mock<ICartProductsLoaderService> _cartProductsLoaderServiceMock;
         protected readonly Mock<ICurrencyService> _currencyServiceMock;
         protected readonly Mock<IMarketingPromoEvaluator> _marketingPromoEvaluatorMock;
         protected readonly Mock<IPaymentMethodsSearchService> _paymentMethodsSearchServiceMock;
@@ -155,6 +156,7 @@ namespace VirtoCommerce.XCart.Tests.Helpers
                .Create());
 
             _cartProductServiceMock = new Mock<ICartProductService>();
+            _cartProductsLoaderServiceMock = new Mock<ICartProductsLoaderService>();
 
             _currencyServiceMock = new Mock<ICurrencyService>();
             _currencyServiceMock

--- a/tests/VirtoCommerce.XCart.Tests/Repositories/CartAggregateRepositoryTests.cs
+++ b/tests/VirtoCommerce.XCart.Tests/Repositories/CartAggregateRepositoryTests.cs
@@ -163,7 +163,7 @@ namespace VirtoCommerce.XCart.Tests.Repositories
                  _currencyService.Object,
                  _memberResolver.Object,
                  _storeService.Object,
-                 _cartProductServiceMock.Object,
+                 _cartProductsLoaderServiceMock.Object,
                  _platformMemoryCache,
                  _fileUploadService.Object);
 
@@ -186,8 +186,8 @@ namespace VirtoCommerce.XCart.Tests.Repositories
             _memberResolver.Setup(x => x.ResolveMemberByIdAsync(It.Is<string>(x => x == shoppingCart.CustomerId)))
                 .ReturnsAsync(customer);
 
-            _cartProductServiceMock.Setup(x => x.GetCartProductsByIdsAsync(It.Is<CartAggregate>(x => x == cartAggregate), It.IsAny<IList<string>>()))
-                .ReturnsAsync(new List<CartProduct>());
+            _cartProductsLoaderServiceMock.Setup(x => x.GetCartProductsAsync(It.IsAny<CartProductsRequest>()))
+                .ReturnsAsync([]);
 
             // Act
             var result = await repository.GetCartForShoppingCartAsync(shoppingCart);
@@ -213,7 +213,7 @@ namespace VirtoCommerce.XCart.Tests.Repositories
                  _currencyService.Object,
                  _memberResolver.Object,
                  _storeService.Object,
-                 _cartProductServiceMock.Object,
+                 _cartProductsLoaderServiceMock.Object,
                  _platformMemoryCache,
                  _fileUploadService.Object);
 
@@ -238,15 +238,13 @@ namespace VirtoCommerce.XCart.Tests.Repositories
             _memberResolver.Setup(x => x.ResolveMemberByIdAsync(It.Is<string>(x => x == shoppingCart.CustomerId)))
                 .ReturnsAsync(customer);
 
-            _cartProductServiceMock.Setup(x => x.GetCartProductsByIdsAsync(It.Is<CartAggregate>(x => x == cartAggregate), It.IsAny<IList<string>>()))
-                .ReturnsAsync(() =>
-                {
-                    var product = _fixture.Create<CartProduct>();
-                    product.Id = lineItem.ProductId;
+            var product = _fixture.Create<CartProduct>();
+            product.Id = lineItem.ProductId;
 
-                    //change price
-                    product.ApplyPrices(new List<Price>()
-                    {
+            lineItem.Currency = currencies.First().Code;
+
+            product.ApplyPrices(
+                    [
                         new Price
                         {
                             ProductId = product.Id,
@@ -254,10 +252,13 @@ namespace VirtoCommerce.XCart.Tests.Repositories
                             List = 1,
                             MinQuantity = 1,
                         }
-                    }, GetCurrency());
+                    ], currencies.First());
 
-                    return new List<CartProduct>() { product };
-                });
+            _cartProductServiceMock.Setup(x => x.GetCartProductsByIdsAsync(It.IsAny<CartAggregate>(), It.IsAny<IList<string>>()))
+                .ReturnsAsync([product]);
+
+            _cartProductsLoaderServiceMock.Setup(x => x.GetCartProductsAsync(It.IsAny<CartProductsRequest>()))
+                .ReturnsAsync([product]);
 
             // Act
             var result = await repository.GetCartForShoppingCartAsync(shoppingCart);

--- a/tests/VirtoCommerce.XCart.Tests/Repositories/CartAggregateRepositoryTests.cs
+++ b/tests/VirtoCommerce.XCart.Tests/Repositories/CartAggregateRepositoryTests.cs
@@ -259,7 +259,7 @@ namespace VirtoCommerce.XCart.Tests.Repositories
                 .Setup(x => x.GetCartProductsAsync(It.IsAny<CartAggregate>(), It.IsAny<IList<(string CurrencyCode, string ProductId)>>()))
                 .ReturnsAsync(new Dictionary<string, CartProduct>()
                 {
-                    { CartAggregate.GetCartProductKey(product.Id, "USD"), product },
+                    { CartAggregate.FormatGetCartProductKey(product.Id, "USD"), product },
                 });
 
             // Act

--- a/tests/VirtoCommerce.XCart.Tests/Repositories/CartAggregateRepositoryTests.cs
+++ b/tests/VirtoCommerce.XCart.Tests/Repositories/CartAggregateRepositoryTests.cs
@@ -163,7 +163,7 @@ namespace VirtoCommerce.XCart.Tests.Repositories
                  _currencyService.Object,
                  _memberResolver.Object,
                  _storeService.Object,
-                 _cartProductsLoaderServiceMock.Object,
+                 _cartProductServiceMock.Object,
                  _platformMemoryCache,
                  _fileUploadService.Object);
 
@@ -186,8 +186,9 @@ namespace VirtoCommerce.XCart.Tests.Repositories
             _memberResolver.Setup(x => x.ResolveMemberByIdAsync(It.Is<string>(x => x == shoppingCart.CustomerId)))
                 .ReturnsAsync(customer);
 
-            _cartProductsLoaderServiceMock.Setup(x => x.GetCartProductsAsync(It.IsAny<CartProductsRequest>()))
-                .ReturnsAsync([]);
+            _cartProductServiceMock
+                .Setup(x => x.GetCartProductsAsync(It.IsAny<CartAggregate>(), It.IsAny<IList<(string CurrencyCode, string ProductId)>>()))
+                .ReturnsAsync(new Dictionary<string, CartProduct>());
 
             // Act
             var result = await repository.GetCartForShoppingCartAsync(shoppingCart);
@@ -213,7 +214,7 @@ namespace VirtoCommerce.XCart.Tests.Repositories
                  _currencyService.Object,
                  _memberResolver.Object,
                  _storeService.Object,
-                 _cartProductsLoaderServiceMock.Object,
+                 _cartProductServiceMock.Object,
                  _platformMemoryCache,
                  _fileUploadService.Object);
 
@@ -254,11 +255,12 @@ namespace VirtoCommerce.XCart.Tests.Repositories
                         }
                     ], currencies.First());
 
-            _cartProductServiceMock.Setup(x => x.GetCartProductsByIdsAsync(It.IsAny<CartAggregate>(), It.IsAny<IList<string>>()))
-                .ReturnsAsync([product]);
-
-            _cartProductsLoaderServiceMock.Setup(x => x.GetCartProductsAsync(It.IsAny<CartProductsRequest>()))
-                .ReturnsAsync([product]);
+            _cartProductServiceMock
+                .Setup(x => x.GetCartProductsAsync(It.IsAny<CartAggregate>(), It.IsAny<IList<(string CurrencyCode, string ProductId)>>()))
+                .ReturnsAsync(new Dictionary<string, CartProduct>()
+                {
+                    { CartAggregate.GetCartProductKey(product.Id, "USD"), product },
+                });
 
             // Act
             var result = await repository.GetCartForShoppingCartAsync(shoppingCart);

--- a/tests/VirtoCommerce.XCart.Tests/Validators/CartLineItemValidatorTests.cs
+++ b/tests/VirtoCommerce.XCart.Tests/Validators/CartLineItemValidatorTests.cs
@@ -129,7 +129,7 @@ namespace VirtoCommerce.XCart.Tests.Validators
             var result = await validator.ValidateAsync(new CartLineItemPriceChangedValidationContext
             {
                 LineItem = item,
-                CartProducts = _context.AllCartProducts.ToDictionary(x => CartAggregate.GetCartProductKey(x.Id, item.Currency))
+                CartProducts = _context.AllCartProducts.ToDictionary(x => CartAggregate.FormatGetCartProductKey(x.Id, item.Currency))
             }, TestContext.Current.CancellationToken);
 
             // Assert

--- a/tests/VirtoCommerce.XCart.Tests/Validators/CartLineItemValidatorTests.cs
+++ b/tests/VirtoCommerce.XCart.Tests/Validators/CartLineItemValidatorTests.cs
@@ -6,6 +6,7 @@ using AutoFixture;
 using FluentAssertions;
 using FluentValidation;
 using VirtoCommerce.CartModule.Core.Model;
+using VirtoCommerce.XCart.Core;
 using VirtoCommerce.XCart.Core.Models;
 using VirtoCommerce.XCart.Core.Validators;
 using VirtoCommerce.XCart.Tests.Helpers;
@@ -128,7 +129,7 @@ namespace VirtoCommerce.XCart.Tests.Validators
             var result = await validator.ValidateAsync(new CartLineItemPriceChangedValidationContext
             {
                 LineItem = item,
-                CartProducts = _context.AllCartProducts.ToDictionary(x => x.Id)
+                CartProducts = _context.AllCartProducts.ToDictionary(x => CartAggregate.GetCartProductKey(x.Id, item.Currency))
             }, TestContext.Current.CancellationToken);
 
             // Assert


### PR DESCRIPTION
## Description

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-5101
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.XCart_3.1018.0-pr-120-ba3a.zip

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Wide changes to cart pricing, merge logic, promotions/tax scope, and checkout selection; incorrect currency handling could misprice or apply discounts to the wrong lines.
> 
> **Overview**
> Adds **mixed-currency line items** so the same cart can hold products priced in different currencies, with catalog/pricing loaded per `(productId, currencyCode)` instead of product id alone.
> 
> **Cart model & behavior:** `CartProducts` keys are now `{productId}:{currencyCode}`; line-item merge on add matches product **and** currency. Commands and GraphQL inputs accept optional `itemCurrencyCode`. Quantity updates can remove/update by product + currency. Repository preloads `AllCurrencies` and loads products per line-item currency pair.
> 
> **Checkout / totals:** Promotions, tax evaluation, cart-level subtotal rewards, and top-level cart money fields use **only line items in the cart’s primary currency** (`CartCurrencySelectedLineItems`). Per-currency breakdowns are exposed via new `cartTotals` (from `ShoppingCart.CartTotals` after Cart module **3.1005.0**). Line-item and configuration-item GraphQL money fields resolve in each line’s currency; product dataloaders batch by currency.
> 
> **API surface:** `currencyCode` on line items; `CartTotalType`; `RemoveItemsByProductIdAndCurrencyAsync`; obsolete overload for `FindExistingLineItemBeforeAdd(string productId, ...)`. Currency-change flow copies items with rules: base-currency lines convert to the new cart currency; other currencies are kept.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ba3a337c2a0a2169fec5293147daa679124a1c64. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->