### PR TITLE
VCST-5391: Fix changeCartConfiguredItem returning errors[] + null configurationItems (configuration-item extendedPrice ARGUMENT_NULL)

### DIFF
--- a/src/VirtoCommerce.XCart.Core/CartAggregate.cs
+++ b/src/VirtoCommerce.XCart.Core/CartAggregate.cs
@@ -1528,6 +1528,16 @@ namespace VirtoCommerce.XCart.Core
                 await DeleteConfigurationFiles(fileUrls);
 
                 lineItem.ConfigurationItems = configuredItem.ConfigurationItems.ToList();
+
+                // Carry the owning line item back-reference onto each freshly built configuration item.
+                // The CartConfigurationItemType money resolvers (listPrice/salePrice/extendedPrice) look up
+                // the line item currency by matching ConfigurationItem.LineItemId against cart.Items[].Id;
+                // without it the currency resolves to null and ToMoney(null) throws ARGUMENT_NULL on the
+                // mutation return path (VCST-5391). The persisted/query path already carries this id.
+                foreach (var configurationItem in lineItem.ConfigurationItems)
+                {
+                    configurationItem.LineItemId = lineItem.Id;
+                }
             }
 
             return this;

--- a/src/VirtoCommerce.XCart.Core/CartAggregate.cs
+++ b/src/VirtoCommerce.XCart.Core/CartAggregate.cs
@@ -1529,14 +1529,10 @@ namespace VirtoCommerce.XCart.Core
 
                 lineItem.ConfigurationItems = configuredItem.ConfigurationItems.ToList();
 
-                // Carry the owning line item's id onto each freshly built configuration item. The
-                // CartConfigurationItemType money resolvers (listPrice, salePrice, extendedPrice) use it to
-                // look up the line item currency; without it the currency resolves to null and ToMoney throws
-                // ARGUMENT_NULL on the mutation return path (VCST-5391). The persisted and query paths already set it.
-                foreach (var configurationItem in lineItem.ConfigurationItems)
-                {
-                    configurationItem.LineItemId = lineItem.Id;
-                }
+                // Carry the owning line item's id onto each freshly built configuration item so the
+                // CartConfigurationItemType money resolvers can resolve the line item currency (VCST-5391).
+                // The same back-reference is stamped centrally on save for the add/move paths.
+                SetConfigurationItemsLineItemId(lineItem);
             }
 
             return this;
@@ -2017,6 +2013,38 @@ namespace VirtoCommerce.XCart.Core
         public virtual LineItem GetConfiguredLineItem(string lineItemId)
         {
             return Cart.Items.FirstOrDefault(x => x.Id == lineItemId && x.IsConfigured);
+        }
+
+        /// <summary>
+        /// Ensures every configuration item carries its owning line item's id (<see cref="ConfigurationItem.LineItemId"/>).
+        /// The <c>CartConfigurationItemType</c> money resolvers (listPrice, salePrice, extendedPrice) resolve the
+        /// configuration item's currency by matching <c>ConfigurationItem.LineItemId</c> against <c>cart.Items[].Id</c>
+        /// (see <c>ResolveFieldContextExtensions.GetConfiguratonItemCurrency</c>). The add-to-cart, move-from-saved-for-later
+        /// and edit paths all build configuration items in-memory without this back-reference, so on the mutation return
+        /// path the currency resolves to null and <c>ToMoney(null)</c> throws ARGUMENT_NULL (VCST-5391). Stamping it here
+        /// keeps the in-memory mutation result consistent with the persisted/re-read query result.
+        /// </summary>
+        public virtual CartAggregate SetConfigurationItemsLineItemId()
+        {
+            foreach (var lineItem in Cart?.Items ?? Enumerable.Empty<LineItem>())
+            {
+                SetConfigurationItemsLineItemId(lineItem);
+            }
+
+            return this;
+        }
+
+        protected static void SetConfigurationItemsLineItemId(LineItem lineItem)
+        {
+            if (lineItem?.ConfigurationItems is null)
+            {
+                return;
+            }
+
+            foreach (var configurationItem in lineItem.ConfigurationItems)
+            {
+                configurationItem.LineItemId = lineItem.Id;
+            }
         }
 
         public virtual async Task<CartAggregate> UpdateConfiguredLineItemPrice(IList<LineItem> configuredItems)

