### PR TITLE
VCST-5103: Validators chain

### DIFF
--- a/src/VirtoCommerce.XCart.Core/CartAggregate.cs
+++ b/src/VirtoCommerce.XCart.Core/CartAggregate.cs
@@ -53,10 +53,10 @@ namespace VirtoCommerce.XCart.Core
         private readonly IMemberService _memberService;
         private readonly IMapper _mapper;
         private readonly IGenericPipelineLauncher _pipeline;
-        private readonly IConfigurationItemValidator _configurationItemValidator;
         private readonly IFileUploadService _fileUploadService;
         private readonly ICartSharingService _cartSharingService;
         private readonly ICartValidationContextFactory _cartValidationContextFactory;
+        private readonly ICartValidatorRegistry _cartValidatorRegistry;
 
         private const char RuleSetSeparator = ',';
 
@@ -69,10 +69,10 @@ namespace VirtoCommerce.XCart.Core
             IMapper mapper,
             IMemberService memberService,
             IGenericPipelineLauncher pipeline,
-            IConfigurationItemValidator configurationItemValidator,
             IFileUploadService fileUploadService,
             ICartSharingService cartSharingService,
-            ICartValidationContextFactory cartValidationContextFactory)
+            ICartValidationContextFactory cartValidationContextFactory,
+            ICartValidatorRegistry cartValidatorRegistry)
         {
             _cartTotalsCalculator = cartTotalsCalculator;
             _marketingEvaluator = marketingEvaluator;
@@ -82,10 +82,10 @@ namespace VirtoCommerce.XCart.Core
             _mapper = mapper;
             _memberService = memberService;
             _pipeline = pipeline;
-            _configurationItemValidator = configurationItemValidator;
             _fileUploadService = fileUploadService;
             _cartSharingService = cartSharingService;
             _cartValidationContextFactory = cartValidationContextFactory;
+            _cartValidatorRegistry = cartValidatorRegistry;
         }
 
         public Store Store { get; protected set; }
@@ -283,10 +283,10 @@ namespace VirtoCommerce.XCart.Core
             ArgumentNullException.ThrowIfNull(newCartItem);
             ArgumentNullException.ThrowIfNull(newConfiguredItem);
 
