### PR TITLE
VCST-5505: Clear cart aggregate cache when cart has changed

### DIFF
--- a/src/VirtoCommerce.XCart.Data/Handlers/CartChangedEventHandler.cs
+++ b/src/VirtoCommerce.XCart.Data/Handlers/CartChangedEventHandler.cs
@@ -1,0 +1,26 @@
+using System.Linq;
+using System.Threading.Tasks;
+using VirtoCommerce.CartModule.Core.Events;
+using VirtoCommerce.Platform.Caching;
+using VirtoCommerce.Platform.Core.Events;
+using VirtoCommerce.XCart.Core;
+
+namespace Heineken.XapiModule.Data.Handlers;
+
+public class CartChangedEventHandler : IEventHandler<CartChangedEvent>
+{
+    public Task Handle(CartChangedEvent message)
+    {
+        var cartIds = message.ChangedEntries
+            .Select(x => x.NewEntry?.Id)
+            .Where(id => !string.IsNullOrEmpty(id))
+            .Distinct();
+
+        foreach (var cartId in cartIds)
+        {
+            GenericCachingRegion<CartAggregate>.ExpireTokenForKey(cartId);
+        }
+
+        return Task.CompletedTask;
+    }
+}

--- a/src/VirtoCommerce.XCart.Data/Handlers/CartChangedEventHandler.cs
+++ b/src/VirtoCommerce.XCart.Data/Handlers/CartChangedEventHandler.cs
@@ -5,7 +5,7 @@ using VirtoCommerce.Platform.Caching;
 using VirtoCommerce.Platform.Core.Events;
 using VirtoCommerce.XCart.Core;
 
-namespace Heineken.XapiModule.Data.Handlers;
+namespace VirtoCommerce.XCart.Data.Handlers;
 
 public class CartChangedEventHandler : IEventHandler<CartChangedEvent>
 {

--- a/src/VirtoCommerce.XCart.Data/Services/CartAggregateRepository.cs
+++ b/src/VirtoCommerce.XCart.Data/Services/CartAggregateRepository.cs
@@ -82,8 +82,7 @@ namespace VirtoCommerce.XCart.Data.Services
             // This ensures the mutation response re-validates against the updated cart.
             cartAggregate.ClearValidationCache();
 
-            // Clear aggregate cache
-            GenericCachingRegion<CartAggregate>.ExpireTokenForKey(cartAggregate.Id);
+            ClearCache(cartAggregate.Id);
         }
 
         public async Task<CartAggregate> GetCartByIdAsync(string cartId, string cultureName = null)
@@ -212,7 +211,7 @@ namespace VirtoCommerce.XCart.Data.Services
         public virtual async Task RemoveCartAsync(string cartId)
         {
             await _shoppingCartService.DeleteAsync(new[] { cartId }, softDelete: true);
-            GenericCachingRegion<CartAggregate>.ExpireTokenForKey(cartId);
+            ClearCache(cartId);
         }
 
         protected virtual async Task<IList<CartAggregate>> GetCartsForShoppingCartsAsync(ShoppingCartSearchCriteria criteria, IList<ShoppingCart> carts, IList<string> productsIncludeFields, string cultureName = null)
@@ -248,13 +247,23 @@ namespace VirtoCommerce.XCart.Data.Services
 
             var result = await _platformMemoryCache.GetOrCreateExclusiveAsync(cacheKey, async cacheOptions =>
             {
-                cacheOptions.AddExpirationToken(GenericCachingRegion<CartAggregate>.CreateChangeTokenForKey(cart.Id));
-                cacheOptions.AddExpirationToken(GenericSearchCachingRegion<Promotion>.CreateChangeToken());
+                ConfigureCache(cacheOptions, cart);
 
                 return await InnerGetCartAggregateFromCartNoCacheAsync(cart, language, productsIncludeFields, responseGroup);
             });
 
             return result;
