### PR TITLE
fix: collapse concurrent cart validations into a single-flight pass (GetFullCart product-search stampede)

### DIFF
--- a/src/VirtoCommerce.XCart.Core/CartAggregate.cs
+++ b/src/VirtoCommerce.XCart.Core/CartAggregate.cs
@@ -195,6 +195,15 @@ namespace VirtoCommerce.XCart.Core
         /// </summary>
         protected ConcurrentDictionary<string, IList<ValidationFailure>> ValidationErrorsByRuleSet { get; private set; } = new(StringComparer.OrdinalIgnoreCase);
 
+        /// <summary>
+        /// Tracks the in-flight validation task per ruleSet so concurrent callers share a single
+        /// validation pass. The GraphQL per-line-item isValid/validationErrors resolvers call
+        /// <see cref="ValidateAsync(string)"/> concurrently for every line in the cart; without this,
+        /// each call would build its own validation context and reload products from the catalog
+        /// index, causing a request-scoped search stampede. Cleared by <see cref="ClearValidationCache"/>.
+        /// </summary>
+        private readonly ConcurrentDictionary<string, Lazy<Task<IList<ValidationFailure>>>> _validationTasksByRuleSet = new(StringComparer.OrdinalIgnoreCase);
+
         public bool IsValid => ValidationErrorsByRuleSet.IsEmpty || ValidationErrorsByRuleSet.Values.All(x => x.Count == 0);
 
         [Obsolete("Use GetValidationErrors().", DiagnosticId = "VC0009", UrlFormat = "https://docs.virtocommerce.org/products/products-virto3-versions/")]
@@ -231,6 +240,7 @@ namespace VirtoCommerce.XCart.Core
         public void ClearValidationCache()
         {
             ValidationErrorsByRuleSet.Clear();
+            _validationTasksByRuleSet.Clear();
 #pragma warning disable VC0015 // Obsolete: maintained for backward compatibility
             CartValidationErrors = new List<ValidationFailure>();
 #pragma warning restore VC0015
@@ -976,11 +986,35 @@ namespace VirtoCommerce.XCart.Core
 
             EnsureCartExists();
 
-            var validationContext = await _cartValidationContextFactory.CreateValidationContextAsync(this);
+            // Single-flight: collapse concurrent validations of the same ruleSet into one pass.
+            // The GraphQL per-line-item isValid/validationErrors resolvers run concurrently, so without
+            // this each line would build its own validation context and reload products, flooding the
+            // catalog index with one search per line item instead of one per cart. Lazy guarantees the
+            // factory delegate runs at most once even under contended GetOrAdd.
+            var lazy = _validationTasksByRuleSet.GetOrAdd(
+                key,
+                _ => new Lazy<Task<IList<ValidationFailure>>>(() => CreateContextAndValidateAsync(ruleSet)));
+
+            return await lazy.Value;
+        }
+
+        private async Task<IList<ValidationFailure>> CreateContextAndValidateAsync(string ruleSet)
+        {
+            try
+            {
+                var validationContext = await _cartValidationContextFactory.CreateValidationContextAsync(this);
 
 #pragma warning disable VC0009 // Obsolete overload is intentionally kept as the virtual extension point
-            return await ValidateAsync(validationContext, ruleSet);
+                return await ValidateAsync(validationContext, ruleSet);
 #pragma warning restore VC0009
+            }
+            finally
+            {
+                // Drop the in-flight entry once complete; the durable result now lives in
+                // ValidationErrorsByRuleSet, and removing it lets a later pass (e.g. after
+                // ClearValidationCache) re-run, and a faulted validation be retried.
+                _validationTasksByRuleSet.TryRemove(NormalizeRuleSet(ruleSet), out _);
+            }
         }
 
         [Obsolete("Use ValidateAsync(string ruleSet). The context is now created internally.", DiagnosticId = "VC0009", UrlFormat = "https://docs.virtocommerce.org/products/products-virto3-versions/")]