-            var validationResult = await _configurationItemValidator.ValidateAsync(newConfiguredItem);
-            if (!validationResult.IsValid)
+            var configurationErrors = await _cartValidatorRegistry.ValidateAsync(new ConfigurationItemValidationContext { LineItem = newConfiguredItem });
+            if (configurationErrors.Count > 0)
             {
-                OperationValidationErrors.AddRange(validationResult.Errors);
+                OperationValidationErrors.AddRange(configurationErrors);
 
                 if (!newCartItem.IgnoreValidationErrors)
                 {
@@ -329,10 +329,10 @@ namespace VirtoCommerce.XCart.Core
 
             EnsureCartExists();
 
-            var validationResult = await AbstractTypeFactory<NewCartItemValidator>.TryCreateInstance().ValidateAsync(newCartItem, options => options.IncludeRuleSets(ValidationRuleSet));
-            if (!validationResult.IsValid)
+            var validationErrors = await _cartValidatorRegistry.ValidateAsync(newCartItem, options => options.IncludeRuleSets(ValidationRuleSet));
+            if (validationErrors.Count > 0)
             {
-                OperationValidationErrors.AddRange(validationResult.Errors);
+                OperationValidationErrors.AddRange(validationErrors);
 
                 if (!newCartItem.IgnoreValidationErrors)
                 {
@@ -563,7 +563,7 @@ namespace VirtoCommerce.XCart.Core
             var lineItem = Cart.Items.FirstOrDefault(x => x.Id == priceAdjustment.LineItemId);
             if (lineItem != null)
             {
-                await AbstractTypeFactory<ChangeCartItemPriceValidator>.TryCreateInstance().ValidateAsync(priceAdjustment, options => options.IncludeRuleSets(ValidationRuleSet).ThrowOnFailures());
+                await _cartValidatorRegistry.ValidateAsync(priceAdjustment, options => options.IncludeRuleSets(ValidationRuleSet).ThrowOnFailures());
                 lineItem.ListPrice = priceAdjustment.NewPrice;
                 lineItem.SalePrice = priceAdjustment.NewPrice;
             }
@@ -575,10 +575,10 @@ namespace VirtoCommerce.XCart.Core
         {
             EnsureCartExists();
 
-            var validationResult = await AbstractTypeFactory<ItemQtyAdjustmentValidator>.TryCreateInstance().ValidateAsync(qtyAdjustment, options => options.IncludeRuleSets(ValidationRuleSet));
-            if (!validationResult.IsValid)
+            var validationErrors = await _cartValidatorRegistry.ValidateAsync(qtyAdjustment, options => options.IncludeRuleSets(ValidationRuleSet));
+            if (validationErrors.Count > 0)
             {
-                OperationValidationErrors.AddRange(validationResult.Errors);
+                OperationValidationErrors.AddRange(validationErrors);
             }
 
             var lineItem = Cart.Items.FirstOrDefault(i => i.Id == qtyAdjustment.LineItemId);
@@ -749,7 +749,7 @@ namespace VirtoCommerce.XCart.Core
                 Shipment = shipment,
                 AvailShippingRates = availRates
             };
-            await AbstractTypeFactory<CartShipmentValidator>.TryCreateInstance().ValidateAsync(validationContext, options => options.IncludeRuleSets(ValidationRuleSet).ThrowOnFailures());
+            await _cartValidatorRegistry.ValidateAsync(validationContext, options => options.IncludeRuleSets(ValidationRuleSet).ThrowOnFailures());
 
             shipment.Currency = Cart.Currency;
             if (shipment.DeliveryAddress != null)
@@ -828,7 +828,7 @@ namespace VirtoCommerce.XCart.Core
                 Payment = payment,
                 AvailPaymentMethods = availPaymentMethods
             };
-            await AbstractTypeFactory<CartPaymentValidator>.TryCreateInstance().ValidateAsync(validationContext, options => options.IncludeRuleSets(ValidationRuleSet).ThrowOnFailures());
+            await _cartValidatorRegistry.ValidateAsync(validationContext, options => options.IncludeRuleSets(ValidationRuleSet).ThrowOnFailures());
 
             payment.Currency ??= Cart.Currency;
             await RemoveExistingPaymentAsync(payment);
@@ -957,14 +957,14 @@ namespace VirtoCommerce.XCart.Core
             validationContext.CartAggregate = this;
 
             var rules = ruleSet?.Split(RuleSetSeparator, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
-            var result = await AbstractTypeFactory<CartValidator>.TryCreateInstance().ValidateAsync(validationContext, options => options.IncludeRuleSets(rules));
+            var errors = await _cartValidatorRegistry.ValidateAsync(validationContext, options => options.IncludeRuleSets(rules));
 
-            ValidationErrorsByRuleSet[key] = result.Errors;
+            ValidationErrorsByRuleSet[key] = errors;
 #pragma warning disable VC0015 // Obsolete: maintained for backward compatibility
-            CartValidationErrors = result.Errors;
+            CartValidationErrors = errors;
 #pragma warning restore VC0015
 
-            return result.Errors;
+            return errors;
         }
 
         [Obsolete("Use ValidateAsync(string ruleSet). The context is now created internally.", DiagnosticId = "VC0009", UrlFormat = "https://docs.virtocommerce.org/products/products-virto3-versions/")]
@@ -984,15 +984,15 @@ namespace VirtoCommerce.XCart.Core
             validationContext.CartAggregate = this;
 
             var rules = ruleSet?.Split(RuleSetSeparator, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
-            var result = await AbstractTypeFactory<CartValidator>.TryCreateInstance().ValidateAsync(validationContext, options => options.IncludeRuleSets(rules));
+            var errors = await _cartValidatorRegistry.ValidateAsync(validationContext, options => options.IncludeRuleSets(rules));
 
-            ValidationErrorsByRuleSet[key] = result.Errors;
-            CartValidationErrors = result.Errors;
+            ValidationErrorsByRuleSet[key] = errors;
+            CartValidationErrors = errors;
 
             // Backward compatibility: keep obsolete flag in sync
             IsValidated = true;
 
-            return result.Errors;
+            return errors;
         }
 
         public virtual async Task<bool> ValidateCouponAsync(string coupon)
@@ -1488,10 +1488,10 @@ namespace VirtoCommerce.XCart.Core
 
             if (lineItem != null)
             {
-                var validationResult = await _configurationItemValidator.ValidateAsync(configuredItem);
-                if (!validationResult.IsValid)
+                var configurationErrors = await _cartValidatorRegistry.ValidateAsync(new ConfigurationItemValidationContext { LineItem = configuredItem });
+                if (configurationErrors.Count > 0)
                 {
-                    OperationValidationErrors.AddRange(validationResult.Errors);
+                    OperationValidationErrors.AddRange(configurationErrors);
                     return this;
                 }
 
@@ -1574,10 +1574,10 @@ namespace VirtoCommerce.XCart.Core
                 return this;
             }
 
-            var validationResult = await _configurationItemValidator.ValidateAsync(cloneItem);
-            if (!validationResult.IsValid)
+            var configurationErrors = await _cartValidatorRegistry.ValidateAsync(new ConfigurationItemValidationContext { LineItem = cloneItem });
+            if (configurationErrors.Count > 0)
             {
-                OperationValidationErrors.AddRange(validationResult.Errors);
+                OperationValidationErrors.AddRange(configurationErrors);
                 return this;
             }
 
@@ -1651,10 +1651,10 @@ namespace VirtoCommerce.XCart.Core
                 return this;
             }
 
-            var validationResult = await _configurationItemValidator.ValidateAsync(cloneItem);
-            if (!validationResult.IsValid)
+            var configurationErrors = await _cartValidatorRegistry.ValidateAsync(new ConfigurationItemValidationContext { LineItem = cloneItem });
+            if (configurationErrors.Count > 0)
             {
-                OperationValidationErrors.AddRange(validationResult.Errors);
+                OperationValidationErrors.AddRange(configurationErrors);
                 return this;
             }
 
@@ -1871,10 +1871,10 @@ namespace VirtoCommerce.XCart.Core
                 }
             }
 
-            var validationResult = await _configurationItemValidator.ValidateAsync(cloneItem);
-            if (!validationResult.IsValid)
+            var configurationErrors = await _cartValidatorRegistry.ValidateAsync(new ConfigurationItemValidationContext { LineItem = cloneItem });
+            if (configurationErrors.Count > 0)
             {
-                OperationValidationErrors.AddRange(validationResult.Errors);
+                OperationValidationErrors.AddRange(configurationErrors);
                 return this;
             }
 

--- a/src/VirtoCommerce.XCart.Core/ModuleConstants.cs
+++ b/src/VirtoCommerce.XCart.Core/ModuleConstants.cs
@@ -35,6 +35,16 @@ namespace VirtoCommerce.XCart.Core
             public const string All = "*";
         }
 
+        /// <summary>
+        /// Relative ordering of <see cref="Validators.ICartValidator{TContext}"/> links in the chain.
+        /// Built-in validators use <see cref="Core"/> so they always run before module-supplied extensions.
+        /// </summary>
+        public static class ValidationOrder
+        {
+            public const int Core = -1000;
+        }
+
+
         public static class Settings
         {
             public static class General

--- a/src/VirtoCommerce.XCart.Core/ModuleConstants.cs
+++ b/src/VirtoCommerce.XCart.Core/ModuleConstants.cs
@@ -36,8 +36,7 @@ namespace VirtoCommerce.XCart.Core
         }
 
         /// <summary>