+        }
+
+        protected virtual void ConfigureCache(MemoryCacheEntryOptions cacheOptions, ShoppingCart cart)
+        {
+            cacheOptions.AddExpirationToken(GenericCachingRegion<CartAggregate>.CreateChangeTokenForKey(cart.Id));
+            cacheOptions.AddExpirationToken(GenericSearchCachingRegion<Promotion>.CreateChangeToken());
+        }
+
+        protected virtual void ClearCache(string cartId)
+        {
+            GenericCachingRegion<CartAggregate>.ExpireTokenForKey(cartId);
         }
 
         private async Task<CartAggregate> InnerGetCartAggregateFromCartNoCacheAsync(ShoppingCart cart, string language, IList<string> productsIncludeFields, string responseGroup)

--- a/src/VirtoCommerce.XCart.Web/Module.cs
+++ b/src/VirtoCommerce.XCart.Web/Module.cs
@@ -1,7 +1,10 @@
 using GraphQL.MicrosoftDI;
+using Heineken.XapiModule.Data.Handlers;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using VirtoCommerce.CartModule.Core.Events;
+using VirtoCommerce.Platform.Core.Events;
 using VirtoCommerce.Platform.Core.Modularity;
 using VirtoCommerce.Platform.Core.Settings;
 using VirtoCommerce.StoreModule.Core.Model;
@@ -37,6 +40,8 @@ public class Module : IModule, IHasConfiguration
         var settingsRegistrar = serviceProvider.GetRequiredService<ISettingsRegistrar>();
         settingsRegistrar.RegisterSettings(ModuleConstants.Settings.General.AllSettings, ModuleInfo.Id);
         settingsRegistrar.RegisterSettingsForType(ModuleConstants.Settings.StoreLevelSettings, nameof(Store));
+
+        appBuilder.RegisterEventHandler<CartChangedEvent, CartChangedEventHandler>();
     }
 
     public void Uninstall()

--- a/src/VirtoCommerce.XCart.Web/Module.cs
+++ b/src/VirtoCommerce.XCart.Web/Module.cs
@@ -1,5 +1,4 @@
 using GraphQL.MicrosoftDI;
-using Heineken.XapiModule.Data.Handlers;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -12,6 +11,7 @@ using VirtoCommerce.Xapi.Core.Extensions;
 using VirtoCommerce.XCart.Core;
 using VirtoCommerce.XCart.Data;
 using VirtoCommerce.XCart.Data.Extensions;
+using VirtoCommerce.XCart.Data.Handlers;
 
 namespace VirtoCommerce.XCart.Web;
 

--- a/src/VirtoCommerce.XCart.Web/Module.cs
+++ b/src/VirtoCommerce.XCart.Web/Module.cs
@@ -22,6 +22,8 @@ public class Module : IModule, IHasConfiguration
 
     public void Initialize(IServiceCollection serviceCollection)
     {
+        serviceCollection.AddSingleton<CartChangedEventHandler>();
+
         var graphQlBuilder = new GraphQLBuilder(serviceCollection, builder =>
         {
             builder.AddSchema(serviceCollection, typeof(CoreAssemblyMarker), typeof(DataAssemblyMarker));


### PR DESCRIPTION
## Description

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-5505
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.XCart_3.1028.0-pr-135-b05a.zip

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches cart read caching correctness; changes are limited to established invalidation tokens and a domain event hook with low blast radius.
> 
> **Overview**
> **Cart aggregate cache** is now invalidated whenever the platform raises **`CartChangedEvent`**, not only when `CartAggregateRepository` saves or removes a cart.
> 
> A new **`CartChangedEventHandler`** collects distinct cart IDs from changed entries and calls **`GenericCachingRegion<CartAggregate>.ExpireTokenForKey`** for each. The XCart web module registers the handler as a singleton and wires it in **`PostInitialize`**.
> 
> **`CartAggregateRepository`** centralizes cache behavior in protected **`ConfigureCache`** and **`ClearCache`** helpers (same expiration tokens as before); **`SaveAsync`** and **`RemoveCartAsync`** use **`ClearCache`** instead of inlining the region calls.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b05a00bfda1b786f471ef021094652a6f0862683. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->