### PR TITLE
VCST-5163: Stable 15 — XCart (platform 3.1039.0)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -337,3 +337,4 @@ ASALocalRun/
 .nuke
 dist/
 **/Properties/launchSettings.json
+/.serena

--- a/src/VirtoCommerce.XCart.Core/VirtoCommerce.XCart.Core.csproj
+++ b/src/VirtoCommerce.XCart.Core/VirtoCommerce.XCart.Core.csproj
@@ -9,15 +9,15 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="FluentValidation" Version="12.1.1" />
-    <PackageReference Include="VirtoCommerce.CartModule.Core" Version="3.1005.0" />
-    <PackageReference Include="VirtoCommerce.CatalogModule.Core" Version="3.1025.0" />
-    <PackageReference Include="VirtoCommerce.FileExperienceApi.Core" Version="3.1000.0" />
-    <PackageReference Include="VirtoCommerce.InventoryModule.Core" Version="3.1000.0" />
-    <PackageReference Include="VirtoCommerce.MarketingModule.Core" Version="3.1000.0" />
-    <PackageReference Include="VirtoCommerce.PaymentModule.Core" Version="3.1002.0" />
-    <PackageReference Include="VirtoCommerce.PricingModule.Core" Version="3.1000.0" />
-    <PackageReference Include="VirtoCommerce.ShippingModule.Core" Version="3.1000.0" />
-    <PackageReference Include="VirtoCommerce.Xapi.Core" Version="3.1001.0" />
-    <PackageReference Include="VirtoCommerce.XCatalog.Core" Version="3.945.0" />
+    <PackageReference Include="VirtoCommerce.CartModule.Core" Version="3.1006.0" />
+    <PackageReference Include="VirtoCommerce.CatalogModule.Core" Version="3.1029.0" />
+    <PackageReference Include="VirtoCommerce.FileExperienceApi.Core" Version="3.1003.0" />
+    <PackageReference Include="VirtoCommerce.InventoryModule.Core" Version="3.1003.0" />
+    <PackageReference Include="VirtoCommerce.MarketingModule.Core" Version="3.1005.0" />
+    <PackageReference Include="VirtoCommerce.PaymentModule.Core" Version="3.1004.0" />
+    <PackageReference Include="VirtoCommerce.PricingModule.Core" Version="3.1003.0" />
+    <PackageReference Include="VirtoCommerce.ShippingModule.Core" Version="3.1005.0" />
+    <PackageReference Include="VirtoCommerce.Xapi.Core" Version="3.1012.0" />
+    <PackageReference Include="VirtoCommerce.XCatalog.Core" Version="3.1007.0" />
   </ItemGroup>
 </Project>

--- a/src/VirtoCommerce.XCart.Data/VirtoCommerce.XCart.Data.csproj
+++ b/src/VirtoCommerce.XCart.Data/VirtoCommerce.XCart.Data.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
@@ -9,7 +9,7 @@
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="VirtoCommerce.Platform.Security" Version="3.1017.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Security" Version="3.1039.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.XCart.Core\VirtoCommerce.XCart.Core.csproj" />

--- a/src/VirtoCommerce.XCart.Web/module.manifest
+++ b/src/VirtoCommerce.XCart.Web/module.manifest
@@ -5,18 +5,18 @@
   <version-tag></version-tag>
 
 
-  <platformVersion>3.1017.0</platformVersion>
+  <platformVersion>3.1039.0</platformVersion>
   <dependencies>
-    <dependency id="VirtoCommerce.Cart" version="3.1005.0" />
-    <dependency id="VirtoCommerce.Catalog" version="3.1025.0" />
-    <dependency id="VirtoCommerce.FileExperienceApi" version="3.1000.0" />
-    <dependency id="VirtoCommerce.Inventory" version="3.1000.0" />
-    <dependency id="VirtoCommerce.Marketing" version="3.1000.0" />
-    <dependency id="VirtoCommerce.Payment" version="3.1002.0" />
-    <dependency id="VirtoCommerce.Pricing" version="3.1000.0" />
-    <dependency id="VirtoCommerce.Shipping" version="3.1000.0" />
-    <dependency id="VirtoCommerce.Xapi" version="3.1001.0" />
-    <dependency id="VirtoCommerce.XCatalog" version="3.945.0" />
+    <dependency id="VirtoCommerce.Cart" version="3.1006.0" />
+    <dependency id="VirtoCommerce.Catalog" version="3.1029.0" />
+    <dependency id="VirtoCommerce.FileExperienceApi" version="3.1003.0" />
+    <dependency id="VirtoCommerce.Inventory" version="3.1003.0" />
+    <dependency id="VirtoCommerce.Marketing" version="3.1005.0" />
+    <dependency id="VirtoCommerce.Payment" version="3.1004.0" />
+    <dependency id="VirtoCommerce.Pricing" version="3.1003.0" />
+    <dependency id="VirtoCommerce.Shipping" version="3.1005.0" />
+    <dependency id="VirtoCommerce.Xapi" version="3.1012.0" />
+    <dependency id="VirtoCommerce.XCatalog" version="3.1007.0" />
   </dependencies>
 
   <title>Cart Experience API</title>

--- a/tests/VirtoCommerce.XCart.Tests/VirtoCommerce.XCart.Tests.csproj
+++ b/tests/VirtoCommerce.XCart.Tests/VirtoCommerce.XCart.Tests.csproj
@@ -7,7 +7,7 @@
   <ItemGroup>
     <PackageReference Include="AutoFixture" Version="4.18.1" />
     <PackageReference Include="Bogus" Version="35.6.5" />
-    <PackageReference Include="coverlet.collector" Version="8.0.0">
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
@@ -19,8 +19,8 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="FluentAssertions" Version="7.2.0" />
-    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.1017.0" />
-    <PackageReference Include="VirtoCommerce.CartModule.Data" Version="3.1002.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.1039.0" />
+    <PackageReference Include="VirtoCommerce.CartModule.Data" Version="3.1006.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\VirtoCommerce.XCart.Data\VirtoCommerce.XCart.Data.csproj" />


### PR DESCRIPTION
Part of **Stable 15** (Wave 9). Builds against published platform [3.1039.0](https://github.com/VirtoCommerce/vc-platform/releases/tag/3.1039.0) + Waves 1–8 packages on nuget.org. Version handled by CI.

- Xapi dep bumped to 3.1012.0.
- `vc-build Compress` green incl. unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version-only dependency and manifest alignment with no logic changes; risk is limited to compatibility with upstream Stable 15 packages.
> 
> **Overview**
> Aligns **VirtoCommerce.XCart** with **Stable 15** by bumping platform and module package versions across Core, Data, Web manifest, and tests—no application code changes.
> 
> **Platform** moves to `3.1039.0` in `VirtoCommerce.XCart.Data` (`VirtoCommerce.Platform.Security`), `module.manifest` (`platformVersion`), and tests (`VirtoCommerce.Platform.Core`). **Module dependencies** in `VirtoCommerce.XCart.Core` and `module.manifest` are updated in lockstep (Cart, Catalog, FileExperienceApi, Inventory, Marketing, Payment, Pricing, Shipping, **Xapi 3.1012.0**, XCatalog). Tests also pick up `VirtoCommerce.CartModule.Data` **3.1006.0** and **coverlet.collector** **10.0.1**. `.gitignore` adds `/.serena`; `VirtoCommerce.XCart.Data.csproj` drops a BOM on the project line.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e468e237862375782e85ec2d331363df7148f879. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-5163
Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.XCart_3.1021.0-pr-129-e468.zip