-        /// Relative ordering of <see cref="Validators.ICartValidator{TContext}"/> links in the chain.
-        /// Built-in validators use <see cref="Core"/> so they always run before module-supplied extensions.
+        /// Default order for the built-in validators
         /// </summary>
         public static class ValidationOrder
         {

--- a/src/VirtoCommerce.XCart.Core/Validators/CartLineItemValidator.cs
+++ b/src/VirtoCommerce.XCart.Core/Validators/CartLineItemValidator.cs
@@ -8,8 +8,10 @@ using VirtoCommerce.XCart.Core.Specifications;
 
 namespace VirtoCommerce.XCart.Core.Validators
 {
-    public class CartLineItemValidator : AbstractValidator<LineItemValidationContext>
+    public class CartLineItemValidator : AbstractValidator<LineItemValidationContext>, ICartValidator<LineItemValidationContext>
     {
+        public int Order => ModuleConstants.ValidationOrder.Core;
+
         public CartLineItemValidator()
         {
             RuleFor(x => x).Custom((lineItemContext, context) =>

--- a/src/VirtoCommerce.XCart.Core/Validators/CartPaymentValidator.cs
+++ b/src/VirtoCommerce.XCart.Core/Validators/CartPaymentValidator.cs
@@ -4,8 +4,10 @@ using VirtoCommerce.Platform.Core.Common;
 
 namespace VirtoCommerce.XCart.Core.Validators
 {
-    public class CartPaymentValidator : AbstractValidator<PaymentValidationContext>
+    public class CartPaymentValidator : AbstractValidator<PaymentValidationContext>, ICartValidator<PaymentValidationContext>
     {
+        public int Order => ModuleConstants.ValidationOrder.Core;
+
         public CartPaymentValidator()
         {
             //To support the use case for partial payment update when user sets the address first.

--- a/src/VirtoCommerce.XCart.Core/Validators/CartShipmentValidator.cs
+++ b/src/VirtoCommerce.XCart.Core/Validators/CartShipmentValidator.cs
@@ -4,8 +4,10 @@ using VirtoCommerce.Platform.Core.Common;
 
 namespace VirtoCommerce.XCart.Core.Validators
 {
-    public class CartShipmentValidator : AbstractValidator<ShipmentValidationContext>
+    public class CartShipmentValidator : AbstractValidator<ShipmentValidationContext>, ICartValidator<ShipmentValidationContext>
     {
+        public int Order => ModuleConstants.ValidationOrder.Core;
+
         public CartShipmentValidator()
         {
             //To support the use case for partial shipment update when user sets the address first.

--- a/src/VirtoCommerce.XCart.Core/Validators/CartValidator.cs
+++ b/src/VirtoCommerce.XCart.Core/Validators/CartValidator.cs
@@ -4,8 +4,10 @@ using VirtoCommerce.Platform.Core.Common;
 
 namespace VirtoCommerce.XCart.Core.Validators;
 
-public class CartValidator : AbstractValidator<CartValidationContext>
+public class CartValidator : AbstractValidator<CartValidationContext>, ICartValidator<CartValidationContext>
 {
+    public int Order => ModuleConstants.ValidationOrder.Core;
+
     protected virtual CartLineItemValidator LineItemValidator { get; set; }
     protected virtual CartShipmentValidator ShipmentValidator { get; set; }
     protected virtual CartPaymentValidator PaymentValidator { get; set; }

--- a/src/VirtoCommerce.XCart.Core/Validators/ChangeCartItemPriceValidator.cs
+++ b/src/VirtoCommerce.XCart.Core/Validators/ChangeCartItemPriceValidator.cs
@@ -3,8 +3,10 @@ using VirtoCommerce.XCart.Core.Models;
 
 namespace VirtoCommerce.XCart.Core.Validators
 {
-    public class ChangeCartItemPriceValidator : AbstractValidator<PriceAdjustment>
+    public class ChangeCartItemPriceValidator : AbstractValidator<PriceAdjustment>, ICartValidator<PriceAdjustment>
     {
+        public int Order => ModuleConstants.ValidationOrder.Core;
+
         public ChangeCartItemPriceValidator()
         {
             RuleFor(x => x.NewPrice).GreaterThanOrEqualTo(0);

--- a/src/VirtoCommerce.XCart.Core/Validators/ConfigurationItemContextValidator.cs
+++ b/src/VirtoCommerce.XCart.Core/Validators/ConfigurationItemContextValidator.cs
@@ -1,0 +1,31 @@
+using FluentValidation;
+
+namespace VirtoCommerce.XCart.Core.Validators;
+
+/// <summary>
+/// Core link of the configuration validation chain. Adapts the existing
+/// <see cref="IConfigurationItemValidator"/> (which validates a bare LineItem) to the
+/// <see cref="ConfigurationItemValidationContext"/> the chain is keyed by, so the built-in
+/// configuration rules keep running while other modules can append their own links.
+/// </summary>
+public class ConfigurationItemContextValidator : AbstractValidator<ConfigurationItemValidationContext>, ICartValidator<ConfigurationItemValidationContext>
+{
+    public int Order => ModuleConstants.ValidationOrder.Core;
+
+    public ConfigurationItemContextValidator(IConfigurationItemValidator configurationItemValidator)
+    {
+        RuleFor(x => x.LineItem).CustomAsync(async (lineItem, context, cancellationToken) =>
+        {
+            if (lineItem == null)
+            {
+                return;
+            }
+
+            var result = await configurationItemValidator.ValidateAsync(lineItem, cancellationToken);
+            foreach (var error in result.Errors)
+            {
+                context.AddFailure(error);
+            }
+        });
+    }
+}

--- a/src/VirtoCommerce.XCart.Core/Validators/ConfigurationItemContextValidator.cs
+++ b/src/VirtoCommerce.XCart.Core/Validators/ConfigurationItemContextValidator.cs
@@ -3,10 +3,7 @@ using FluentValidation;
 namespace VirtoCommerce.XCart.Core.Validators;
 
 /// <summary>
-/// Core link of the configuration validation chain. Adapts the existing
-/// <see cref="IConfigurationItemValidator"/> (which validates a bare LineItem) to the
-/// <see cref="ConfigurationItemValidationContext"/> the chain is keyed by, so the built-in
-/// configuration rules keep running while other modules can append their own links.
+/// Wrapper for the existing IConfigurationItemValidator as a link in the validation chain
 /// </summary>
 public class ConfigurationItemContextValidator : AbstractValidator<ConfigurationItemValidationContext>, ICartValidator<ConfigurationItemValidationContext>
 {

--- a/src/VirtoCommerce.XCart.Core/Validators/ConfigurationItemValidationContext.cs
+++ b/src/VirtoCommerce.XCart.Core/Validators/ConfigurationItemValidationContext.cs
@@ -3,11 +3,7 @@ using VirtoCommerce.CartModule.Core.Model;
 namespace VirtoCommerce.XCart.Core.Validators
 {
     /// <summary>
-    /// Validation context for a configured line item. Wraps the <see cref="LineItem"/> so the
-    /// configuration validation chain is keyed by a dedicated type rather than the shared
-    /// <see cref="LineItem"/> — this keeps it isolated from any other LineItem-based validators and
-    /// lets other modules contribute <see cref="ICartValidator{ConfigurationItemValidationContext}"/>
-    /// without colliding with unrelated validation.
+    /// Validation context for a configured line item, wraps the LineItem.
     /// </summary>
     public class ConfigurationItemValidationContext
     {

--- a/src/VirtoCommerce.XCart.Core/Validators/ConfigurationItemValidationContext.cs
+++ b/src/VirtoCommerce.XCart.Core/Validators/ConfigurationItemValidationContext.cs
@@ -1,0 +1,17 @@
+using VirtoCommerce.CartModule.Core.Model;
+
+namespace VirtoCommerce.XCart.Core.Validators
+{
+    /// <summary>
+    /// Validation context for a configured line item. Wraps the <see cref="LineItem"/> so the
+    /// configuration validation chain is keyed by a dedicated type rather than the shared
+    /// <see cref="LineItem"/> — this keeps it isolated from any other LineItem-based validators and
+    /// lets other modules contribute <see cref="ICartValidator{ConfigurationItemValidationContext}"/>
+    /// without colliding with unrelated validation.
+    /// </summary>
+    public class ConfigurationItemValidationContext
+    {
+        public LineItem LineItem { get; set; }
+    }
+
+}

--- a/src/VirtoCommerce.XCart.Core/Validators/ICartValidator.cs
+++ b/src/VirtoCommerce.XCart.Core/Validators/ICartValidator.cs
@@ -10,7 +10,7 @@ namespace VirtoCommerce.XCart.Core.Validators;
 /// Built-in validators and validators contributed by other modules implement this interface.
 /// </summary>
 /// <typeparam name="TContext">The object being validated (e.g. CartValidationContext, NewCartItem).</typeparam>
-public interface ICartValidator<TContext> : IValidator<TContext>
+public interface ICartValidator<in TContext> : IValidator<TContext>
 {
     /// <summary>
     /// Relative position in the chain. Lower runs first; built-in validators use

--- a/src/VirtoCommerce.XCart.Core/Validators/ICartValidator.cs
+++ b/src/VirtoCommerce.XCart.Core/Validators/ICartValidator.cs
@@ -1,0 +1,20 @@
+using FluentValidation;
+
+namespace VirtoCommerce.XCart.Core.Validators;
+
+/// <summary>
+/// A single link in the cart validation chain for a given <typeparamref name="TContext"/>.
+/// It is a plain FluentValidation <see cref="IValidator{T}"/> plus an <see cref="Order"/>; the
+/// <see cref="ICartValidatorRegistry"/> resolves all registered links for a context type, runs
+/// them ordered by <see cref="Order"/> via the native <c>ValidateAsync</c> and aggregates failures.
+/// Built-in validators and validators contributed by other modules implement this interface.
+/// </summary>
+/// <typeparam name="TContext">The object being validated (e.g. CartValidationContext, NewCartItem).</typeparam>
+public interface ICartValidator<TContext> : IValidator<TContext>
+{
+    /// <summary>
+    /// Relative position in the chain. Lower runs first; built-in validators use
+    /// <see cref="ModuleConstants.ValidationOrder.Core"/> so they run before extensions.
+    /// </summary>
+    int Order => 0;
+}

--- a/src/VirtoCommerce.XCart.Core/Validators/ICartValidator.cs
+++ b/src/VirtoCommerce.XCart.Core/Validators/ICartValidator.cs
@@ -3,18 +3,13 @@ using FluentValidation;
 namespace VirtoCommerce.XCart.Core.Validators;
 
 /// <summary>
-/// A single link in the cart validation chain for a given <typeparamref name="TContext"/>.
-/// It is a plain FluentValidation <see cref="IValidator{T}"/> plus an <see cref="Order"/>; the
-/// <see cref="ICartValidatorRegistry"/> resolves all registered links for a context type, runs
-/// them ordered by <see cref="Order"/> via the native <c>ValidateAsync</c> and aggregates failures.
+/// A single link in the cart validation chain for a given TContext.
 /// Built-in validators and validators contributed by other modules implement this interface.
 /// </summary>
-/// <typeparam name="TContext">The object being validated (e.g. CartValidationContext, NewCartItem).</typeparam>
 public interface ICartValidator<in TContext> : IValidator<TContext>
 {
     /// <summary>
-    /// Relative position in the chain. Lower runs first; built-in validators use
-    /// <see cref="ModuleConstants.ValidationOrder.Core"/> so they run before extensions.
+    /// Relative position in the chain. Lower runs first.
     /// </summary>
     int Order => 0;
 }

--- a/src/VirtoCommerce.XCart.Core/Validators/ICartValidatorRegistry.cs
+++ b/src/VirtoCommerce.XCart.Core/Validators/ICartValidatorRegistry.cs
@@ -7,17 +7,9 @@ using FluentValidation.Results;
 namespace VirtoCommerce.XCart.Core.Validators;
 
 /// <summary>
-/// Resolves every <see cref="ICartValidator{TContext}"/> registered for <typeparamref name="TContext"/>,
-/// runs them in <see cref="ICartValidator{TContext}.Order"/> order and returns the combined failures.
-/// This is the single entry point the cart aggregate uses to validate; built-in validators are the
-/// first links of the chain and other modules append their own.
+/// Resolves every ICartValidator{TContext} registered for TContext, runs them in order and returns the combined failures.
 /// </summary>
 public interface ICartValidatorRegistry
 {
-    /// <param name="context">The object to validate.</param>
-    /// <param name="options">
-    /// Optional FluentValidation strategy applied to every link (e.g. IncludeRuleSets(...).ThrowOnFailures() etc) to make a failing link throw
-    /// the chain stops at the first throwing validator; the core validator runs first.
-    /// </param>
     Task<IList<ValidationFailure>> ValidateAsync<TContext>(TContext context, Action<ValidationStrategy<TContext>> options = null);
 }

--- a/src/VirtoCommerce.XCart.Core/Validators/ICartValidatorRegistry.cs
+++ b/src/VirtoCommerce.XCart.Core/Validators/ICartValidatorRegistry.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using FluentValidation.Internal;
+using FluentValidation.Results;
+
+namespace VirtoCommerce.XCart.Core.Validators;
+
+/// <summary>
+/// Resolves every <see cref="ICartValidator{TContext}"/> registered for <typeparamref name="TContext"/>,
+/// runs them in <see cref="ICartValidator{TContext}.Order"/> order and returns the combined failures.
+/// This is the single entry point the cart aggregate uses to validate; built-in validators are the
+/// first links of the chain and other modules append their own.
+/// </summary>
+public interface ICartValidatorRegistry
+{
+    /// <param name="context">The object to validate.</param>
+    /// <param name="options">
+    /// Optional FluentValidation strategy applied to every link (e.g. IncludeRuleSets(...).ThrowOnFailures() etc) to make a failing link throw
+    /// the chain stops at the first throwing validator; the core validator runs first.
+    /// </param>
+    Task<IList<ValidationFailure>> ValidateAsync<TContext>(TContext context, Action<ValidationStrategy<TContext>> options = null);
+}

--- a/src/VirtoCommerce.XCart.Core/Validators/ItemQtyAdjustmentValidator.cs
+++ b/src/VirtoCommerce.XCart.Core/Validators/ItemQtyAdjustmentValidator.cs
@@ -5,8 +5,10 @@ using VirtoCommerce.XCart.Core.Specifications;
 
 namespace VirtoCommerce.XCart.Core.Validators
 {
-    public class ItemQtyAdjustmentValidator : AbstractValidator<ItemQtyAdjustment>
+    public class ItemQtyAdjustmentValidator : AbstractValidator<ItemQtyAdjustment>, ICartValidator<ItemQtyAdjustment>
     {
+        public int Order => ModuleConstants.ValidationOrder.Core;
+
         public ItemQtyAdjustmentValidator()
         {
             RuleFor(x => x.NewQuantity).GreaterThan(0);

--- a/src/VirtoCommerce.XCart.Core/Validators/NewCartItemValidator.cs
+++ b/src/VirtoCommerce.XCart.Core/Validators/NewCartItemValidator.cs
@@ -7,8 +7,10 @@ using VirtoCommerce.XCart.Core.Specifications;
 
 namespace VirtoCommerce.XCart.Core.Validators
 {
-    public class NewCartItemValidator : AbstractValidator<NewCartItem>
+    public class NewCartItemValidator : AbstractValidator<NewCartItem>, ICartValidator<NewCartItem>
     {
+        public int Order => ModuleConstants.ValidationOrder.Core;
+
         public NewCartItemValidator()
         {
             RuleFor(x => x.Quantity).GreaterThan(0);

--- a/src/VirtoCommerce.XCart.Data/Extensions/ServiceCollectionExtensions.cs
+++ b/src/VirtoCommerce.XCart.Data/Extensions/ServiceCollectionExtensions.cs
@@ -15,6 +15,7 @@ using VirtoCommerce.XCart.Core.Validators;
 using VirtoCommerce.XCart.Data.Authorization;
 using VirtoCommerce.XCart.Data.Middlewares;
 using VirtoCommerce.XCart.Data.Services;
+using VirtoCommerce.XCart.Data.Validators;
 using VirtoCommerce.XCatalog.Core.Models;
 
 namespace VirtoCommerce.XCart.Data.Extensions
@@ -39,6 +40,16 @@ namespace VirtoCommerce.XCart.Data.Extensions
             services.AddTransient<IConfiguredLineItemContainerService, ConfiguredLineItemContainerService>();
             services.AddTransient<IConfigurationItemValidator, ConfigurationItemValidator>();
             services.AddSingleton<IFileAuthorizationRequirementFactory, ConfigurationItemFileAuthorizationRequirementFactory>();
+
+            services.AddTransient<ICartValidatorRegistry, CartValidatorRegistry>();
+            services.AddTransient<ICartValidator<CartValidationContext>, CartValidator>();
+            services.AddTransient<ICartValidator<LineItemValidationContext>, CartLineItemValidator>();
+            services.AddTransient<ICartValidator<PaymentValidationContext>, CartPaymentValidator>();
+            services.AddTransient<ICartValidator<ShipmentValidationContext>, CartShipmentValidator>();
+            services.AddTransient<ICartValidator<ConfigurationItemValidationContext>, ConfigurationItemContextValidator>();
+            services.AddTransient<ICartValidator<NewCartItem>, NewCartItemValidator>();
+            services.AddTransient<ICartValidator<ItemQtyAdjustment>, ItemQtyAdjustmentValidator>();
+            services.AddTransient<ICartValidator<PriceAdjustment>, ChangeCartItemPriceValidator>();
 
             services.AddPipeline<SearchProductResponse>(builder =>
             {
@@ -66,6 +77,41 @@ namespace VirtoCommerce.XCart.Data.Extensions
             });
 
             services.AddPipeline<ShipmentContextCartMap>();
+
+            return services;
+        }
+
+        /// <summary>
+        /// Replaces a single registration identified by both its service type and its concrete
+        /// implementation type, keeping the original lifetime and position in the collection.
+        /// Use it to swap one specific link in a multi-registration service (e.g. replace
+        /// <c>CartValidator2</c> among several <c>ICartValidator&lt;CartValidationContext&gt;</c>
+        /// registrations) without touching the others — unlike <c>Replace</c> (matches the service
+        /// type only, takes the first) or <c>RemoveAll</c> (drops every registration).
+        /// </summary>
+        /// <typeparam name="TService">The registered service type, e.g. ICartValidator&lt;CartValidationContext&gt;.</typeparam>
+        /// <typeparam name="TOldImplementation">The concrete implementation to find and remove.</typeparam>
+        /// <typeparam name="TNewImplementation">The concrete implementation to register in its place.</typeparam>
+        /// <remarks>
+        /// Matches by <see cref="ServiceDescriptor.ImplementationType"/>, so it only works for
+        /// type-based registrations. Factory/instance registrations have no implementation type and
+        /// are skipped. No-op if no matching descriptor is found.
+        /// </remarks>
+        public static IServiceCollection ReplaceImplementation<TService, TOldImplementation, TNewImplementation>(
+            this IServiceCollection services)
+            where TService : class
+            where TOldImplementation : class, TService
+            where TNewImplementation : class, TService
+        {
+            for (var i = 0; i < services.Count; i++)
+            {
+                var descriptor = services[i];
+                if (descriptor.ServiceType == typeof(TService) && descriptor.ImplementationType == typeof(TOldImplementation))
+                {
+                    services[i] = ServiceDescriptor.Describe(typeof(TService), typeof(TNewImplementation), descriptor.Lifetime);
+                    break;
+                }
+            }
 
             return services;
         }

--- a/src/VirtoCommerce.XCart.Data/Extensions/ServiceCollectionExtensions.cs
+++ b/src/VirtoCommerce.XCart.Data/Extensions/ServiceCollectionExtensions.cs
@@ -83,20 +83,8 @@ namespace VirtoCommerce.XCart.Data.Extensions
 
         /// <summary>
         /// Replaces a single registration identified by both its service type and its concrete
-        /// implementation type, keeping the original lifetime and position in the collection.
-        /// Use it to swap one specific link in a multi-registration service (e.g. replace
-        /// <c>CartValidator2</c> among several <c>ICartValidator&lt;CartValidationContext&gt;</c>
-        /// registrations) without touching the others — unlike <c>Replace</c> (matches the service
-        /// type only, takes the first) or <c>RemoveAll</c> (drops every registration).
+        /// implementation type. Use it to swap one specific link in the CartValidator 
         /// </summary>
-        /// <typeparam name="TService">The registered service type, e.g. ICartValidator&lt;CartValidationContext&gt;.</typeparam>
-        /// <typeparam name="TOldImplementation">The concrete implementation to find and remove.</typeparam>
-        /// <typeparam name="TNewImplementation">The concrete implementation to register in its place.</typeparam>
-        /// <remarks>
-        /// Matches by <see cref="ServiceDescriptor.ImplementationType"/>, so it only works for
-        /// type-based registrations. Factory/instance registrations have no implementation type and
-        /// are skipped. No-op if no matching descriptor is found.
-        /// </remarks>
         public static IServiceCollection ReplaceImplementation<TService, TOldImplementation, TNewImplementation>(
             this IServiceCollection services)
             where TService : class

--- a/src/VirtoCommerce.XCart.Data/Validators/CartValidatorRegistry.cs
+++ b/src/VirtoCommerce.XCart.Data/Validators/CartValidatorRegistry.cs
@@ -10,11 +10,6 @@ using VirtoCommerce.XCart.Core.Validators;
 
 namespace VirtoCommerce.XCart.Data.Validators;
 
-/// <summary>
-/// Default <see cref="ICartValidatorRegistry"/>. Resolves the validator chain from the ambient
-/// <see cref="IServiceProvider"/> (the cart aggregate's scope), so scoped validators such as the
-/// configuration-item validator and module-supplied validators bind to the right scope.
-/// </summary>
 public class CartValidatorRegistry(IServiceProvider serviceProvider) : ICartValidatorRegistry
 {
     public async Task<IList<ValidationFailure>> ValidateAsync<TContext>(TContext context, Action<ValidationStrategy<TContext>> options = null)
@@ -27,7 +22,7 @@ public class CartValidatorRegistry(IServiceProvider serviceProvider) : ICartVali
 
         foreach (var validator in validators)
         {
-            // Throws here if the caller opted into ThrowOnFailures — chain stops at the first failing link.
+            // Throws here if the caller called ThrowOnFailures(), chain stops at the first failing link.
             var result = options is null
                 ? await validator.ValidateAsync(context)
                 : await validator.ValidateAsync(context, options);

--- a/src/VirtoCommerce.XCart.Data/Validators/CartValidatorRegistry.cs
+++ b/src/VirtoCommerce.XCart.Data/Validators/CartValidatorRegistry.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using FluentValidation;
+using FluentValidation.Internal;
+using FluentValidation.Results;
+using Microsoft.Extensions.DependencyInjection;
+using VirtoCommerce.XCart.Core.Validators;
+
+namespace VirtoCommerce.XCart.Data.Validators;
+
+/// <summary>
+/// Default <see cref="ICartValidatorRegistry"/>. Resolves the validator chain from the ambient
+/// <see cref="IServiceProvider"/> (the cart aggregate's scope), so scoped validators such as the
+/// configuration-item validator and module-supplied validators bind to the right scope.
+/// </summary>
+public class CartValidatorRegistry(IServiceProvider serviceProvider) : ICartValidatorRegistry
+{
+    public async Task<IList<ValidationFailure>> ValidateAsync<TContext>(TContext context, Action<ValidationStrategy<TContext>> options = null)
+    {
+        var errors = new List<ValidationFailure>();
+
+        var validators = serviceProvider
+            .GetServices<ICartValidator<TContext>>()
+            .OrderBy(x => x.Order);
+
+        foreach (var validator in validators)
+        {
+            // Throws here if the caller opted into ThrowOnFailures — chain stops at the first failing link.
+            var result = options is null
+                ? await validator.ValidateAsync(context)
+                : await validator.ValidateAsync(context, options);
+
+            errors.AddRange(result.Errors);
+        }
+
+        return errors;
+    }
+}

--- a/tests/VirtoCommerce.XCart.Tests/Aggregates/CartAggregateTests.cs
+++ b/tests/VirtoCommerce.XCart.Tests/Aggregates/CartAggregateTests.cs
@@ -986,10 +986,10 @@ namespace VirtoCommerce.XCart.Tests.Aggregates
                 _mapperMock.Object,
                 _memberService.Object,
                 _genericPipelineLauncherMock.Object,
-                _configurationItemValidatorMock.Object,
                 _fileUploadService.Object,
                 _cartSharingService.Object,
-                _cartValidationContextFactoryMock.Object);
+                _cartValidationContextFactoryMock.Object,
+                _cartValidatorRegistry);
             aggregate.GrabCart(GetCart(), GetStore(), GetMember(), GetCurrency());
 
             _cartValidationContextFactoryMock
@@ -1016,12 +1016,12 @@ namespace VirtoCommerce.XCart.Tests.Aggregates
                 IMapper mapper,
                 VirtoCommerce.CustomerModule.Core.Services.IMemberService memberService,
                 VirtoCommerce.Xapi.Core.Pipelines.IGenericPipelineLauncher pipeline,
-                IConfigurationItemValidator configurationItemValidator,
                 VirtoCommerce.FileExperienceApi.Core.Services.IFileUploadService fileUploadService,
                 VirtoCommerce.XCart.Core.Services.ICartSharingService cartSharingService,
-                ICartValidationContextFactory cartValidationContextFactory)
+                ICartValidationContextFactory cartValidationContextFactory,
+                ICartValidatorRegistry cartValidatorRegistry)
                 : base(marketingEvaluator, cartTotalsCalculator, taxProviderSearchService, cartProductService, dynamicPropertyUpdaterService, mapper, memberService, pipeline,
-                    configurationItemValidator, fileUploadService, cartSharingService, cartValidationContextFactory)
+                    fileUploadService, cartSharingService, cartValidationContextFactory, cartValidatorRegistry)
             {
             }
 

--- a/tests/VirtoCommerce.XCart.Tests/Aggregates/CartAggregateTests.cs
+++ b/tests/VirtoCommerce.XCart.Tests/Aggregates/CartAggregateTests.cs
@@ -41,10 +41,10 @@ namespace VirtoCommerce.XCart.Tests.Aggregates
                 _mapperMock.Object,
                 _memberService.Object,
                 _genericPipelineLauncherMock.Object,
-                _configurationItemValidatorMock.Object,
                 _fileUploadService.Object,
                 _cartSharingService.Object,
-                _cartValidationContextFactoryMock.Object);
+                _cartValidationContextFactoryMock.Object,
+                _cartValidatorRegistry);
 
             var cart = GetCart();
             var member = GetMember();

--- a/tests/VirtoCommerce.XCart.Tests/Helpers/XCartMoqHelper.cs
+++ b/tests/VirtoCommerce.XCart.Tests/Helpers/XCartMoqHelper.cs
@@ -59,9 +59,7 @@ namespace VirtoCommerce.XCart.Tests.Helpers
         protected readonly Mock<ICartSharingService> _cartSharingService;
         protected readonly Mock<ICartValidationContextFactory> _cartValidationContextFactoryMock;
 
-        // Not a mock on purpose: it runs the real validator chain, mirroring the legacy behavior where
-        // validators were created via AbstractTypeFactory (which couldn't be mocked) and honestly validated.
-        // Only IConfigurationItemValidator stays mocked, exactly as before.
+        // Not a mock on purpose: it runs the real validator chain, as they did when validators were created via AbstractTypeFactory
         protected readonly ICartValidatorRegistry _cartValidatorRegistry;
 
         protected readonly Randomizer Rand = new Randomizer();
@@ -211,10 +209,8 @@ namespace VirtoCommerce.XCart.Tests.Helpers
         }
 
         /// <summary>
-        /// Builds a real <see cref="CartValidatorRegistry"/> backed by the genuine validator chain,
-        /// so unit tests exercise the actual validators (as they did when validators were created via
-        /// AbstractTypeFactory). Only <see cref="IConfigurationItemValidator"/> is mocked, matching the
-        /// previous test setup.
+        /// Builds a real CartValidatorRegistry so unit tests exercise the actual validators,
+        /// as they did when validators were created via AbstractTypeFactory 
         /// </summary>
         private CartValidatorRegistry BuildCartValidatorRegistry()
         {

--- a/tests/VirtoCommerce.XCart.Tests/Helpers/XCartMoqHelper.cs
+++ b/tests/VirtoCommerce.XCart.Tests/Helpers/XCartMoqHelper.cs
@@ -4,6 +4,7 @@ using System.Threading;
 using AutoFixture;
 using AutoMapper;
 using Bogus;
+using Microsoft.Extensions.DependencyInjection;
 using Moq;
 using VirtoCommerce.CartModule.Core.Model;
 using VirtoCommerce.CartModule.Core.Services;
@@ -30,6 +31,7 @@ using VirtoCommerce.XCart.Core;
 using VirtoCommerce.XCart.Core.Models;
 using VirtoCommerce.XCart.Core.Services;
 using VirtoCommerce.XCart.Core.Validators;
+using VirtoCommerce.XCart.Data.Validators;
 using VirtoCommerce.XCart.Tests.Helpers.Stubs;
 using Store = VirtoCommerce.StoreModule.Core.Model.Store;
 
@@ -56,6 +58,11 @@ namespace VirtoCommerce.XCart.Tests.Helpers
         protected readonly Mock<IFileUploadService> _fileUploadService;
         protected readonly Mock<ICartSharingService> _cartSharingService;
         protected readonly Mock<ICartValidationContextFactory> _cartValidationContextFactoryMock;
+
+        // Not a mock on purpose: it runs the real validator chain, mirroring the legacy behavior where
+        // validators were created via AbstractTypeFactory (which couldn't be mocked) and honestly validated.
+        // Only IConfigurationItemValidator stays mocked, exactly as before.
+        protected readonly ICartValidatorRegistry _cartValidatorRegistry;
 
         protected readonly Randomizer Rand = new Randomizer();
 
@@ -199,6 +206,32 @@ namespace VirtoCommerce.XCart.Tests.Helpers
 
             _cartSharingService = new Mock<ICartSharingService>();
             _cartValidationContextFactoryMock = new Mock<ICartValidationContextFactory>();
+
+            _cartValidatorRegistry = BuildCartValidatorRegistry();
+        }
+
+        /// <summary>
+        /// Builds a real <see cref="ICartValidatorRegistry"/> backed by the genuine validator chain,
+        /// so unit tests exercise the actual validators (as they did when validators were created via
+        /// AbstractTypeFactory). Only <see cref="IConfigurationItemValidator"/> is mocked, matching the
+        /// previous test setup.
+        /// </summary>
+        private ICartValidatorRegistry BuildCartValidatorRegistry()
+        {
+            var services = new ServiceCollection();
+
+            services.AddSingleton(_configurationItemValidatorMock.Object);
+
+            services.AddTransient<ICartValidator<CartValidationContext>, CartValidator>();
+            services.AddTransient<ICartValidator<LineItemValidationContext>, CartLineItemValidator>();
+            services.AddTransient<ICartValidator<PaymentValidationContext>, CartPaymentValidator>();
+            services.AddTransient<ICartValidator<ShipmentValidationContext>, CartShipmentValidator>();
+            services.AddTransient<ICartValidator<ConfigurationItemValidationContext>, ConfigurationItemContextValidator>();
+            services.AddTransient<ICartValidator<NewCartItem>, NewCartItemValidator>();
+            services.AddTransient<ICartValidator<ItemQtyAdjustment>, ItemQtyAdjustmentValidator>();
+            services.AddTransient<ICartValidator<PriceAdjustment>, ChangeCartItemPriceValidator>();
+
+            return new CartValidatorRegistry(services.BuildServiceProvider());
         }
 
         protected ShoppingCart GetCart() => _fixture.Create<ShoppingCart>();
@@ -257,10 +290,10 @@ namespace VirtoCommerce.XCart.Tests.Helpers
                 _mapperMock.Object,
                 _memberService.Object,
                 _genericPipelineLauncherMock.Object,
-                _configurationItemValidatorMock.Object,
                 _fileUploadService.Object,
                 _cartSharingService.Object,
-                _cartValidationContextFactoryMock.Object);
+                _cartValidationContextFactoryMock.Object,
+                _cartValidatorRegistry);
 
             aggregate.GrabCart(cart ?? GetCart(), new Store(), null, currency ?? GetCurrency());
 
@@ -278,10 +311,10 @@ namespace VirtoCommerce.XCart.Tests.Helpers
                 _mapperMock.Object,
                 _memberService.Object,
                 _genericPipelineLauncherMock.Object,
-                _configurationItemValidatorMock.Object,
                 _fileUploadService.Object,
                 _cartSharingService.Object,
-                _cartValidationContextFactoryMock.Object);
+                _cartValidationContextFactoryMock.Object,
+                _cartValidatorRegistry);
 
             aggregate.GrabCart(cart ?? GetCart(), new Store(), GetMember(), currency ?? GetCurrency());
 

--- a/tests/VirtoCommerce.XCart.Tests/Helpers/XCartMoqHelper.cs
+++ b/tests/VirtoCommerce.XCart.Tests/Helpers/XCartMoqHelper.cs
@@ -211,12 +211,12 @@ namespace VirtoCommerce.XCart.Tests.Helpers
         }
 
         /// <summary>
-        /// Builds a real <see cref="ICartValidatorRegistry"/> backed by the genuine validator chain,
+        /// Builds a real <see cref="CartValidatorRegistry"/> backed by the genuine validator chain,
         /// so unit tests exercise the actual validators (as they did when validators were created via
         /// AbstractTypeFactory). Only <see cref="IConfigurationItemValidator"/> is mocked, matching the
         /// previous test setup.
         /// </summary>
-        private ICartValidatorRegistry BuildCartValidatorRegistry()
+        private CartValidatorRegistry BuildCartValidatorRegistry()
         {
             var services = new ServiceCollection();
 


### PR DESCRIPTION
## Description

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-5099
https://virtocommerce.atlassian.net/browse/VCST-5103
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.XCart_3.1022.0-pr-125-45bf.zip


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches all cart mutation and checkout validation paths; behavior should match prior validators but ThrowOnFailures and multi-validator ordering are new integration points for extensions.
> 
> **Overview**
> Cart validation is centralized through **`ICartValidatorRegistry`**, which resolves every **`ICartValidator<TContext>`** from DI, runs them in **`Order`**, and merges **`ValidationFailure`** results. **`CartAggregate`** no longer calls **`AbstractTypeFactory`** for validators or injects **`IConfigurationItemValidator`** directly; all add/update/shipment/payment/cart validation paths go through the registry.
> 
> Built-in FluentValidation types (**`CartValidator`**, line item/shipment/payment validators, **`NewCartItemValidator`**, qty/price adjusters, etc.) implement **`ICartValidator<>`** with **`ModuleConstants.ValidationOrder.Core`**. Configured items use **`ConfigurationItemValidationContext`** and **`ConfigurationItemContextValidator`**, which delegates to the existing **`IConfigurationItemValidator`**.
> 
> **`AddXCart`** registers the registry and each validator link; **`ReplaceImplementation`** lets modules swap a specific **`ICartValidator<>`** implementation without replacing the whole chain. Unit tests wire a real **`CartValidatorRegistry`** via a small **`ServiceCollection`** so behavior matches production registration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 45bf07a066de64c525e41a55abc27ed8b453b7c8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->