### PR TITLE
VCST-5233: Fix case-sensitive coupon matching in cart validation

### DIFF
--- a/src/VirtoCommerce.XCart.Core/CartAggregate.cs
+++ b/src/VirtoCommerce.XCart.Core/CartAggregate.cs
@@ -127,7 +127,7 @@ namespace VirtoCommerce.XCart.Core
                     var cartCoupon = new CartCoupon
                     {
                         Code = coupon,
-                        IsAppliedSuccessfully = allAppliedCoupons.Contains(coupon)
+                        IsAppliedSuccessfully = allAppliedCoupons.Any(c => c.EqualsIgnoreCase(coupon))
                     };
                     yield return cartCoupon;
                 }
@@ -1005,7 +1005,7 @@ namespace VirtoCommerce.XCart.Core
                 return false;
             }
 
-            var validCoupon = promotionResult.Rewards.FirstOrDefault(x => x.IsValid && x.Coupon == coupon);
+            var validCoupon = promotionResult.Rewards.FirstOrDefault(x => x.IsValid && x.Coupon.EqualsIgnoreCase(coupon));
 
             return validCoupon != null;
         }

--- a/tests/VirtoCommerce.XCart.Tests/Aggregates/CartAggregateTests.cs
+++ b/tests/VirtoCommerce.XCart.Tests/Aggregates/CartAggregateTests.cs
@@ -9,6 +9,7 @@ using FluentAssertions;
 using Moq;
 using VirtoCommerce.CartModule.Core.Model;
 using VirtoCommerce.CatalogModule.Core.Model;
+using VirtoCommerce.CoreModule.Core.Common;
 using VirtoCommerce.CoreModule.Core.Currency;
 using VirtoCommerce.FileExperienceApi.Core.Models;
 using VirtoCommerce.MarketingModule.Core.Model.Promotions;
@@ -970,6 +971,80 @@ namespace VirtoCommerce.XCart.Tests.Aggregates
 
             // Assert
             result.Should().BeTrue();
+        }
+
+        // VCST-5233: a coupon stored in non-uppercase case (the promotion engine + DB match
+        // case-insensitively and DynamicPromotion stamps the reward with the stored canonical
+        // code) must still validate when the entered code differs only in case. Mirrors the
+        // case-insensitive handling already used by AddCouponAsync/RemoveCouponAsync.
+        [Fact]
+        public async Task ValidateCouponAsync_CaseInsensitiveMatch_CouponValidated()
+        {
+            // Arrange
+            var cartAggregate = GetValidCartAggregate();
+            var lineItem = _fixture.Create<LineItem>();
+            lineItem.SelectedForCheckout = true;
+            cartAggregate.Cart.Items = [lineItem];
+
+            // Stored/canonical coupon code as returned by the promotion engine.
+            var storedCoupon = "agent";
+            // Entered code differs only in case (what the shopper submits).
+            var enteredCoupon = "AGENT";
+
+            var context = new PromotionEvaluationContext
+            {
+                Coupon = enteredCoupon,
+            };
+
+            var stub = new PromotionResult();
+            stub.Rewards.Add(new StubPromotionReward
+            {
+                Coupon = storedCoupon,
+                IsValid = true,
+            });
+
+            _mapperMock.Setup(x => x.Map<PromotionEvaluationContext>(It.Is<CartAggregate>(x => x == cartAggregate)))
+                .Returns(context);
+
+            _marketingPromoEvaluatorMock
+               .Setup(x => x.EvaluatePromotionAsync(It.Is<PromotionEvaluationContext>(x => x.Coupon == enteredCoupon)))
+               .ReturnsAsync(stub);
+
+            _genericPipelineLauncherMock.Setup(x => x.Execute(It.IsAny<PromotionEvaluationContextCartMap>()))
+                .Callback<PromotionEvaluationContextCartMap>(x =>
+                {
+                    x.PromotionEvaluationContext = _mapperMock.Object.Map<PromotionEvaluationContext>(cartAggregate);
+                });
+
+            // Act
+            var result = await cartAggregate.ValidateCouponAsync(enteredCoupon);
+
+            // Assert
+            result.Should().BeTrue();
+        }
+
+        [Fact]
+        public void Coupons_CaseInsensitiveMatch_ReportsAppliedSuccessfully()
+        {
+            // Arrange
+            var cartAggregate = GetValidCartAggregate();
+
+            // Stored/canonical coupon code stamped onto the applied discount by the engine.
+            var storedCoupon = "agent";
+            // Entered code differs only in case (what the shopper added to the cart).
+            var enteredCoupon = "AGENT";
+
+            cartAggregate.Cart.Coupons = new List<string> { enteredCoupon };
+            cartAggregate.Cart.Discounts = new List<Discount>
+            {
+                new Discount { Coupon = storedCoupon },
+            };
+
+            // Act
+            var couponState = cartAggregate.Coupons.Single(x => x.Code == enteredCoupon);
+
+            // Assert
+            couponState.IsAppliedSuccessfully.Should().BeTrue();
         }
 
         #endregion ValidateCouponAsync


### PR DESCRIPTION
## Summary
Cart coupon validation now matches the entered code against the stored canonical code case-insensitively, consistent with how the promotion engine, the DB, and this file's own Add/RemoveCoupon already behave. Fixes JIRA **VCST-5233**.

## Root cause
The promotion engine + DB match coupons case-insensitively and `DynamicPromotion` stamps the reward with the stored canonical code (e.g. `agent`). The cart layer then re-checked the entered code (`AGENT`) ordinally at two sites and rejected the valid coupon.

## Fix
`src/VirtoCommerce.XCart.Core/CartAggregate.cs`, two comparison sites, reusing the file's existing `EqualsIgnoreCase` extension (no new using):
- `Coupons` getter: `allAppliedCoupons.Contains(coupon)` → `allAppliedCoupons.Any(c => c.EqualsIgnoreCase(coupon))`
- `ValidateCouponAsync`: `x.Coupon == coupon` → `x.Coupon.EqualsIgnoreCase(coupon)`

Minimal diff; no signature/DTO/GraphQL/contract/migration change; marketing module untouched.

## Test (red → green)
Added `CartAggregateTests.ValidateCouponAsync_CaseInsensitiveMatch_CouponValidated` and `CartAggregateTests.Coupons_CaseInsensitiveMatch_ReportsAppliedSuccessfully`: stored `agent`, entered `AGENT` → both assert true. Fail on current code, pass with the fix. Existing tests untouched.

## Verification
- [x] `dotnet build -c Debug` — 0 warnings / 0 errors
- [x] `dotnet test` (XCart.Tests) — 203 passed / 0 failed / 0 skipped

## ⚠ Needs deploy verification
Statically verified only. The live storefront symptom from VCST-5233 must be re-confirmed after this module builds and deploys to QA (regression pipeline + `/qa-verify-fix VCST-5233`).

> 🤖 Opened by the QA auto-fix pipeline. **DO NOT MERGE until human review + deploy verification.**

Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-5233
Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.XCart_3.1020.0-pr-123-f160.zip