### PR TITLE
fix: Bridge built-in cart validators through AbstractTypeFactory

### DIFF
--- a/src/VirtoCommerce.XCart.Data/Extensions/ServiceCollectionExtensions.cs
+++ b/src/VirtoCommerce.XCart.Data/Extensions/ServiceCollectionExtensions.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.Extensions.DependencyInjection;
 using VirtoCommerce.FileExperienceApi.Core.Authorization;
 using VirtoCommerce.MarketingModule.Core.Model.Promotions;
+using VirtoCommerce.Platform.Core.Common;
 using VirtoCommerce.PricingModule.Core.Model;
 using VirtoCommerce.TaxModule.Core.Model;
 using VirtoCommerce.Xapi.Core.Infrastructure;
@@ -42,14 +43,21 @@ namespace VirtoCommerce.XCart.Data.Extensions
             services.AddSingleton<IFileAuthorizationRequirementFactory, ConfigurationItemFileAuthorizationRequirementFactory>();
 
             services.AddTransient<ICartValidatorRegistry, CartValidatorRegistry>();
-            services.AddTransient<ICartValidator<CartValidationContext>, CartValidator>();
-            services.AddTransient<ICartValidator<LineItemValidationContext>, CartLineItemValidator>();
-            services.AddTransient<ICartValidator<PaymentValidationContext>, CartPaymentValidator>();
-            services.AddTransient<ICartValidator<ShipmentValidationContext>, CartShipmentValidator>();
+
+            // Bridge each built-in validator through AbstractTypeFactory so a downstream
+            // AbstractTypeFactory<T>.OverrideType still applies.
+            services.AddTransient<ICartValidator<CartValidationContext>>(_ => AbstractTypeFactory<CartValidator>.TryCreateInstance());
+            services.AddTransient<ICartValidator<PaymentValidationContext>>(_ => AbstractTypeFactory<CartPaymentValidator>.TryCreateInstance());
+            services.AddTransient<ICartValidator<ShipmentValidationContext>>(_ => AbstractTypeFactory<CartShipmentValidator>.TryCreateInstance());
+            services.AddTransient<ICartValidator<NewCartItem>>(_ => AbstractTypeFactory<NewCartItemValidator>.TryCreateInstance());
+            services.AddTransient<ICartValidator<ItemQtyAdjustment>>(_ => AbstractTypeFactory<ItemQtyAdjustmentValidator>.TryCreateInstance());
+            services.AddTransient<ICartValidator<PriceAdjustment>>(_ => AbstractTypeFactory<ChangeCartItemPriceValidator>.TryCreateInstance());
+
+            // Pure DI: this wrapper has a constructor dependency the factory can't inject.
             services.AddTransient<ICartValidator<ConfigurationItemValidationContext>, ConfigurationItemContextValidator>();