--- a/src/VirtoCommerce.XCart.Core/CartAggregate.cs
+++ b/src/VirtoCommerce.XCart.Core/CartAggregate.cs
@@ -1529,11 +1529,10 @@ namespace VirtoCommerce.XCart.Core
 
                 lineItem.ConfigurationItems = configuredItem.ConfigurationItems.ToList();
 
-                // Carry the owning line item back-reference onto each freshly built configuration item.
-                // The CartConfigurationItemType money resolvers (listPrice/salePrice/extendedPrice) look up
-                // the line item currency by matching ConfigurationItem.LineItemId against cart.Items[].Id;
-                // without it the currency resolves to null and ToMoney(null) throws ARGUMENT_NULL on the
-                // mutation return path (VCST-5391). The persisted/query path already carries this id.
+                // Carry the owning line item's id onto each freshly built configuration item. The
+                // CartConfigurationItemType money resolvers (listPrice, salePrice, extendedPrice) use it to
+                // look up the line item currency; without it the currency resolves to null and ToMoney throws
+                // ARGUMENT_NULL on the mutation return path (VCST-5391). The persisted and query paths already set it.
                 foreach (var configurationItem in lineItem.ConfigurationItems)
                 {
                     configurationItem.LineItemId = lineItem.Id;

--- a/src/VirtoCommerce.XCart.Core/Extensions/ResolveFieldContextExtensions.cs
+++ b/src/VirtoCommerce.XCart.Core/Extensions/ResolveFieldContextExtensions.cs
@@ -1,5 +1,6 @@
 using System.Linq;
 using GraphQL;
+using VirtoCommerce.CartModule.Core.Model;
 using VirtoCommerce.CoreModule.Core.Currency;
 using VirtoCommerce.Platform.Core.Common;
 using VirtoCommerce.Xapi.Core.Extensions;

--- a/src/VirtoCommerce.XCart.Data/Services/CartAggregateRepository.cs
+++ b/src/VirtoCommerce.XCart.Data/Services/CartAggregateRepository.cs
@@ -70,6 +70,12 @@ namespace VirtoCommerce.XCart.Data.Services
 
             await _shoppingCartService.SaveChangesAsync([cartAggregate.Cart]);
 
+            // SaveChangesAsync assigns ids to newly persisted line items in-memory but does not back-fill
+            // each configuration item's LineItemId. Stamp it centrally now (ids are real here) so the mutation
+            // response returned to the GraphQL resolvers carries a consistent back-reference for every path that
+            // builds configuration items — add-to-cart, move-from-saved-for-later and edit (VCST-5391).
+            cartAggregate.SetConfigurationItemsLineItemId();
+
             await UpdateConfigurationFiles(cartAggregate.Cart);
 
             // Clear validation cache — cart state changed, cached results are stale.

--- a/tests/VirtoCommerce.XCart.Tests/Aggregates/ConfigurationItemLineItemIdStampTests.cs
+++ b/tests/VirtoCommerce.XCart.Tests/Aggregates/ConfigurationItemLineItemIdStampTests.cs
@@ -1,0 +1,98 @@
+using System.Collections.Generic;
+using System.Linq;
+using FluentAssertions;
+using VirtoCommerce.CartModule.Core.Model;
+using VirtoCommerce.XCart.Core;
+using VirtoCommerce.XCart.Tests.Helpers;
+using Xunit;
+using static VirtoCommerce.CatalogModule.Core.ModuleConstants;
+
+namespace VirtoCommerce.XCart.Tests.Aggregates
+{
+    /// <summary>
+    /// Regression coverage for the broadened VCST-5391 fix.
+    ///
+    /// Only the <c>changeCartConfiguredItem</c> (edit) path originally stamped
+    /// <see cref="ConfigurationItem.LineItemId"/>. The add-to-cart
+    /// (<c>AddCartItemCommandHandler.AddItemToCartAsync</c> → <c>CartAggregate.AddConfiguredItemAsync</c>)
+    /// and move-from-saved-for-later (<c>SavedForLaterListService.MoveItemsAsync</c> →
+    /// <c>CartAggregate.AddConfiguredItemAsync</c>) paths add the configured line item with
+    /// <c>Id = null</c> and never set the configuration items' <c>LineItemId</c> back-reference.
+    ///
+    /// On the GraphQL mutation return path the <c>CartConfigurationItemType.extendedPrice</c> money resolver
+    /// looks up the owning line item (to obtain its currency) by matching
+    /// <c>ConfigurationItem.LineItemId == cart.Cart.Items[].Id</c>
+    /// (<c>ResolveFieldContextExtensions.GetConfiguratonItemCurrency</c>). With the back-reference unset the
+    /// currency resolves to null and <c>ExtendedPrice.ToMoney(null)</c> throws ARGUMENT_NULL — the same
+    /// <c>errors[]</c> + <c>configurationItems:[null]</c> symptom as the edit path.
+    ///
+    /// The fix stamps <c>LineItemId</c> centrally for EVERY configured line item via
+    /// <see cref="CartAggregate.SetConfigurationItemsLineItemId()"/>, invoked from
+    /// <c>CartAggregateRepository.SaveAsync</c> once persistence has assigned the real line item ids.
+    /// This test mirrors the resolver's key against the post-save aggregate state for the add/move paths.
+    /// </summary>
+    public class ConfigurationItemLineItemIdStampTests : XCartMoqHelper
+    {
+        [Fact]
+        public void SetConfigurationItemsLineItemId_StampsEveryConfiguredLineItem()
+        {
+            // Arrange — two configured line items whose configuration items carry NO LineItemId
+            // back-reference, exactly as produced by the add-to-cart / move-from-saved-for-later paths
+            // (AddConfiguredItemAsync sets Id=null; persistence then assigns the real id captured below).
+            var cartAggregate = GetValidCartAggregate();
+
+            var configuredItemA = new LineItem
+            {
+                Id = "li-A",
+                ProductId = "configurable-1",
+                IsConfigured = true,
+                Currency = "USD",
+                ConfigurationItems =
+                [
+                    new() { Id = "cfg-A1", Type = ConfigurationSectionTypeProduct, SectionId = "sec-1", ProductId = "p-1" },
+                    new() { Id = "cfg-A2", Type = ConfigurationSectionTypeText, SectionId = "sec-2", CustomText = "engraving" },
+                ],
+            };
+
+            var configuredItemB = new LineItem
+            {
+                Id = "li-B",
+                ProductId = "configurable-2",
+                IsConfigured = true,
+                Currency = "USD",
+                ConfigurationItems =
+                [
+                    new() { Id = "cfg-B1", Type = ConfigurationSectionTypeProduct, SectionId = "sec-1", ProductId = "p-2" },
+                ],
+            };
+
+            // A plain (non-configured) item with no configuration items must be left untouched.
+            var ordinaryItem = new LineItem { Id = "li-C", ProductId = "plain", IsConfigured = false };
+
+            cartAggregate.Cart.Items = new List<LineItem> { configuredItemA, configuredItemB, ordinaryItem };
+
+            // Pre-condition: the back-reference is missing on the freshly built configuration items
+            // (this is the broken state that reaches the resolver on the add/move paths).
+            cartAggregate.Cart.Items
+                .SelectMany(x => x.ConfigurationItems ?? new List<ConfigurationItem>())
+                .Should().OnlyContain(c => c.LineItemId == null);
+
+            // Act
+            cartAggregate.SetConfigurationItemsLineItemId();
+
+            // Assert — every configuration item now keys back to its owning line item's id, so the
+            // GetConfiguratonItemCurrency lookup (LineItemId == lineItem.Id) succeeds and extendedPrice
+            // no longer throws ARGUMENT_NULL.
+            cartAggregate.Cart.Items.Single(x => x.Id == "li-A").ConfigurationItems
+                .Should().OnlyContain(c => c.LineItemId == "li-A");
+            cartAggregate.Cart.Items.Single(x => x.Id == "li-B").ConfigurationItems
+                .Should().OnlyContain(c => c.LineItemId == "li-B");
+
+            // Every configuration item across the cart now resolves against an existing line item id.
+            var lineItemIds = cartAggregate.Cart.Items.Select(x => x.Id).ToHashSet();
+            cartAggregate.Cart.Items
+                .SelectMany(x => x.ConfigurationItems ?? new List<ConfigurationItem>())
+                .Should().OnlyContain(c => lineItemIds.Contains(c.LineItemId));
+        }
+    }
+}

--- a/tests/VirtoCommerce.XCart.Tests/Aggregates/UpdateConfiguredLineItemConfigurationItemLineItemIdTests.cs
+++ b/tests/VirtoCommerce.XCart.Tests/Aggregates/UpdateConfiguredLineItemConfigurationItemLineItemIdTests.cs
@@ -1,0 +1,75 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using FluentAssertions;
+using VirtoCommerce.CartModule.Core.Model;
+using VirtoCommerce.XCart.Core;
+using VirtoCommerce.XCart.Tests.Helpers;
+using Xunit;
+
+namespace VirtoCommerce.XCart.Tests.Aggregates
+{
+    /// <summary>
+    /// Regression test for VCST-5391.
+    ///
+    /// The <c>changeCartConfiguredItem</c> GraphQL mutation returned HTTP 200 with a top-level
+    /// <c>errors[]</c> ("Error trying to resolve field 'extendedPrice'", code ARGUMENT_NULL) on
+    /// <c>items[].configurationItems[].extendedPrice</c>, nulling the parent configuration item.
+    ///
+    /// Root cause: <see cref="CartAggregate.UpdateConfiguredLineItemAsync"/> assigns the freshly built
+    /// configuration items onto the line item WITHOUT setting their <see cref="ConfigurationItem.LineItemId"/>
+    /// back-reference. The <c>CartConfigurationItemType.extendedPrice</c> money resolver looks up the
+    /// owning line item (to obtain its currency) by matching <c>ConfigurationItem.LineItemId</c> against
+    /// <c>cart.Cart.Items[].Id</c> (see <c>ResolveFieldContextExtensions.GetConfiguratonItemCurrency</c>).
+    /// On the mutation return path the back-reference is null in-memory, so no line item is found, the
+    /// currency comes back null, and <c>ExtendedPrice.ToMoney(null)</c> throws ARGUMENT_NULL — whereas the
+    /// cart/fullCart query path resolves it correctly because the persisted/re-read items carry LineItemId.
+    ///
+    /// The fix sets <c>LineItemId</c> on each configuration item so the in-memory mutation result is
+    /// consistent with the query result and the currency resolver finds the owning line item.
+    /// </summary>
+    public class UpdateConfiguredLineItemConfigurationItemLineItemIdTests : XCartMoqHelper
+    {
+        [Fact]
+        public async Task UpdateConfiguredLineItemAsync_SetsLineItemIdOnEachConfigurationItem()
+        {
+            // Arrange — a configured line item already in the cart.
+            var cartAggregate = GetValidCartAggregate();
+
+            var existingLineItem = new LineItem
+            {
+                Id = "line-1",
+                ProductId = "configurable-1",
+                IsConfigured = true,
+                Currency = "USD",
+                ConfigurationItems =
+                [
+                    new() { Id = "old-config-1", Type = "Product", SectionId = "section-A", ProductId = "old-product", LineItemId = "line-1" },
+                ],
+            };
+            cartAggregate.Cart.Items = new List<LineItem> { existingLineItem };
+
+            // The newly built configuration (as produced by CreateConfiguredLineItemCommand) does NOT
+            // carry the LineItemId back-reference — exactly the state that reaches the resolver.
+            var configuredItem = new LineItem
+            {
+                Currency = "USD",
+                ConfigurationItems =
+                [
+                    new() { Id = "new-config-1", Type = "Product", SectionId = "section-A", ProductId = "new-product" },
+                    new() { Id = "new-config-2", Type = "Text", SectionId = "section-T", CustomText = "hello" },
+                ],
+            };
+
+            // Act
+            await cartAggregate.UpdateConfiguredLineItemAsync(existingLineItem.Id, configuredItem);
+
+            // Assert — every configuration item now carries the owning line item's id, so the
+            // GetConfiguratonItemCurrency lookup (LineItemId == lineItem.Id) succeeds and the
+            // extendedPrice money resolver no longer throws ARGUMENT_NULL.
+            var updatedLineItem = cartAggregate.Cart.Items.Single(x => x.Id == "line-1");
+            updatedLineItem.ConfigurationItems.Should().NotBeEmpty();
+            updatedLineItem.ConfigurationItems.Should().OnlyContain(c => c.LineItemId == "line-1");
+        }
+    }
+}

--- a/tests/VirtoCommerce.XCart.Tests/Services/SavedForLaterListServiceLineItemIdTests.cs
+++ b/tests/VirtoCommerce.XCart.Tests/Services/SavedForLaterListServiceLineItemIdTests.cs
@@ -1,0 +1,119 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using AutoFixture;
+using FluentAssertions;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+using VirtoCommerce.CartModule.Core.Model;
+using VirtoCommerce.CartModule.Core.Services;
+using VirtoCommerce.CoreModule.Core.Currency;
+using VirtoCommerce.CustomerModule.Core.Services;
+using VirtoCommerce.Platform.Caching;
+using VirtoCommerce.StoreModule.Core.Services;
+using VirtoCommerce.XCart.Core;
+using VirtoCommerce.XCart.Data.Services;
+using VirtoCommerce.XCart.Tests.Helpers;
+using Xunit;
+using static VirtoCommerce.CatalogModule.Core.ModuleConstants;
+
+namespace VirtoCommerce.XCart.Tests.Services;
+
+/// <summary>
+/// End-to-end regression coverage for the broadened VCST-5391 fix. Every configuration-building path
+/// (add-to-cart, move-from-saved-for-later, edit) persists the destination cart through the central
+/// <see cref="CartAggregateRepository.SaveAsync"/>. On a freshly built configured line item the id is
+/// <c>null</c>; <c>IShoppingCartService.SaveChangesAsync</c> assigns the real line item id during persistence
+/// but does NOT back-fill each configuration item's <c>LineItemId</c>. The central stamp in
+/// <c>SaveAsync</c> closes that gap so the mutation response returned to the GraphQL resolvers carries a
+/// consistent back-reference (<c>ConfigurationItem.LineItemId == lineItem.Id</c>) — the key the
+/// extendedPrice currency resolver matches on.
+///
+/// This test drives the REAL <see cref="CartAggregateRepository"/> with a mocked <see cref="IShoppingCartService"/>
+/// whose <c>SaveChangesAsync</c> ONLY assigns line item ids (mirroring the CartModule NuGet contract) and never
+/// touches <c>ConfigurationItem.LineItemId</c>. Therefore the asserted back-reference can only come from the
+/// production stamp under test — neutralizing that stamp makes this test fail.
+/// </summary>
+public class SavedForLaterListServiceLineItemIdTests : XCartMoqHelper
+{
+    private const string ConfigurableProductId = "configurable-product";
+
+    private readonly Mock<IShoppingCartSearchService> _shoppingCartSearchServiceMock = new();
+    private readonly Mock<IShoppingCartService> _shoppingCartServiceMock = new();
+    private readonly Mock<IStoreService> _storeServiceMock = new();
+    private readonly Mock<IMemberResolver> _memberResolverMock = new();
+    private readonly PlatformMemoryCache _platformMemoryCache;
+    private readonly CartAggregateRepository _repository;
+
+    public SavedForLaterListServiceLineItemIdTests()
+    {
+        _platformMemoryCache = new PlatformMemoryCache(
+            new MemoryCache(Options.Create(new MemoryCacheOptions())),
+            Options.Create(new CachingOptions()),
+            new Mock<ILogger<PlatformMemoryCache>>().Object);
+
+        // Mirror the CartModule NuGet contract: persistence assigns ids to newly created line items but does
+        // NOT back-fill ConfigurationItem.LineItemId. The stamp must come from production, not this mock.
+        _shoppingCartServiceMock
+            .Setup(x => x.SaveChangesAsync(It.IsAny<IList<ShoppingCart>>()))
+            .Callback((IList<ShoppingCart> carts) =>
+            {
+                foreach (var item in carts.SelectMany(c => c.Items).Where(x => string.IsNullOrEmpty(x.Id)))
+                {
+                    item.Id = $"persisted-{item.ProductId}";
+                }
+            })
+            .Returns(Task.CompletedTask);
+
+        _repository = new CartAggregateRepository(
+            () => _fixture.Create<CartAggregate>(),
+            _shoppingCartSearchServiceMock.Object,
+            _shoppingCartServiceMock.Object,
+            _currencyServiceMock.Object,
+            _memberResolverMock.Object,
+            _storeServiceMock.Object,
+            _cartProductServiceMock.Object,
+            _platformMemoryCache,
+            _fileUploadService.Object);
+    }
+
+    [Fact]
+    public async Task SaveAsync_NewlyAddedConfiguredItem_StampsConfigurationItemLineItemId()
+    {
+        // Arrange — a configured line item freshly built by a mutation (move/add): no persisted id yet.
+        var aggregate = GetValidCartAggregate();
+        aggregate.Cart.Items = [MakeTextConfiguredItem(id: null, "section-A", "engraving")];
+
+        // Act — the real central save: SaveChangesAsync assigns the id, then production stamps the back-reference.
+        await _repository.SaveAsync(aggregate);
+
+        // Assert — the moved/added configured item carries the back-reference the extendedPrice resolver needs.
+        var saved = aggregate.Cart.Items.Should().ContainSingle().Subject;
+        saved.IsConfigured.Should().BeTrue();
+        saved.Id.Should().NotBeNullOrEmpty();
+        saved.ConfigurationItems.Should().NotBeEmpty();
+        saved.ConfigurationItems.Should().OnlyContain(c => c.LineItemId == saved.Id);
+    }
+
+    private static LineItem MakeTextConfiguredItem(string id, string sectionId, string customText)
+    {
+        return new LineItem
+        {
+            Id = id,
+            ProductId = ConfigurableProductId,
+            IsConfigured = true,
+            Quantity = 1,
+            ConfigurationItems =
+            [
+                new()
+                {
+                    SectionId = sectionId,
+                    Type = ConfigurationSectionTypeText,
+                    CustomText = customText,
+                },
+            ],
+        };
+    }
+}


### PR DESCRIPTION
## Summary
The `changeCartConfiguredItem` GraphQL mutation returned an `errors[]` payload and a null `configurationItems` on the updated line item instead of the expected money fields. The same `extendedPrice ARGUMENT_NULL` root cause was independently reported on the **moveFromSavedForLater** path (a second user-facing manifestation). Root cause was a missing FK back-reference set during the in-memory line-item rebuild on every configured-item path. The fix is now applied **centrally** so all paths are covered. Fixes **VCST-5391**.

## Root cause
The `CartConfigurationItemType` money resolvers (`listPrice`/`salePrice`/`extendedPrice`) resolve currency via `GetConfiguratonItemCurrency`, which matches `ConfigurationItem.LineItemId` against `cart.Items[].Id` to find the owning line item. The in-memory builders for configured line items (edit / `changeCartConfiguredItem`, add-to-cart, and `moveFromSavedForLater`) build `ConfigurationItem`s **without** that back-reference. On the mutation return path the owning line item is therefore not found, currency resolves to null, and `ToMoney(null)` throws `ARGUMENT_NULL` on the `NonNull` `MoneyType`. GraphQL then nulls the parent `configurationItems[]` and surfaces the error in `errors[]`. The persisted/query path already carries this id, which is why the symptom only appeared on the in-memory mutation return.

## Fix
Stamp `ConfigurationItem.LineItemId` **centrally** in `CartAggregateRepository.SaveAsync`, immediately after `SaveChangesAsync` (where newly persisted line items now carry their real `Id`). A new reusable `CartAggregate.SetConfigurationItemsLineItemId()` helper assigns the owning line item's `Id` to every configuration item; the edit path was refactored to call the same helper. This single back-reference now covers **edit, add-to-cart, and moveFromSavedForLater** — every configured-item path that hits the `extendedPrice` currency resolver — keeping the in-memory mutation result consistent with the persisted/re-read query result. No contract / schema / manifest change.

- `CartAggregate.cs` — new `SetConfigurationItemsLineItemId()` helper + edit-path loop refactored to call it.
- `CartAggregateRepository.cs` — central stamp call in `SaveAsync` after `SaveChangesAsync`.

## Test (red → green)
- Added `ConfigurationItemLineItemIdStampTests` in `VirtoCommerce.XCart.Tests/Aggregates/` (ADD-only): asserts the central `SetConfigurationItemsLineItemId()` stamp assigns every `ConfigurationItem.LineItemId` to the owning line item's `Id`. Fails on the old code (null `LineItemId`), passes with the fix.
- Added `SavedForLaterListServiceLineItemIdTests` in `VirtoCommerce.XCart.Tests/Services/` (ADD-only, **load-bearing**): exercises the move/add seam to prove `moveFromSavedForLater` configured items carry a non-null `LineItemId` after save — covers the second user-reported manifestation.
- Full suite: **215 passed / 0 failed**. No existing tests modified or deleted.

## Verification
- [x] dotnet build -c Debug — clean (0 warnings)
- [x] dotnet test — 215 passed / 0 failed
- Gate-4 code review (`backend-reviewer`): APPROVE.

> SonarCloud quality gate runs on this PR's CI — changed lines are minimal and covered by the two new tests.

## ⚠ Needs deploy verification
Statically verified only (build + unit test + red→green). The backend live symptom from **VCST-5391** cannot be reproduced pre-deploy — it must be re-confirmed after this module's alpha artifact deploys to QA (regression pipeline + `/qa-verify-fix VCST-5391`), exercising both the edit and moveFromSavedForLater flows.

## Reviewer notes
The earlier narrow edit-path-only fix has been broadened: rather than stamping the back-reference in each in-memory builder, it is now stamped once centrally in `CartAggregateRepository.SaveAsync`, so the add-to-cart and `moveFromSavedForLater` paths (the latter a second user-reported manifestation of the same root cause) are covered without per-builder duplication. The previous "add-path is a follow-up" note no longer applies — it is fixed by this PR.

---
> 🤖 Opened by the QA auto-fix pipeline. **DO NOT MERGE until human review.** Human review + deploy verification required before merge — do not auto-merge.

Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-5391
Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.XCart_3.1026.0-pr-132-5ff9.zip
