### PR TITLE
VCST-5234: Fix line item validation errors lost after cart save

### DIFF
--- a/src/VirtoCommerce.XCart.Core/CartAggregate.cs
+++ b/src/VirtoCommerce.XCart.Core/CartAggregate.cs
@@ -249,6 +249,24 @@ namespace VirtoCommerce.XCart.Core
 #pragma warning restore VC0015
         }
 
+        /// <summary>
+        /// Re-validates the cart with the line-item ruleset and returns the validation errors for the
+        /// specified line item. Used by the GraphQL per-line resolvers so the line-level
+        /// validationErrors/isValid stay consistent with the cart-level resolver after a save clears the
+        /// validation cache. Results are cached per ruleSet by <see cref="ValidateAsync(string)"/>.
+        /// </summary>
+        public virtual async Task<IList<CartValidationError>> GetLineItemValidationErrorsAsync(LineItem lineItem)
+        {
+            ArgumentNullException.ThrowIfNull(lineItem);
+
+            var errors = await ValidateAsync(ModuleConstants.ValidationRuleSets.Items);
+
+            return errors
+                .Concat(OperationValidationErrors)
+                .GetEntityCartErrors(lineItem)
+                .ToList();
+        }
+
         public virtual CartAggregate GrabCart(ShoppingCart cart, Store store, Member member, Currency currency)
         {
             Id = cart.Id;
@@ -934,6 +952,11 @@ namespace VirtoCommerce.XCart.Core
         /// Validates the cart with the specified <paramref name="ruleSet"/>. Results are cached
         /// per ruleSet in <see cref="ValidationErrorsByRuleSet"/> — subsequent calls with the same
         /// ruleSet return cached results without re-running validation.
+        /// <para>
+        /// Delegates to <see cref="ValidateAsync(CartValidationContext, string)"/>, which remains the
+        /// virtual extension point for derived aggregates during its deprecation window — overrides of
+        /// that overload participate in every validation triggered through this method.
+        /// </para>
         /// </summary>
         public virtual async Task<IList<ValidationFailure>> ValidateAsync(string ruleSet)
         {
@@ -954,17 +977,10 @@ namespace VirtoCommerce.XCart.Core
             EnsureCartExists();
 
             var validationContext = await _cartValidationContextFactory.CreateValidationContextAsync(this);
-            validationContext.CartAggregate = this;
 
-            var rules = ruleSet?.Split(RuleSetSeparator, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
-            var result = await AbstractTypeFactory<CartValidator>.TryCreateInstance().ValidateAsync(validationContext, options => options.IncludeRuleSets(rules));
-
-            ValidationErrorsByRuleSet[key] = result.Errors;
-#pragma warning disable VC0015 // Obsolete: maintained for backward compatibility
-            CartValidationErrors = result.Errors;
-#pragma warning restore VC0015
-
-            return result.Errors;
+#pragma warning disable VC0009 // Obsolete overload is intentionally kept as the virtual extension point
+            return await ValidateAsync(validationContext, ruleSet);
+#pragma warning restore VC0009
         }
 
         [Obsolete("Use ValidateAsync(string ruleSet). The context is now created internally.", DiagnosticId = "VC0009", UrlFormat = "https://docs.virtocommerce.org/products/products-virto3-versions/")]
@@ -1401,6 +1417,8 @@ namespace VirtoCommerce.XCart.Core
         /// <summary>
         /// Normalizes a ruleSet string into a consistent cache key for <see cref="ValidationErrorsByRuleSet"/>.
         /// Sorts composite rulesets ("shipments,default" → "default,shipments") and collapses "*" variants.
+        /// Protected so derived aggregates that post-process validation results can update
+        /// the cache entry for a ruleSet under the same key the base class uses.
         /// <para>
         /// Note: composite keys like "default,shipments" and standalone "default" are cached separately
         /// even though the composite result is a superset. This is a deliberate design decision —
@@ -1408,7 +1426,7 @@ namespace VirtoCommerce.XCart.Core
         /// without meaningful performance benefit in practice.
         /// </para>
         /// </summary>
-        private static string NormalizeRuleSet(string ruleSet)
+        protected static string NormalizeRuleSet(string ruleSet)
         {
             if (string.IsNullOrEmpty(ruleSet))
             {

--- a/src/VirtoCommerce.XCart.Core/Schemas/LineItemType.cs
+++ b/src/VirtoCommerce.XCart.Core/Schemas/LineItemType.cs
@@ -53,10 +53,10 @@ namespace VirtoCommerce.XCart.Core.Schemas
 
             Field<NonNullGraphType<BooleanGraphType>>("IsValid")
                 .Description("Shows whether this is valid")
-                .Resolve(context => !context.GetCart().GetValidationErrors().GetEntityCartErrors(context.Source).Any());
+                .ResolveAsync(async context => (await context.GetCart().GetLineItemValidationErrorsAsync(context.Source)).Count == 0);
             Field<NonNullGraphType<ListGraphType<NonNullGraphType<ValidationErrorType>>>>("validationErrors")
                 .Description("Validation errors")
-                .Resolve(context => context.GetCart().GetValidationErrors().GetEntityCartErrors(context.Source));
+                .ResolveAsync(async context => await context.GetCart().GetLineItemValidationErrorsAsync(context.Source));
 
             Field(x => x.CatalogId, nullable: false).Description("Catalog ID value");
             Field(x => x.CategoryId, nullable: true).Description("Category ID value");

--- a/tests/VirtoCommerce.XCart.Tests/Aggregates/CartAggregateTests.cs
+++ b/tests/VirtoCommerce.XCart.Tests/Aggregates/CartAggregateTests.cs
@@ -928,6 +928,116 @@ namespace VirtoCommerce.XCart.Tests.Aggregates
 
         #endregion ValidateAsync
 
+        #region GetLineItemValidationErrorsAsync
+
+        [Fact]
+        public async Task GetLineItemValidationErrorsAsync_AfterCacheCleared_RevalidatesAndReturnsLineItemErrors()
+        {
+            // Arrange
+            // Regression guard for VCST-5234: after a save clears the validation cache, the per-line
+            // validationErrors/isValid resolvers must still re-validate (like the cart-level resolver)
+            // instead of reading the now-empty obsolete sync store.
+            var cartAggregate = GetValidCartAggregate();
+            cartAggregate.ValidationRuleSet = ["default"];
+
+            var invalidLineItem = new LineItem
+            {
+                Id = "line-1",
+                ProductId = "product-1",
+                Currency = CURRENCY_CODE,
+                IsGift = false,
+                SelectedForCheckout = true,
+                Quantity = ModuleConstants.LineItemQualityLimit + 1,
+            };
+            cartAggregate.Cart.Items = new List<LineItem> { invalidLineItem };
+
+            _cartValidationContextFactoryMock
+                .Setup(x => x.CreateValidationContextAsync(cartAggregate))
+                .ReturnsAsync(new CartValidationContext());
+
+            // Simulate CartAggregateRepository.SaveAsync(), which clears the validation cache.
+            cartAggregate.ClearValidationCache();
+
+            // Act
+            var errors = await cartAggregate.GetLineItemValidationErrorsAsync(invalidLineItem);
+
+            // Assert
+            errors.Should().Contain(x => x.ErrorCode == "LINE_ITEM_LIMIT" && x.ObjectId == invalidLineItem.Id);
+        }
+
+        #endregion GetLineItemValidationErrorsAsync
+
+        #region ValidateAsync extensibility
+
+        [Fact]
+        public async Task ValidateAsync_DerivedOverridesContextOverload_OverrideParticipatesInValidation()
+        {
+            // Arrange
+            // Extensibility guard: derived aggregates (module customizations) override the virtual
+            // ValidateAsync(CartValidationContext, string) to append their own validation results.
+            // The ruleSet-only overload must delegate to it so those customizations keep working.
+            var aggregate = new ExtendedCartAggregate(
+                _marketingPromoEvaluatorMock.Object,
+                _shoppingCartTotalsCalculatorMock.Object,
+                _taxProviderSearchServiceMock.Object,
+                _cartProductServiceMock.Object,
+                _dynamicPropertyUpdaterService.Object,
+                _mapperMock.Object,
+                _memberService.Object,
+                _genericPipelineLauncherMock.Object,
+                _configurationItemValidatorMock.Object,
+                _fileUploadService.Object,
+                _cartSharingService.Object,
+                _cartValidationContextFactoryMock.Object);
+            aggregate.GrabCart(GetCart(), GetStore(), GetMember(), GetCurrency());
+
+            _cartValidationContextFactoryMock
+                .Setup(x => x.CreateValidationContextAsync(aggregate))
+                .ReturnsAsync(new CartValidationContext());
+
+            // Act
+            var errors = await aggregate.ValidateAsync("default");
+
+            // Assert
+            errors.Should().Contain(x => x.ErrorCode == ExtendedCartAggregate.CustomErrorCode);
+        }
+
+        private class ExtendedCartAggregate : CartAggregate
+        {
+            public const string CustomErrorCode = "CUSTOM_VALIDATION_ERROR";
+
+            public ExtendedCartAggregate(
+                VirtoCommerce.MarketingModule.Core.Services.IMarketingPromoEvaluator marketingEvaluator,
+                VirtoCommerce.CartModule.Core.Services.IShoppingCartTotalsCalculator cartTotalsCalculator,
+                VirtoCommerce.Platform.Core.Modularity.IOptionalDependency<VirtoCommerce.TaxModule.Core.Services.ITaxProviderSearchService> taxProviderSearchService,
+                VirtoCommerce.XCart.Core.Services.ICartProductService cartProductService,
+                VirtoCommerce.Xapi.Core.Services.IDynamicPropertyUpdaterService dynamicPropertyUpdaterService,
+                IMapper mapper,
+                VirtoCommerce.CustomerModule.Core.Services.IMemberService memberService,
+                VirtoCommerce.Xapi.Core.Pipelines.IGenericPipelineLauncher pipeline,
+                IConfigurationItemValidator configurationItemValidator,
+                VirtoCommerce.FileExperienceApi.Core.Services.IFileUploadService fileUploadService,
+                VirtoCommerce.XCart.Core.Services.ICartSharingService cartSharingService,
+                ICartValidationContextFactory cartValidationContextFactory)
+                : base(marketingEvaluator, cartTotalsCalculator, taxProviderSearchService, cartProductService, dynamicPropertyUpdaterService, mapper, memberService, pipeline,
+                    configurationItemValidator, fileUploadService, cartSharingService, cartValidationContextFactory)
+            {
+            }
+
+#pragma warning disable VC0009 // The obsolete overload remains the virtual extension point during the deprecation window
+            public override async Task<IList<FluentValidation.Results.ValidationFailure>> ValidateAsync(CartValidationContext validationContext, string ruleSet)
+            {
+                var errors = await base.ValidateAsync(validationContext, ruleSet);
+
+                return errors
+                    .Concat(new[] { new CartValidationError("TestEntity", "test-id", "Custom validation error", CustomErrorCode) })
+                    .ToList();
+            }
+#pragma warning restore VC0009
+        }
+
+        #endregion ValidateAsync extensibility
+
         #region ValidateCouponAsync
 
         [Fact]


### PR DESCRIPTION
## Description
- Resolve LineItemType isValid/validationErrors by re-validating with the "items" ruleset (mirrors the cart-level resolver) instead of reading the obsolete sync error store that SaveAsync clears
- Restore ValidateAsync(CartValidationContext, string) as the virtual extension point: ValidateAsync(ruleSet) now delegates to it so derived aggregate overrides participate in all validation paths
- Make NormalizeRuleSet protected so derived aggregates can update the per-ruleSet validation cache under the same keys


## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-5234
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.XCart_3.1019.0-pr-124-89a6.zip
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes cart validation and GraphQL resolver behavior on a hot path; risk is mitigated by caching and targeted tests, but clients may see validation again where it was previously missing after save.
> 
> **Overview**
> Fixes **VCST-5234**: after `SaveAsync` clears the validation cache, GraphQL line-item **`isValid`** / **`validationErrors`** no longer read the obsolete sync `GetValidationErrors()` store (which stays empty). They now **async re-validate** via new **`GetLineItemValidationErrorsAsync`**, running the **`items`** ruleset and filtering errors for that line—aligned with how cart-level **`validationErrors`** calls **`ValidateAsync`**.
> 
> **`ValidateAsync(string)`** no longer inlines validator logic; it builds context and **delegates to** the virtual **`ValidateAsync(CartValidationContext, string)`** so custom **`CartAggregate`** subclasses that override the context overload still run on every validation path. **`NormalizeRuleSet`** is **`protected`** so subclasses can update the per-ruleset cache with the same keys.
> 
> Tests cover post-save cache clear behavior and derived-aggregate extensibility.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 89a6036ade1171cfbf65d813a76e186a0167fd08. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->