-            services.AddTransient<ICartValidator<NewCartItem>, NewCartItemValidator>();
-            services.AddTransient<ICartValidator<ItemQtyAdjustment>, ItemQtyAdjustmentValidator>();
-            services.AddTransient<ICartValidator<PriceAdjustment>, ChangeCartItemPriceValidator>();
+
+            // No LineItemValidationContext link: the registry never dispatches it — CartValidator runs the nested
+            // CartLineItemValidator (override via AbstractTypeFactory<CartLineItemValidator>).
 
             services.AddPipeline<SearchProductResponse>(builder =>
             {

--- a/tests/VirtoCommerce.XCart.Tests/Helpers/XCartMoqHelper.cs
+++ b/tests/VirtoCommerce.XCart.Tests/Helpers/XCartMoqHelper.cs
@@ -19,6 +19,7 @@ using VirtoCommerce.InventoryModule.Core.Model;
 using VirtoCommerce.MarketingModule.Core.Services;
 using VirtoCommerce.PaymentModule.Core.Model;
 using VirtoCommerce.PaymentModule.Core.Services;
+using VirtoCommerce.Platform.Core.Common;
 using VirtoCommerce.Platform.Core.Modularity;
 using VirtoCommerce.PricingModule.Core.Model;
 using VirtoCommerce.ShippingModule.Core.Services;
@@ -218,14 +219,14 @@ namespace VirtoCommerce.XCart.Tests.Helpers
 
             services.AddSingleton(_configurationItemValidatorMock.Object);
 
-            services.AddTransient<ICartValidator<CartValidationContext>, CartValidator>();
-            services.AddTransient<ICartValidator<LineItemValidationContext>, CartLineItemValidator>();
-            services.AddTransient<ICartValidator<PaymentValidationContext>, CartPaymentValidator>();
-            services.AddTransient<ICartValidator<ShipmentValidationContext>, CartShipmentValidator>();
+            // Mirror production AddXCart wiring.
+            services.AddTransient<ICartValidator<CartValidationContext>>(_ => AbstractTypeFactory<CartValidator>.TryCreateInstance());
+            services.AddTransient<ICartValidator<PaymentValidationContext>>(_ => AbstractTypeFactory<CartPaymentValidator>.TryCreateInstance());
+            services.AddTransient<ICartValidator<ShipmentValidationContext>>(_ => AbstractTypeFactory<CartShipmentValidator>.TryCreateInstance());
+            services.AddTransient<ICartValidator<NewCartItem>>(_ => AbstractTypeFactory<NewCartItemValidator>.TryCreateInstance());
+            services.AddTransient<ICartValidator<ItemQtyAdjustment>>(_ => AbstractTypeFactory<ItemQtyAdjustmentValidator>.TryCreateInstance());
+            services.AddTransient<ICartValidator<PriceAdjustment>>(_ => AbstractTypeFactory<ChangeCartItemPriceValidator>.TryCreateInstance());
             services.AddTransient<ICartValidator<ConfigurationItemValidationContext>, ConfigurationItemContextValidator>();
-            services.AddTransient<ICartValidator<NewCartItem>, NewCartItemValidator>();
-            services.AddTransient<ICartValidator<ItemQtyAdjustment>, ItemQtyAdjustmentValidator>();
-            services.AddTransient<ICartValidator<PriceAdjustment>, ChangeCartItemPriceValidator>();
 
             return new CartValidatorRegistry(services.BuildServiceProvider());
         }

--- a/tests/VirtoCommerce.XCart.Tests/Validators/CartValidatorRegistrySeamTests.cs
+++ b/tests/VirtoCommerce.XCart.Tests/Validators/CartValidatorRegistrySeamTests.cs
@@ -1,0 +1,58 @@
+using System.Threading.Tasks;
+using FluentAssertions;
+using FluentValidation;
+using FluentValidation.Results;
+using Microsoft.Extensions.DependencyInjection;
+using VirtoCommerce.Platform.Core.Common;
+using VirtoCommerce.XCart.Core.Validators;
+using VirtoCommerce.XCart.Data.Validators;
+using Xunit;
+
+namespace VirtoCommerce.XCart.Tests.Validators;
+
+// VCST-5103 guard: a factory OverrideType must flow through ICartValidatorRegistry (the AddXCart bridge).
+// A dedicated probe type with its own AbstractTypeFactory<SeamProbeValidator> keeps the mutation from
+// bleeding into the parallel XCartMoqHelper-based tests.
+public class CartValidatorRegistrySeamTests
+{
+    [Fact]
+    public async Task Registry_HonorsAbstractTypeFactoryOverride_WhenRegistrationBridgedThroughFactory()
+    {
+        AbstractTypeFactory<SeamProbeValidator>.OverrideType<SeamProbeValidator, SeamProbeValidatorOverride>();
+        try
+        {
+            var services = new ServiceCollection();
+            // Same bridge shape as production AddXCart.
+            services.AddTransient<ICartValidator<SeamProbeContext>>(_ => AbstractTypeFactory<SeamProbeValidator>.TryCreateInstance());
+            using var provider = services.BuildServiceProvider();
+
+            var registry = new CartValidatorRegistry(provider);
+            var errors = await registry.ValidateAsync(new SeamProbeContext());
+
+            errors.Should().ContainSingle(x => x.ErrorCode == SeamProbeValidatorOverride.MarkerCode);
+        }
+        finally
+        {
+            AbstractTypeFactory<SeamProbeValidator>.RemoveType<SeamProbeValidatorOverride>();
+        }
+    }
+
+    public class SeamProbeContext
+    {
+    }
+
+    public class SeamProbeValidator : AbstractValidator<SeamProbeContext>, ICartValidator<SeamProbeContext>
+    {
+    }
+
+    public sealed class SeamProbeValidatorOverride : SeamProbeValidator
+    {
+        public const string MarkerCode = "SEAM_PROBE_OVERRIDE";
+
+        public SeamProbeValidatorOverride()
+        {
+            RuleFor(x => x).Custom((_, context) =>
+                context.AddFailure(new ValidationFailure(string.Empty, "probe") { ErrorCode = MarkerCode }));
+        }
+    }
+}


### PR DESCRIPTION
## Problem

VCST-5103 (#125) introduced the cart validator chain (`ICartValidatorRegistry` + `ICartValidator<TContext>`), moving built-in cart validators from `AbstractTypeFactory<T>` resolution onto plain DI registrations. This silently broke downstream modules that customize validation via `AbstractTypeFactory<CartValidator>.OverrideType<...>`: the override no longer intercepts anything, because the registry resolves the DI-registered concrete type directly. The failure is invisible to the compiler — build stays green, the override just stops firing at runtime.

The seam also became inconsistent:
- `ICartValidator<LineItemValidationContext>` was registered but never dispatched by the registry — line-item validation runs only through `CartValidator`'s nested `LineItemValidator`, still built via the factory. Dead registration.
- Shipment/Payment validators resolved two ways at once: top-level via the registry (DI) and nested inside `CartValidator` via the factory — so a factory override affected only the nested path.

## Fix

Bridge each built-in validator's registry registration through the factory:

```csharp
services.AddTransient<ICartValidator<CartValidationContext>>(_ => AbstractTypeFactory<CartValidator>.TryCreateInstance());
```

`AbstractTypeFactory<T>.OverrideType` is honored again through the registry, while additional `ICartValidator<TContext>` registrations still stack as chain links (the VCST-5103 capability is preserved).

- `ConfigurationItemContextValidator` stays on plain DI — it has a constructor dependency the factory cannot inject (`TryCreateInstance` needs a parameterless ctor).
- The dead `ICartValidator<LineItemValidationContext>` registration is dropped; line-item validation is overridden via `AbstractTypeFactory<CartLineItemValidator>.OverrideType` (unchanged).

### Behavioral note

This widens override reach for Shipment/Payment: previously the top-level `ValidateShipmentAsync` / `ValidatePaymentAsync` path did not honor the factory override (only the nested path did). After this change both paths resolve through the factory, so a single `OverrideType<CartShipmentValidator>` affects both. This is the intended fix, but a consumer that only overrode the nested path may notice the wider effect.

## Verification

- All XCart unit tests green (213/213).
- New regression guard `CartValidatorRegistrySeamTests` proves a factory `OverrideType` flows through `ICartValidatorRegistry`. It uses an isolated probe type with its own static factory (so the mutation can't bleed into parallel tests) and was verified to fail if the bridge is reverted to a direct registration.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes cart validation resolution for payment/shipment and extension overrides; behavior shifts are intentional but could surprise modules that relied on the old split between registry DI and nested factory paths.
> 
> **Overview**
> Restores **VirtoCommerce `AbstractTypeFactory` overrides** for built-in cart validators when they are resolved through **`ICartValidatorRegistry`**, after plain DI registration had bypassed `OverrideType` at runtime.
> 
> In **`AddXCart`**, built-in `ICartValidator<TContext>` links now resolve via `AbstractTypeFactory<T>.TryCreateInstance()` instead of registering concrete types directly. **`ConfigurationItemContextValidator`** stays on normal DI because the factory cannot inject its dependencies. The unused **`ICartValidator<LineItemValidationContext>`** registration is removed; line-item customization remains on **`AbstractTypeFactory<CartLineItemValidator>`** inside **`CartValidator`**.
> 
> **Shipment/payment** validation through the registry now uses the same factory path as nested validation, so a single override can affect both top-level and nested flows.
> 
> Test wiring in **`XCartMoqHelper`** matches production, and **`CartValidatorRegistrySeamTests`** guards that registry resolution honors factory overrides.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8b8458cba9d58e23b17c4dda7b2132e983114e3d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-5103
Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.XCart_3.1024.0-pr-133-8b84.zip