--- a/tests/VirtoCommerce.XCart.Tests/Aggregates/CartAggregateTests.cs
+++ b/tests/VirtoCommerce.XCart.Tests/Aggregates/CartAggregateTests.cs
@@ -927,6 +927,43 @@ namespace VirtoCommerce.XCart.Tests.Aggregates
             cartAggregate.GetValidationErrors().Should().BeEmpty();
         }
 
+        [Fact]
+        public async Task ValidateAsync_ConcurrentCallsSameRuleSet_CreatesValidationContextOnce()
+        {
+            // Regression guard: the per-line-item isValid/validationErrors GraphQL resolvers call
+            // ValidateAsync(ruleSet) concurrently for every line in the cart. Without single-flight
+            // de-duplication each concurrent call builds its own validation context and reloads
+            // products, producing a catalog-search stampede (observed as ~N product searches per
+            // GetFullCart in load tests instead of one). All concurrent callers of the same ruleSet
+            // must share a single validation pass.
+
+            // Arrange
+            var cartAggregate = GetValidCartAggregate();
+
+            var contextCreations = 0;
+            var gate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            _cartValidationContextFactoryMock
+                .Setup(x => x.CreateValidationContextAsync(cartAggregate))
+                .Returns(async () =>
+                {
+                    Interlocked.Increment(ref contextCreations);
+                    await gate.Task;
+                    return new CartValidationContext();
+                });
+
+            // Act - fire many concurrent validations of the same ruleSet, then release the gate so
+            // they can complete. Each call runs synchronously up to the awaited context creation, so
+            // by the time the gate is released every caller has already entered ValidateAsync.
+            var tasks = Enumerable.Range(0, 50)
+                .Select(_ => cartAggregate.ValidateAsync("default"))
+                .ToList();
+            gate.SetResult();
+            await Task.WhenAll(tasks);
+
+            // Assert - the expensive validation context (which loads products) was built exactly once.
+            contextCreations.Should().Be(1);
+        }
+
         #endregion ValidateAsync
 
         #region GetLineItemValidationErrorsAsync

