### PR TITLE
feat: factory-aware NewCartItem construction (AbstractTypeFactory + ExtendableInputObjectGraphType)

### DIFF
--- a/src/VirtoCommerce.XCart.Core/Models/NewCartItem.cs
+++ b/src/VirtoCommerce.XCart.Core/Models/NewCartItem.cs
@@ -6,6 +6,10 @@ namespace VirtoCommerce.XCart.Core.Models
 {
     public class NewCartItem
     {
+        public NewCartItem()
+        {
+        }
+
         public NewCartItem(string productId, int quantity)
         {
             ProductId = productId;

--- a/src/VirtoCommerce.XCart.Core/Schemas/InputNewCartItemType.cs
+++ b/src/VirtoCommerce.XCart.Core/Schemas/InputNewCartItemType.cs
@@ -4,7 +4,7 @@ using VirtoCommerce.XCart.Core.Models;
 
 namespace VirtoCommerce.XCart.Core.Schemas
 {
-    public class InputNewCartItemType : InputObjectGraphType<NewCartItem>
+    public class InputNewCartItemType : ExtendableInputObjectGraphType<NewCartItem>
     {
         public InputNewCartItemType()
         {

--- a/src/VirtoCommerce.XCart.Data/Commands/AddCartItemCommandHandler.cs
+++ b/src/VirtoCommerce.XCart.Data/Commands/AddCartItemCommandHandler.cs
@@ -44,14 +44,7 @@ namespace VirtoCommerce.XCart.Data.Commands
         {
             var product = (await _cartProductService.GetCartProductsByIdsAsync(cartAggregate, [request.ProductId])).FirstOrDefault();
 
-            var newItem = new NewCartItem(request.ProductId, request.Quantity)
-            {
-                Comment = request.Comment,
-                DynamicProperties = request.DynamicProperties,
-                Price = request.Price,
-                CartProduct = product,
-                CreatedDate = request.CreatedDate,
-            };
+            var newItem = CreateNewCartItem(request, product);
 
             var configurations = await _productConfigurationSearchService.SearchNoCloneAsync(new ProductConfigurationSearchCriteria
             {
@@ -78,6 +71,20 @@ namespace VirtoCommerce.XCart.Data.Commands
             {
                 await cartAggregate.AddItemAsync(newItem);
             }
+        }
+
+        protected virtual NewCartItem CreateNewCartItem(AddCartItemCommand request, CartProduct product)
+        {
+            var newItem = AbstractTypeFactory<NewCartItem>.TryCreateInstance();
+            newItem.ProductId = request.ProductId;
+            newItem.Quantity = request.Quantity;
+            newItem.Comment = request.Comment;
+            newItem.DynamicProperties = request.DynamicProperties;
+            newItem.Price = request.Price;
+            newItem.CartProduct = product;
+            newItem.CreatedDate = request.CreatedDate;
+
+            return newItem;
         }
     }
 }

--- a/src/VirtoCommerce.XCart.Data/Commands/AddCartItemsBulkCommandHandler.cs
+++ b/src/VirtoCommerce.XCart.Data/Commands/AddCartItemsBulkCommandHandler.cs
@@ -60,7 +60,9 @@ namespace VirtoCommerce.XCart.Data.Commands
                 var product = products.FirstOrDefault(x => x.Code == item.ProductSku);
                 if (product != null)
                 {
-                    var newCartItem = new NewCartItem(product.Id, item.Quantity);
+                    var newCartItem = AbstractTypeFactory<NewCartItem>.TryCreateInstance();
+                    newCartItem.ProductId = product.Id;
+                    newCartItem.Quantity = item.Quantity;
                     cartItemsToAdd.Add(newCartItem);
                 }
                 else

--- a/src/VirtoCommerce.XCart.Data/Commands/AddWishlistItemCommandHandler.cs
+++ b/src/VirtoCommerce.XCart.Data/Commands/AddWishlistItemCommandHandler.cs
@@ -37,11 +37,11 @@ namespace VirtoCommerce.XCart.Data.Commands
             var cartAggregate = await CartRepository.GetCartByIdAsync(request.ListId);
             cartAggregate.ValidationRuleSet = ["default"];
 
-            var newItem = new NewCartItem(request.ProductId, request.Quantity ?? 1)
-            {
-                IsWishlist = true,
-                IgnoreValidationErrors = true,
-            };
+            var newItem = AbstractTypeFactory<NewCartItem>.TryCreateInstance();
+            newItem.ProductId = request.ProductId;
+            newItem.Quantity = request.Quantity ?? 1;
+            newItem.IsWishlist = true;
+            newItem.IgnoreValidationErrors = true;
 
             var productConfiguration = await GetProductConfiguration(request);
             if (productConfiguration?.IsActive == true)

--- a/src/VirtoCommerce.XCart.Data/Commands/ChangeCartCurrencyCommandHandler.cs
+++ b/src/VirtoCommerce.XCart.Data/Commands/ChangeCartCurrencyCommandHandler.cs
@@ -70,13 +70,16 @@ namespace VirtoCommerce.XCart.Data.Commands
             if (ordinaryItems.Length > 0)
             {
                 var newCartItems = ordinaryItems
-                    .Select(x => new NewCartItem(x.ProductId, x.Quantity)
+                    .Select(x =>
                     {
-                        IgnoreValidationErrors = true,
-                        CreatedDate = x.CreatedDate,
-                        Comment = x.Note,
-                        IsSelectedForCheckout = x.SelectedForCheckout,
-                        DynamicProperties = x.DynamicProperties.SelectMany(p => p.Values.Select(v =>
+                        var newCartItem = AbstractTypeFactory<NewCartItem>.TryCreateInstance();
+                        newCartItem.ProductId = x.ProductId;
+                        newCartItem.Quantity = x.Quantity;
+                        newCartItem.IgnoreValidationErrors = true;
+                        newCartItem.CreatedDate = x.CreatedDate;
+                        newCartItem.Comment = x.Note;
+                        newCartItem.IsSelectedForCheckout = x.SelectedForCheckout;
+                        newCartItem.DynamicProperties = x.DynamicProperties.SelectMany(p => p.Values.Select(v =>
                         {
                             var value = AbstractTypeFactory<DynamicPropertyValue>.TryCreateInstance();
                             value.Name = p.Name;
@@ -84,7 +87,9 @@ namespace VirtoCommerce.XCart.Data.Commands
                             value.Locale = v.Locale;
 
                             return value;
-                        })).ToArray(),
+                        })).ToArray();
+
+                        return newCartItem;
                     })
                     .ToArray();
 
@@ -127,23 +132,25 @@ namespace VirtoCommerce.XCart.Data.Commands
 
                 var expItem = container.CreateConfiguredLineItem(configurationLineItem.Quantity);
 
-                await newCurrencyCartAggregate.AddConfiguredItemAsync(new NewCartItem(configurationLineItem.ProductId, configurationLineItem.Quantity)
+                var newCartItem = AbstractTypeFactory<NewCartItem>.TryCreateInstance();
+                newCartItem.ProductId = configurationLineItem.ProductId;
+                newCartItem.Quantity = configurationLineItem.Quantity;
+                newCartItem.CartProduct = container.ConfigurableProduct;
+                newCartItem.IgnoreValidationErrors = true;
+                newCartItem.CreatedDate = configurationLineItem.CreatedDate;
+                newCartItem.Comment = configurationLineItem.Note;
+                newCartItem.IsSelectedForCheckout = configurationLineItem.SelectedForCheckout;
+                newCartItem.DynamicProperties = configurationLineItem.DynamicProperties.SelectMany(x => x.Values.Select(y =>
                 {
-                    CartProduct = container.ConfigurableProduct,
-                    IgnoreValidationErrors = true,
-                    CreatedDate = configurationLineItem.CreatedDate,
-                    Comment = configurationLineItem.Note,
-                    IsSelectedForCheckout = configurationLineItem.SelectedForCheckout,
-                    DynamicProperties = configurationLineItem.DynamicProperties.SelectMany(x => x.Values.Select(y =>
-                    {
-                        var value = AbstractTypeFactory<DynamicPropertyValue>.TryCreateInstance();
-                        value.Name = x.Name;
-                        value.Value = y.Value;
-                        value.Locale = y.Locale;
+                    var value = AbstractTypeFactory<DynamicPropertyValue>.TryCreateInstance();
+                    value.Name = x.Name;
+                    value.Value = y.Value;
+                    value.Locale = y.Locale;
 
-                        return value;
-                    })).ToArray(),
-                }, expItem.Item);
+                    return value;
+                })).ToArray();
+
+                await newCurrencyCartAggregate.AddConfiguredItemAsync(newCartItem, expItem.Item);
             }
         }
 

--- a/src/VirtoCommerce.XCart.Data/Commands/CloneWishlistCommandHandler.cs
+++ b/src/VirtoCommerce.XCart.Data/Commands/CloneWishlistCommandHandler.cs
@@ -36,7 +36,15 @@ public class CloneWishlistCommandHandler : ScopedWishlistCommandHandlerBase<Clon
             cloneCartAggregate.ValidationRuleSet = ["default"];
 
             var items = cart.Items
-                            ?.Select(x => new NewCartItem(x.ProductId, x.Quantity) { IsWishlist = true })
+                            ?.Select(x =>
+                            {
+                                var newCartItem = AbstractTypeFactory<NewCartItem>.TryCreateInstance();
+                                newCartItem.ProductId = x.ProductId;
+                                newCartItem.Quantity = x.Quantity;
+                                newCartItem.IsWishlist = true;
+
+                                return newCartItem;
+                            })
                             .ToArray()
                         ?? [];
 

--- a/src/VirtoCommerce.XCart.Data/Commands/CreateCartFromWishlistCommandHandler.cs
+++ b/src/VirtoCommerce.XCart.Data/Commands/CreateCartFromWishlistCommandHandler.cs
@@ -2,6 +2,7 @@ using System;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using VirtoCommerce.Platform.Core.Common;
 using VirtoCommerce.XCart.Core;
 using VirtoCommerce.XCart.Core.Commands;
 using VirtoCommerce.XCart.Core.Commands.BaseCommands;
@@ -50,12 +51,17 @@ public class CreateCartFromWishlistCommandHandler : CartCommandHandler<CreateCar
         if (ordinaryItems.Length > 0)
         {
             var newCartItems = ordinaryItems
-                .Select(x => new NewCartItem(x.ProductId, x.Quantity)
+                .Select(x =>
                 {
-                    IgnoreValidationErrors = true,
-                    IsSelectedForCheckout = true,
-                    CreatedDate = x.CreatedDate,
-                    Comment = x.Note,
+                    var newCartItem = AbstractTypeFactory<NewCartItem>.TryCreateInstance();
+                    newCartItem.ProductId = x.ProductId;
+                    newCartItem.Quantity = x.Quantity;
+                    newCartItem.IgnoreValidationErrors = true;
+                    newCartItem.IsSelectedForCheckout = true;
+                    newCartItem.CreatedDate = x.CreatedDate;
+                    newCartItem.Comment = x.Note;
+
+                    return newCartItem;
                 })
                 .ToArray();
 

--- a/src/VirtoCommerce.XCart.Data/Commands/MoveWishListItemCommandHandler.cs
+++ b/src/VirtoCommerce.XCart.Data/Commands/MoveWishListItemCommandHandler.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using VirtoCommerce.Platform.Core.Common;
 using VirtoCommerce.XCart.Core;
 using VirtoCommerce.XCart.Core.Commands;
 using VirtoCommerce.XCart.Core.Commands.BaseCommands;
@@ -25,9 +26,11 @@ namespace VirtoCommerce.XCart.Data.Commands
             var item = sourceCartAggregate.Cart.Items.FirstOrDefault(x => x.Id == request.LineItemId);
             if (item != null)
             {
-                destinationCartAggregate = await destinationCartAggregate.AddItemsAsync(new List<NewCartItem> {
-                    new NewCartItem(item.ProductId, item.Quantity)
-                });
+                var newCartItem = AbstractTypeFactory<NewCartItem>.TryCreateInstance();
+                newCartItem.ProductId = item.ProductId;
+                newCartItem.Quantity = item.Quantity;
+
+                destinationCartAggregate = await destinationCartAggregate.AddItemsAsync(new List<NewCartItem> { newCartItem });
 
                 await sourceCartAggregate.RemoveItemAsync(request.LineItemId);
 

--- a/src/VirtoCommerce.XCart.Data/Commands/UpdateCartQuantityCommandHandler.cs
+++ b/src/VirtoCommerce.XCart.Data/Commands/UpdateCartQuantityCommandHandler.cs
@@ -57,12 +57,13 @@ namespace VirtoCommerce.XCart.Data.Commands
                 var requestItem = requestItems.FirstOrDefault(x => x.ProductId == product.Id);
                 if (requestItem != null)
                 {
-                    newCartItems.Add(new NewCartItem(product.Id, requestItem.Quantity)
-                    {
-                        CartProduct = product,
-                        IgnoreValidationErrors = true,
-                        OverrideQuantity = true,
-                    });
+                    var newCartItem = AbstractTypeFactory<NewCartItem>.TryCreateInstance();
+                    newCartItem.ProductId = product.Id;
+                    newCartItem.Quantity = requestItem.Quantity;
+                    newCartItem.CartProduct = product;
+                    newCartItem.IgnoreValidationErrors = true;
+                    newCartItem.OverrideQuantity = true;
+                    newCartItems.Add(newCartItem);
                 }
             }
 

--- a/src/VirtoCommerce.XCart.Data/Queries/GetPricesSumQueryHandler.cs
+++ b/src/VirtoCommerce.XCart.Data/Queries/GetPricesSumQueryHandler.cs
@@ -53,9 +53,14 @@ public class GetPricesSumQueryHandler : IQueryHandler<GetPricesSumQuery, ExpPric
         if (items.Length > 0)
         {
             var newCartItems = items
-                .Select(x => new NewCartItem(x.ProductId, x.Quantity)
+                .Select(x =>
                 {
-                    IgnoreValidationErrors = true,
+                    var newCartItem = AbstractTypeFactory<NewCartItem>.TryCreateInstance();
+                    newCartItem.ProductId = x.ProductId;
+                    newCartItem.Quantity = x.Quantity;
+                    newCartItem.IgnoreValidationErrors = true;
+
+                    return newCartItem;
                 })
                 .ToArray();
 

--- a/src/VirtoCommerce.XCart.Data/Services/SavedForLaterListService.cs
+++ b/src/VirtoCommerce.XCart.Data/Services/SavedForLaterListService.cs
@@ -240,14 +240,16 @@ public class SavedForLaterListService(
 
     private static NewCartItem BuildNewCartItem(LineItem source)
     {
-        return new NewCartItem(source.ProductId, source.Quantity)
-        {
-            IgnoreValidationErrors = true,
-            CreatedDate = source.CreatedDate,
-            Comment = source.Note,
-            IsSelectedForCheckout = source.SelectedForCheckout,
-            DynamicProperties = MapDynamicProperties(source.DynamicProperties),
-        };
+        var newCartItem = AbstractTypeFactory<NewCartItem>.TryCreateInstance();
+        newCartItem.ProductId = source.ProductId;
+        newCartItem.Quantity = source.Quantity;
+        newCartItem.IgnoreValidationErrors = true;
+        newCartItem.CreatedDate = source.CreatedDate;
+        newCartItem.Comment = source.Note;
+        newCartItem.IsSelectedForCheckout = source.SelectedForCheckout;
+        newCartItem.DynamicProperties = MapDynamicProperties(source.DynamicProperties);
+
+        return newCartItem;
     }
 
     private async Task<IList<ConfigurationItemFile>> CopyConfigurationFiles(ConfigurationItem configurationItem, ShoppingCart cart)

--- a/src/VirtoCommerce.XCart.Data/VirtoCommerce.XCart.Data.csproj
+++ b/src/VirtoCommerce.XCart.Data/VirtoCommerce.XCart.Data.csproj
@@ -9,7 +9,7 @@
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="VirtoCommerce.Platform.Security" Version="3.1007.10" />
+    <PackageReference Include="VirtoCommerce.Platform.Security" Version="3.1017.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.XCart.Core\VirtoCommerce.XCart.Core.csproj" />

--- a/src/VirtoCommerce.XCart.Data/VirtoCommerce.XCart.Data.csproj
+++ b/src/VirtoCommerce.XCart.Data/VirtoCommerce.XCart.Data.csproj
@@ -9,7 +9,7 @@
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="VirtoCommerce.Platform.Security" Version="3.1017.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Security" Version="3.1007.10" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.XCart.Core\VirtoCommerce.XCart.Core.csproj" />

--- a/src/VirtoCommerce.XCart.Data/VirtoCommerce.XCart.Data.csproj
+++ b/src/VirtoCommerce.XCart.Data/VirtoCommerce.XCart.Data.csproj
@@ -9,7 +9,7 @@
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="VirtoCommerce.Platform.Security" Version="3.1002.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Security" Version="3.1017.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.XCart.Core\VirtoCommerce.XCart.Core.csproj" />

--- a/src/VirtoCommerce.XCart.Web/module.manifest
+++ b/src/VirtoCommerce.XCart.Web/module.manifest
@@ -4,7 +4,7 @@
   <version>3.1017.0</version>
   <version-tag></version-tag>
 
-  <platformVersion>3.1007.10</platformVersion>
+  <platformVersion>3.1017.0</platformVersion>
   <dependencies>
     <dependency id="VirtoCommerce.Catalog" version="3.1025.0" />
     <dependency id="VirtoCommerce.Cart" version="3.1002.0" />

--- a/src/VirtoCommerce.XCart.Web/module.manifest
+++ b/src/VirtoCommerce.XCart.Web/module.manifest
@@ -4,7 +4,7 @@
   <version>3.1017.0</version>
   <version-tag></version-tag>
 
-  <platformVersion>3.1017.0</platformVersion>
+  <platformVersion>3.1007.10</platformVersion>
   <dependencies>
     <dependency id="VirtoCommerce.Catalog" version="3.1025.0" />
     <dependency id="VirtoCommerce.Cart" version="3.1002.0" />

--- a/src/VirtoCommerce.XCart.Web/module.manifest
+++ b/src/VirtoCommerce.XCart.Web/module.manifest
@@ -4,7 +4,7 @@
   <version>3.1017.0</version>
   <version-tag></version-tag>
 
-  <platformVersion>3.1002.0</platformVersion>
+  <platformVersion>3.1017.0</platformVersion>
   <dependencies>
     <dependency id="VirtoCommerce.Catalog" version="3.1025.0" />
     <dependency id="VirtoCommerce.Cart" version="3.1002.0" />

--- a/tests/VirtoCommerce.XCart.Tests/Schemas/InputNewCartItemTypeTests.cs
+++ b/tests/VirtoCommerce.XCart.Tests/Schemas/InputNewCartItemTypeTests.cs
@@ -10,25 +10,31 @@ using Xunit;
 
 namespace VirtoCommerce.XCart.Tests.Schemas
 {
-    // These tests exercise the global, static AbstractTypeFactory<NewCartItem> registry, which has no
-    // removal API in the consumed platform version. Rather than rely on a pristine global (which a
-    // sibling test could have dirtied), each test establishes its own precondition: the base-type tests
-    // force a direct "NewCartItem" name entry via RegisterType, which wins over the inheritance-chain
-    // fallback that resolves a registered override. No XCart test constructs NewCartItem through the
-    // factory, so the residual registration is benign for the rest of the suite.
+    // ParseDictionary resolves the actual type via the global, static AbstractTypeFactory<NewCartItem>.
+    // Only the override-test mutates it, so that test removes its registration in a finally block. The
+    // other tests never touch the factory, so they exercise the real production path (no module registers
+    // NewCartItem, so resolution falls back to typeof(NewCartItem)).
     public class InputNewCartItemTypeTests
     {
         [Fact]
         public void ParseDictionary_WithOverride_YieldsOverrideType()
         {
             AbstractTypeFactory<NewCartItem>.OverrideType<NewCartItem, TestNewCartItem>();
-            var type = BuildInitializedType();
-
-            var parsed = type.ParseDictionary(new Dictionary<string, object>
+            object parsed;
+            try
             {
-                ["productId"] = "p1",
-                ["quantity"] = 2,
-            });
+                var type = BuildInitializedType();
+
+                parsed = type.ParseDictionary(new Dictionary<string, object>
+                {
+                    ["productId"] = "p1",
+                    ["quantity"] = 2,
+                });
+            }
+            finally
+            {
+                AbstractTypeFactory<NewCartItem>.RemoveType<TestNewCartItem>();
+            }
 
             parsed.Should().BeOfType<TestNewCartItem>();
             ((NewCartItem)parsed).ProductId.Should().Be("p1");
@@ -38,10 +44,9 @@ namespace VirtoCommerce.XCart.Tests.Schemas
         [Fact]
         public void ParseDictionary_WithoutOverride_YieldsBaseType()
         {
-            // RegisterType adds a direct "NewCartItem" name entry, which resolves to the base type even
-            // if a sibling test registered an override. Proves GraphQL.NET picks the parameterless ctor
-            // for the two-ctor NewCartItem without any [GraphQLConstructor] (same as InputNewWishlistItemType).
-            AbstractTypeFactory<NewCartItem>.RegisterType<NewCartItem>();
+            // Empty factory == production state (the upstream module registers no NewCartItem type).
+            // Proves GraphQL.NET picks the parameterless ctor for the two-ctor NewCartItem without any
+            // [GraphQLConstructor] annotation (same binding as the existing InputNewWishlistItemType).
             var type = BuildInitializedType();
 
             var parsed = type.ParseDictionary(new Dictionary<string, object>
@@ -63,7 +68,6 @@ namespace VirtoCommerce.XCart.Tests.Schemas
             // ParseDictionary path, so scalar parity de-risks it. Nested-list fidelity (dynamicProperties,
             // configurationSections) is an orthogonal GraphQL.NET concern unaffected by the re-base and is
             // covered end-to-end by the LEO-side override test and the integration test.
-            AbstractTypeFactory<NewCartItem>.RegisterType<NewCartItem>();
             var type = BuildInitializedType();
 
             var createdDate = new DateTime(2026, 5, 29, 10, 0, 0, DateTimeKind.Utc);
@@ -86,7 +90,7 @@ namespace VirtoCommerce.XCart.Tests.Schemas
         // CompileToObject (used by ParseDictionary) requires every field's ResolvedType to be wired,
         // which only happens during a full schema initialization. Reference the input type as a query
         // argument and initialize a minimal schema so the field graph is resolved, then return the
-        // initialized instance. The factory override/registration must be set BEFORE this runs, because
+        // initialized instance. Any factory override must be registered BEFORE this runs, because
         // ExtendableInputObjectGraphType.Initialize resolves the actual type via the factory.
         private static InputNewCartItemType BuildInitializedType()
         {

--- a/tests/VirtoCommerce.XCart.Tests/Schemas/InputNewCartItemTypeTests.cs
+++ b/tests/VirtoCommerce.XCart.Tests/Schemas/InputNewCartItemTypeTests.cs
@@ -1,0 +1,114 @@
+using System;
+using System.Collections.Generic;
+using FluentAssertions;
+using GraphQL.Resolvers;
+using GraphQL.Types;
+using VirtoCommerce.Platform.Core.Common;
+using VirtoCommerce.XCart.Core.Models;
+using VirtoCommerce.XCart.Core.Schemas;
+using Xunit;
+
+namespace VirtoCommerce.XCart.Tests.Schemas
+{
+    // These tests exercise the global, static AbstractTypeFactory<NewCartItem> registry, which has no
+    // removal API in the consumed platform version. Rather than rely on a pristine global (which a
+    // sibling test could have dirtied), each test establishes its own precondition: the base-type tests
+    // force a direct "NewCartItem" name entry via RegisterType, which wins over the inheritance-chain
+    // fallback that resolves a registered override. No XCart test constructs NewCartItem through the
+    // factory, so the residual registration is benign for the rest of the suite.
+    public class InputNewCartItemTypeTests
+    {
+        [Fact]
+        public void ParseDictionary_WithOverride_YieldsOverrideType()
+        {
+            AbstractTypeFactory<NewCartItem>.OverrideType<NewCartItem, TestNewCartItem>();
+            var type = BuildInitializedType();
+
+            var parsed = type.ParseDictionary(new Dictionary<string, object>
+            {
+                ["productId"] = "p1",
+                ["quantity"] = 2,
+            });
+
+            parsed.Should().BeOfType<TestNewCartItem>();
+            ((NewCartItem)parsed).ProductId.Should().Be("p1");
+            ((NewCartItem)parsed).Quantity.Should().Be(2);
+        }
+
+        [Fact]
+        public void ParseDictionary_WithoutOverride_YieldsBaseType()
+        {
+            // RegisterType adds a direct "NewCartItem" name entry, which resolves to the base type even
+            // if a sibling test registered an override. Proves GraphQL.NET picks the parameterless ctor
+            // for the two-ctor NewCartItem without any [GraphQLConstructor] (same as InputNewWishlistItemType).
+            AbstractTypeFactory<NewCartItem>.RegisterType<NewCartItem>();
+            var type = BuildInitializedType();
+
+            var parsed = type.ParseDictionary(new Dictionary<string, object>
+            {
+                ["productId"] = "p1",
+                ["quantity"] = 2,
+            });
+
+            parsed.Should().BeOfType<NewCartItem>();
+            ((NewCartItem)parsed).ProductId.Should().Be("p1");
+            ((NewCartItem)parsed).Quantity.Should().Be(2);
+        }
+
+        [Fact]
+        public void ParseDictionary_RoundTrips_ScalarFields()
+        {
+            // Scalar-field parity guard for the InputObjectGraphType -> ExtendableInputObjectGraphType
+            // re-base. The re-base swaps the base class uniformly across all fields via one shared
+            // ParseDictionary path, so scalar parity de-risks it. Nested-list fidelity (dynamicProperties,
+            // configurationSections) is an orthogonal GraphQL.NET concern unaffected by the re-base and is
+            // covered end-to-end by the LEO-side override test and the integration test.
+            AbstractTypeFactory<NewCartItem>.RegisterType<NewCartItem>();
+            var type = BuildInitializedType();
+
+            var createdDate = new DateTime(2026, 5, 29, 10, 0, 0, DateTimeKind.Utc);
+            var parsed = (NewCartItem)type.ParseDictionary(new Dictionary<string, object>
+            {
+                ["productId"] = "p1",
+                ["quantity"] = 5,
+                ["price"] = 12.34m,
+                ["comment"] = "hello",
+                ["createdDate"] = createdDate,
+            });
+
+            parsed.ProductId.Should().Be("p1");
+            parsed.Quantity.Should().Be(5);
+            parsed.Price.Should().Be(12.34m);
+            parsed.Comment.Should().Be("hello");
+            parsed.CreatedDate.Should().Be(createdDate);
+        }
+
+        // CompileToObject (used by ParseDictionary) requires every field's ResolvedType to be wired,
+        // which only happens during a full schema initialization. Reference the input type as a query
+        // argument and initialize a minimal schema so the field graph is resolved, then return the
+        // initialized instance. The factory override/registration must be set BEFORE this runs, because
+        // ExtendableInputObjectGraphType.Initialize resolves the actual type via the factory.
+        private static InputNewCartItemType BuildInitializedType()
+        {
+            var type = new InputNewCartItemType();
+
+            var query = new ObjectGraphType { Name = "Query" };
+            query.AddField(new FieldType
+            {
+                Name = "probe",
+                Type = typeof(StringGraphType),
+                Arguments = new QueryArguments(new QueryArgument(type) { Name = "item" }),
+                Resolver = new FuncFieldResolver<string>(_ => null),
+            });
+
+            var schema = new Schema { Query = query };
+            schema.Initialize();
+
+            return type;
+        }
+
+        private sealed class TestNewCartItem : NewCartItem
+        {
+        }
+    }
+}

--- a/tests/VirtoCommerce.XCart.Tests/VirtoCommerce.XCart.Tests.csproj
+++ b/tests/VirtoCommerce.XCart.Tests/VirtoCommerce.XCart.Tests.csproj
@@ -13,13 +13,14 @@
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageReference Include="Moq" Version="4.20.72" />
-    <PackageReference Include="VirtoCommerce.CartModule.Data" Version="3.1001.0-alpha.776-variation-configuration-type" />
     <PackageReference Include="xunit.v3" Version="3.2.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="FluentAssertions" Version="7.2.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.1017.0" />
+    <PackageReference Include="VirtoCommerce.CartModule.Data" Version="3.1002.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\VirtoCommerce.XCart.Data\VirtoCommerce.XCart.Data.csproj" />

--- a/tests/VirtoCommerce.XCart.Tests/VirtoCommerce.XCart.Tests.csproj
+++ b/tests/VirtoCommerce.XCart.Tests/VirtoCommerce.XCart.Tests.csproj
@@ -19,7 +19,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="FluentAssertions" Version="7.2.0" />
-    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.1007.10" />
+    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.1017.0" />
     <PackageReference Include="VirtoCommerce.CartModule.Data" Version="3.1002.0" />
   </ItemGroup>
   <ItemGroup>

--- a/tests/VirtoCommerce.XCart.Tests/VirtoCommerce.XCart.Tests.csproj
+++ b/tests/VirtoCommerce.XCart.Tests/VirtoCommerce.XCart.Tests.csproj
@@ -19,7 +19,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="FluentAssertions" Version="7.2.0" />
-    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.1017.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.1007.10" />
     <PackageReference Include="VirtoCommerce.CartModule.Data" Version="3.1002.0" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
## Motivation

`NewCartItem` — the carrier passed into `CartAggregate.AddItemAsync` / `AddConfiguredItemAsync` — was always constructed with `new NewCartItem(...)`. That hard-codes the concrete type, so a downstream module that needs to extend the cart-item carrier (extra fields flowing from the GraphQL input through to the aggregate) has no seam to do so: even after registering an `AbstractTypeFactory` override, every construction site still produced the base type, and the GraphQL `InputNewCartItemType` deserialized straight to `NewCartItem`.

## Changes

- **`NewCartItem`** — add a parameterless constructor alongside the existing `(productId, quantity)` one, so the type is constructible via `AbstractTypeFactory<NewCartItem>.TryCreateInstance()`. No behavioural change; the existing constructor is retained.
- **`InputNewCartItemType`** — re-base from `InputObjectGraphType<NewCartItem>` to `ExtendableInputObjectGraphType<NewCartItem>`. The extendable base resolves the actual CLR type via `AbstractTypeFactory` during schema initialization, so a registered override is honoured on GraphQL deserialization. With no override registered, it resolves to the base type exactly as before (the inheritance-chain fallback in `AbstractTypeFactory.FindTypeInfoByName` makes a base `RegisterType` unnecessary).
- **`AddCartItemCommandHandler`** — extract a `protected virtual NewCartItem CreateNewCartItem(AddCartItemCommand, CartProduct)` seam so the single-add construction can be overridden without re-implementing the configurable-vs-flat dispatch.
- **Construction sites** — route the remaining `new NewCartItem(...)` usages across the Data project through `AbstractTypeFactory<NewCartItem>.TryCreateInstance()` so an override applies uniformly.

## Tests

New `InputNewCartItemTypeTests` covers the factory-aware deserialization:
- with an override registered → `ParseDictionary` yields the override type;
- without an override → yields the base type (confirms the two-constructor type deserializes via the parameterless constructor with no `[GraphQLConstructor]` annotation, matching the existing `InputNewWishlistItemType` binding);
- scalar-field round-trip parity across the base-class change.

Full XCart test suite: 201/201 green.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Wide touch across cart mutation/copy paths; behavior should match when no override is registered, but any factory mis-registration could affect line-item creation across add, wishlist, currency, and bulk flows.
> 
> **Overview**
> Introduces an **extension seam** for `NewCartItem` so downstream modules can substitute a derived type for cart add/copy flows and GraphQL cart-item inputs, instead of always materializing the base class.
> 
> `NewCartItem` gains a **parameterless constructor** for factory construction; **`InputNewCartItemType`** now inherits **`ExtendableInputObjectGraphType<NewCartItem>`** so deserialization honors `AbstractTypeFactory` overrides. **`AddCartItemCommandHandler`** exposes **`CreateNewCartItem`** as a `protected virtual` hook; other Data-layer sites that built `new NewCartItem(...)` now use **`AbstractTypeFactory<NewCartItem>.TryCreateInstance()`** with the same property assignments (bulk add, wishlist, currency change, clones, quantity updates, saved-for-later, etc.).
> 
> **Platform/module** references move to **3.1017.0**; new **`InputNewCartItemTypeTests`** cover override vs base type parsing and scalar field round-trip.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 74a091e6b57388ab22b63b306e8e43b1724e37ff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.XCart_3.1017.0-pr-121-74a0.zip