--- a/tests/VirtoCommerce.XCart.Tests/Performance/CartValidationStampedeDemo.cs
+++ b/tests/VirtoCommerce.XCart.Tests/Performance/CartValidationStampedeDemo.cs
@@ -1,0 +1,138 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using VirtoCommerce.CartModule.Core.Model;
+using VirtoCommerce.XCart.Core;
+using VirtoCommerce.XCart.Core.Models;
+using VirtoCommerce.XCart.Core.Validators;
+using VirtoCommerce.XCart.Tests.Helpers;
+using Xunit;
+
+namespace VirtoCommerce.XCart.Tests.Performance
+{
+    /// <summary>
+    /// Before/after demo for the GetFullCart validation stampede. Drives the REAL CartAggregate the
+    /// way GraphQL does — every line item's isValid/validationErrors resolver concurrently calls
+    /// GetLineItemValidationErrorsAsync -> ValidateAsync("Items") — while modeling the catalog index
+    /// as a bounded, latency-bearing dependency. Prints product-search count and wall-clock so you
+    /// can capture numbers on `dev` (before) and the fix branch (after).
+    ///
+    /// Run after  : dotnet test --filter FullyQualifiedName~CartValidationStampedeDemo
+    /// Run before : git checkout dev -- src/VirtoCommerce.XCart.Core/CartAggregate.cs  (then run, then restore)
+    /// </summary>
+    public class CartValidationStampedeDemo : XCartMoqHelper
+    {
+        private const int LineItemCount = 40;
+        private const int CatalogIndexMaxConcurrency = 4;   // models a bounded ES connection pool / cluster capacity
+        private const int ProductSearchLatencyMs = 120;     // observed per-call latency under load (prod: ~123 ms)
+
+        private readonly ITestOutputHelper _output;
+
+        public CartValidationStampedeDemo(ITestOutputHelper output)
+        {
+            _output = output;
+        }
+
+        [Fact]
+        public async Task GetFullCart_PerLineValidation_ProductSearchesDoNotScaleWithCartSize()
+        {
+            // Arrange - a cart with many line items and the catalog index modeled as a slow, bounded dependency.
+            var index = new BoundedCatalogIndexFake(CatalogIndexMaxConcurrency, ProductSearchLatencyMs);
+            var aggregate = BuildAggregate(index, LineItemCount);
+
+            // Act - reproduce GraphQL's concurrent per-line resolution of isValid + validationErrors.
+            var sw = Stopwatch.StartNew();
+            await Task.WhenAll(aggregate.Cart.Items.SelectMany(li => new[]
+            {
+                aggregate.GetLineItemValidationErrorsAsync(li),   // isValid resolver
+                aggregate.GetLineItemValidationErrorsAsync(li),   // validationErrors resolver
+            }));
+            sw.Stop();
+
+            // Report
+            _output.WriteLine($"line items            : {LineItemCount}");
+            _output.WriteLine($"product index searches: {index.SearchCount}");
+            _output.WriteLine($"GetFullCart wall-clock: {sw.ElapsedMilliseconds} ms");
+
+            // Guard - one validation pass per cart, regardless of size (fails on pre-fix code: ~{LineItemCount}).
+            Assert.True(index.SearchCount <= CatalogIndexMaxConcurrency,
+                $"Expected the catalog index to be hit a small constant number of times, but it was hit " +
+                $"{index.SearchCount} times for {LineItemCount} line items - the per-line validation stampede is back.");
+        }
+
+        private CartAggregate BuildAggregate(ICartValidationContextFactory validationContextFactory, int lineItemCount)
+        {
+            var aggregate = new CartAggregate(
+                _marketingPromoEvaluatorMock.Object,
+                _shoppingCartTotalsCalculatorMock.Object,
+                _taxProviderSearchServiceMock.Object,
+                _cartProductServiceMock.Object,
+                _dynamicPropertyUpdaterService.Object,
+                _mapperMock.Object,
+                _memberService.Object,
+                _genericPipelineLauncherMock.Object,
+                _configurationItemValidatorMock.Object,
+                _fileUploadService.Object,
+                _cartSharingService.Object,
+                validationContextFactory);
+
+            var currency = GetCurrency();
+            var cart = GetCart();
+            cart.Items = Enumerable.Range(0, lineItemCount)
+                .Select(i => new LineItem
+                {
+                    Id = $"li-{i}",
+                    ProductId = $"prod-{i}",
+                    Currency = currency.Code,
+                    Quantity = 1,
+                    SelectedForCheckout = true,
+                })
+                .ToList<LineItem>();
+
+            aggregate.GrabCart(cart, GetStore(), GetMember(), currency);
+            return aggregate;
+        }
+
+        /// <summary>
+        /// Models the catalog search index: every CreateValidationContextAsync call represents one
+        /// product search, throttled to <paramref name="maxConcurrency"/> in-flight calls, each taking
+        /// <paramref name="latencyMs"/>. This reproduces the real saturation behaviour (bounded pool +
+        /// per-call latency) without a live Elasticsearch.
+        /// </summary>
+        private sealed class BoundedCatalogIndexFake : ICartValidationContextFactory
+        {
+            private readonly SemaphoreSlim _capacity;
+            private readonly int _latencyMs;
+            private int _searchCount;
+
+            public BoundedCatalogIndexFake(int maxConcurrency, int latencyMs)
+            {
+                _capacity = new SemaphoreSlim(maxConcurrency, maxConcurrency);
+                _latencyMs = latencyMs;
+            }
+
+            public int SearchCount => _searchCount;
+
+            public async Task<CartValidationContext> CreateValidationContextAsync(CartAggregate cartAggregate)
+            {
+                await _capacity.WaitAsync();
+                try
+                {
+                    Interlocked.Increment(ref _searchCount);
+                    await Task.Delay(_latencyMs);
+                    return new CartValidationContext();
+                }
+                finally
+                {
+                    _capacity.Release();
+                }
+            }
+
+            public Task<CartValidationContext> CreateValidationContextAsync(CartAggregate cartAggregate, IList<CartProduct> products)
+                => CreateValidationContextAsync(cartAggregate);
+        }
+    }
+}


### PR DESCRIPTION
## Problem

Load-test telemetry (App Insights `vcptcore-loadtest`) shows `POST graphql/GetFullCart` degraded sharply starting the **6/14 run** (XCart `3.1019.0`, platform `3.1037.0`):

| Run | version | p50 | p95 | avg |
|---|---|---|---|---|
| 6/05 (good) | 10.0.8 | 436 | 1733 | 633 |
| 6/14 (bad) | 10.0.9 | 742 | **4189** | 1229 |
| 6/15 (bad) | 10.0.9 | 815 | **6409** | 1648 |

Decomposition pinned it to **Elasticsearch product searches per cart rising 3.6 → ~9** (per-call latency 10 ms → ~123 ms from saturation). A single slow `GetFullCart` issued **up to 43** `product-active/_search` calls — scaling with line-item count, i.e. an N+1.

## Root cause

The per-line-item GraphQL resolvers `isValid` / `validationErrors` ([LineItemType.cs](https://github.com/VirtoCommerce/vc-module-x-cart/blob/dev/src/VirtoCommerce.XCart.Core/Schemas/LineItemType.cs)) each call `GetLineItemValidationErrorsAsync` → `CartAggregate.ValidateAsync("Items")`. That method checks the `ValidationErrorsByRuleSet` cache, **misses**, builds a validation context via `ICartValidationContextFactory` (**which loads products from the catalog index**), and only writes the cache *after* validation completes.

`ValidationErrorsByRuleSet` is thread-safe but **not single-flight**. GraphQL resolves line-item fields concurrently, so for an N-line cart, ~N (up to 2N) calls enter `ValidateAsync("Items")` before any populates the cache → every one runs a full cart validation + product search. The per-line revalidation path was introduced in VCST-5234 (#124).

## Fix

Dedupe in-flight validation per normalized ruleSet with `ConcurrentDictionary<string, Lazy<Task<…>>>`, so concurrent callers await **one** shared validation pass → one context creation → one product search per cart. The durable result still lands in `ValidationErrorsByRuleSet`; the in-flight entry is dropped on completion and on `ClearValidationCache` (so post-save re-validation and faulted retries still work). The virtual `ValidateAsync(CartValidationContext, string)` extension point is unchanged.

## Tests

- **Regression guard** (`ValidateAsync_ConcurrentCallsSameRuleSet_CreatesValidationContextOnce`): 50 concurrent validations → asserts exactly 1 context creation. Verified RED (`found 50`) → GREEN.
- **Before/after perf demo** (`CartValidationStampedeDemo`): drives the real aggregate the way GraphQL does, modeling the catalog index as a bounded, latency-bearing dependency. Deterministic guard on search count.

Measured (40-line cart, 4-way index @120 ms):

| | product searches | wall-clock |
|---|---|---|
| before | **80** | **2509 ms** |
| after | **1** | **221 ms** |

Full suite: **207/207 green**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches hot-path validation and caching on `CartAggregate` used by GraphQL cart and line-item resolvers; behavior change is intentional (shared in-flight work) but wrong deduplication could mask or delay validation errors.
> 
> **Overview**
> **GetFullCart** and per-line GraphQL fields were triggering many parallel `ValidateAsync` calls for the same ruleSet before the result cache was filled, so each miss rebuilt the validation context and hit the catalog index again (product-search stampede).
> 
> `CartAggregate` now **dedupes in-flight validation per normalized ruleSet** with `ConcurrentDictionary` + `Lazy<Task<…>>`, so concurrent callers share one validation pass; results still land in `ValidationErrorsByRuleSet`, and both the in-flight map and cache clear on `ClearValidationCache` so post-save revalidation and retries stay correct.
> 
> Adds a **concurrency regression test** (50 parallel validations → one context creation) and a **perf demo** that models bounded catalog latency and asserts search count does not scale with line count.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ba5d76b117d51c1bb0025e524b944897f75a1280. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.XCart_3.1021.0-pr-126-ba5d.zip