### PR TITLE
VCST-5332: Sales rep customer wishlist sharing scope

### DIFF
--- a/src/VirtoCommerce.XCart.Core/Commands/BaseCommands/ScopedWishlistCommand.cs
+++ b/src/VirtoCommerce.XCart.Core/Commands/BaseCommands/ScopedWishlistCommand.cs
@@ -6,7 +6,5 @@ public abstract class ScopedWishlistCommand : WishlistCommand
 
     public string SharingKey { get; set; }
 
-    // Optional principal the list is shared with (its id space is defined by Scope, e.g. a customer organization id
-    // for a customer-targeted scope). Null for the built-in non-targeted scopes (Private/Organization/Anyone).
     public string SharedWithId { get; set; }
 }

--- a/src/VirtoCommerce.XCart.Core/Commands/BaseCommands/ScopedWishlistCommand.cs
+++ b/src/VirtoCommerce.XCart.Core/Commands/BaseCommands/ScopedWishlistCommand.cs
@@ -5,4 +5,8 @@ public abstract class ScopedWishlistCommand : WishlistCommand
     public string Scope { get; set; }
 
     public string SharingKey { get; set; }
+
+    // Optional principal the list is shared with (its id space is defined by Scope, e.g. a customer organization id
+    // for a customer-targeted scope). Null for the built-in non-targeted scopes (Private/Organization/Anyone).
+    public string SharedWithId { get; set; }
 }

--- a/src/VirtoCommerce.XCart.Core/Models/WishlistScopeContext.cs
+++ b/src/VirtoCommerce.XCart.Core/Models/WishlistScopeContext.cs
@@ -1,0 +1,18 @@
+namespace VirtoCommerce.XCart.Core.Models;
+
+// Inputs for applying a wishlist sharing scope, decoupled from the command shape so ICartSharingService.UpdateScopeAsync
+// stays command-agnostic. Scope defines SharedWithId's id space (null for the built-in non-targeted scopes).
+public class WishlistScopeContext
+{
+    public string Scope { get; set; }
+
+    public string SharingKey { get; set; }
+
+    public string SharedWithId { get; set; }
+
+    public string CurrentUserId { get; set; }
+
+    public string CustomerName { get; set; }
+
+    public string CurrentOrganizationId { get; set; }
+}

--- a/src/VirtoCommerce.XCart.Core/Models/WishlistScopeContext.cs
+++ b/src/VirtoCommerce.XCart.Core/Models/WishlistScopeContext.cs
@@ -1,7 +1,5 @@
 namespace VirtoCommerce.XCart.Core.Models;
 
-// Inputs for applying a wishlist sharing scope, decoupled from the command shape so ICartSharingService.UpdateScopeAsync
-// stays command-agnostic. Scope defines SharedWithId's id space (null for the built-in non-targeted scopes).
 public class WishlistScopeContext
 {
     public string Scope { get; set; }

--- a/src/VirtoCommerce.XCart.Core/Schemas/InputChangeWishlistType.cs
+++ b/src/VirtoCommerce.XCart.Core/Schemas/InputChangeWishlistType.cs
@@ -10,6 +10,7 @@ namespace VirtoCommerce.XCart.Core.Schemas
             Field<StringGraphType>("listName").Description("New List name");
             Field<StringGraphType>("scope").Description("List scope (private or organization)");
             Field<StringGraphType>("sharingKey").Description("Sharing key (URL argument)");
+            Field<StringGraphType>("sharedWithId").Description("Id of the principal the list is shared with (id space defined by scope, e.g. a customer organization id)");
             Field<StringGraphType>("description").Description("List description");
             Field<StringGraphType>("cultureName").Description("Culture name");
         }

--- a/src/VirtoCommerce.XCart.Core/Schemas/InputChangeWishlistType.cs
+++ b/src/VirtoCommerce.XCart.Core/Schemas/InputChangeWishlistType.cs
@@ -10,7 +10,7 @@ namespace VirtoCommerce.XCart.Core.Schemas
             Field<StringGraphType>("listName").Description("New List name");
             Field<StringGraphType>("scope").Description("List scope (private or organization)");
             Field<StringGraphType>("sharingKey").Description("Sharing key (URL argument)");
-            Field<StringGraphType>("sharedWithId").Description("Id of the principal the list is shared with (id space defined by scope, e.g. a customer organization id)");
+            Field<StringGraphType>("sharedWithId").Description("Id of the principal the list is shared with (id space defined by scope)");
             Field<StringGraphType>("description").Description("List description");
             Field<StringGraphType>("cultureName").Description("Culture name");
         }

--- a/src/VirtoCommerce.XCart.Core/Schemas/InputCreateWishlistType.cs
+++ b/src/VirtoCommerce.XCart.Core/Schemas/InputCreateWishlistType.cs
@@ -13,7 +13,7 @@ namespace VirtoCommerce.XPurchase.Schemas
             Field<StringGraphType>("currencyCode").Description("Currency code");
             Field<StringGraphType>("scope").Description("List scope (private or organization)");
             Field<StringGraphType>("sharingKey").Description("Sharing key (URL argument)");
-            Field<StringGraphType>("sharedWithId").Description("Id of the principal the list is shared with (id space defined by scope, e.g. a customer organization id)");
+            Field<StringGraphType>("sharedWithId").Description("Id of the principal the list is shared with (id space defined by scope)");
             Field<StringGraphType>("description").Description("List description");
         }
     }

--- a/src/VirtoCommerce.XCart.Core/Schemas/InputCreateWishlistType.cs
+++ b/src/VirtoCommerce.XCart.Core/Schemas/InputCreateWishlistType.cs
@@ -13,6 +13,7 @@ namespace VirtoCommerce.XPurchase.Schemas
             Field<StringGraphType>("currencyCode").Description("Currency code");
             Field<StringGraphType>("scope").Description("List scope (private or organization)");
             Field<StringGraphType>("sharingKey").Description("Sharing key (URL argument)");
+            Field<StringGraphType>("sharedWithId").Description("Id of the principal the list is shared with (id space defined by scope, e.g. a customer organization id)");
             Field<StringGraphType>("description").Description("List description");
         }
     }

--- a/src/VirtoCommerce.XCart.Core/Schemas/SharingSettingType.cs
+++ b/src/VirtoCommerce.XCart.Core/Schemas/SharingSettingType.cs
@@ -10,6 +10,7 @@ namespace VirtoCommerce.XCart.Core.Schemas
         public SharingSettingType()
         {
             Field(x => x.Id, nullable: false).Description("Id (sharing key)");
+            Field(x => x.SharedWithId, nullable: true).Description("Id of the principal the list is shared with (id space defined by scope, e.g. a customer organization id); null for non-targeted scopes");
             Field<WishlistScopeType>("Scope").Description("Scope (private, organization, etc.)").Resolve(context => context.Source.Scope);
             Field<WishlistAccessType>("Access").Description("Access (read or write)").Resolve(context => context.Source.Access);
             Field<bool>("IsOwner", nullable: false).Description("Created by current user").Resolve(ResolveIsOwner);

--- a/src/VirtoCommerce.XCart.Core/Schemas/SharingSettingType.cs
+++ b/src/VirtoCommerce.XCart.Core/Schemas/SharingSettingType.cs
@@ -10,7 +10,7 @@ namespace VirtoCommerce.XCart.Core.Schemas
         public SharingSettingType()
         {
             Field(x => x.Id, nullable: false).Description("Id (sharing key)");
-            Field(x => x.SharedWithId, nullable: true).Description("Id of the principal the list is shared with (id space defined by scope, e.g. a customer organization id); null for non-targeted scopes");
+            Field(x => x.SharedWithId, nullable: true).Description("Id of the principal the list is shared with (id space defined by scope); null for non-targeted scopes");
             Field<WishlistScopeType>("Scope").Description("Scope (private, organization, etc.)").Resolve(context => context.Source.Scope);
             Field<WishlistAccessType>("Access").Description("Access (read or write)").Resolve(context => context.Source.Access);
             Field<bool>("IsOwner", nullable: false).Description("Created by current user").Resolve(ResolveIsOwner);

--- a/src/VirtoCommerce.XCart.Core/Schemas/WishlistType.cs
+++ b/src/VirtoCommerce.XCart.Core/Schemas/WishlistType.cs
@@ -38,11 +38,14 @@ namespace VirtoCommerce.XCart.Core.Schemas
         {
             var result = AbstractTypeFactory<CartSharingSetting>.TryCreateInstance();
 
-            result.Id = context.Source.Cart.SharingSettings.FirstOrDefault()?.Id ?? Guid.NewGuid().ToString();
+            var existingSetting = context.Source.Cart.SharingSettings.FirstOrDefault();
+
+            result.Id = existingSetting?.Id ?? Guid.NewGuid().ToString();
 
             result.CreatedBy = _cartSharingService.GetSharingOwnerUserId(context.Source.Cart);//TODO: refactor
             result.Scope = _cartSharingService.GetSharingScope(context.Source.Cart);
             result.Access = _cartSharingService.GetSharingAccess(context.Source.Cart, context.User.GetUserId());
+            result.SharedWithId = existingSetting?.SharedWithId;
 
             return result;
         }

--- a/src/VirtoCommerce.XCart.Core/Services/ICartSharingService.cs
+++ b/src/VirtoCommerce.XCart.Core/Services/ICartSharingService.cs
@@ -16,5 +16,11 @@ public interface ICartSharingService
 
     void EnsureSharingSettings(ShoppingCart cart, string sharingKey, string mode, string access, string sharedWithId = null);
 
+    // Authorizes the caller to persist a sharing setting with the given scope and target before it is written.
+    // The base pipeline has no targeted scope and does nothing here; a module that adds a targeted scope (e.g. a
+    // Sales Rep publishing to a customer organization) overrides this to enforce who may target whom. Throws when
+    // the caller is not allowed.
+    Task AuthorizeSharingAsync(string scope, string sharedWithId, string currentUserId);
+
     Task<CartAggregate> GetWishlistBySharingKeyAsync(string sharingKey, IList<string> includeFields);
 }

--- a/src/VirtoCommerce.XCart.Core/Services/ICartSharingService.cs
+++ b/src/VirtoCommerce.XCart.Core/Services/ICartSharingService.cs
@@ -14,7 +14,7 @@ public interface ICartSharingService
     string GetSharingOwnerUserId(ShoppingCart cart);
     string GetSharingOwnerOrganizationId(ShoppingCart cart);
 
-    void EnsureSharingSettings(ShoppingCart cart, string sharingKey, string mode, string access);
+    void EnsureSharingSettings(ShoppingCart cart, string sharingKey, string mode, string access, string sharedWithId = null);
 
     Task<CartAggregate> GetWishlistBySharingKeyAsync(string sharingKey, IList<string> includeFields);
 }

--- a/src/VirtoCommerce.XCart.Core/Services/ICartSharingService.cs
+++ b/src/VirtoCommerce.XCart.Core/Services/ICartSharingService.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using VirtoCommerce.CartModule.Core.Model;
+using VirtoCommerce.XCart.Core.Models;
 
 namespace VirtoCommerce.XCart.Core.Services;
 
@@ -16,11 +17,10 @@ public interface ICartSharingService
 
     void EnsureSharingSettings(ShoppingCart cart, string sharingKey, string mode, string access, string sharedWithId = null);
 
-    // Authorizes the caller to persist a sharing setting with the given scope and target before it is written.
-    // The base pipeline has no targeted scope and does nothing here; a module that adds a targeted scope (e.g. a
-    // Sales Rep publishing to a customer organization) overrides this to enforce who may target whom. Throws when
-    // the caller is not allowed.
-    Task AuthorizeSharingAsync(string scope, string sharedWithId, string currentUserId);
+    // Authorizes and applies the requested sharing scope to the cart (writes the sharing setting + owner). Throws
+    // when the scope is unsupported or the caller is not allowed to use it. A null/empty scope is a no-op (e.g. a
+    // rename-only edit that does not touch sharing).
+    Task UpdateScopeAsync(ShoppingCart cart, WishlistScopeContext context);
 
     Task<CartAggregate> GetWishlistBySharingKeyAsync(string sharingKey, IList<string> includeFields);
 }

--- a/src/VirtoCommerce.XCart.Core/Services/ICartSharingService.cs
+++ b/src/VirtoCommerce.XCart.Core/Services/ICartSharingService.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using VirtoCommerce.CartModule.Core.Model;
@@ -15,11 +16,11 @@ public interface ICartSharingService
     string GetSharingOwnerUserId(ShoppingCart cart);
     string GetSharingOwnerOrganizationId(ShoppingCart cart);
 
-    void EnsureSharingSettings(ShoppingCart cart, string sharingKey, string mode, string access, string sharedWithId = null);
+    [Obsolete("Use the overload with sharedWithId (null for the built-in non-targeted scopes).", DiagnosticId = "VC0015", UrlFormat = "https://docs.virtocommerce.org/products/products-virto3-versions")]
+    void EnsureSharingSettings(ShoppingCart cart, string sharingKey, string mode, string access);
 
-    // Authorizes and applies the requested sharing scope to the cart (writes the sharing setting + owner). Throws
-    // when the scope is unsupported or the caller is not allowed to use it. A null/empty scope is a no-op (e.g. a
-    // rename-only edit that does not touch sharing).
+    void EnsureSharingSettings(ShoppingCart cart, string sharingKey, string mode, string access, string sharedWithId);
+
     Task UpdateScopeAsync(ShoppingCart cart, WishlistScopeContext context);
 
     Task<CartAggregate> GetWishlistBySharingKeyAsync(string sharingKey, IList<string> includeFields);

--- a/src/VirtoCommerce.XCart.Core/VirtoCommerce.XCart.Core.csproj
+++ b/src/VirtoCommerce.XCart.Core/VirtoCommerce.XCart.Core.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="FluentValidation" Version="12.1.1" />
-    <PackageReference Include="VirtoCommerce.CartModule.Core" Version="3.1008.0-alpha.803-vcst-5332-customer-wishlist-sharing-scope" />
+    <PackageReference Include="VirtoCommerce.CartModule.Core" Version="3.1008.0" />
     <PackageReference Include="VirtoCommerce.CatalogModule.Core" Version="3.1029.0" />
     <PackageReference Include="VirtoCommerce.FileExperienceApi.Core" Version="3.1003.0" />
     <PackageReference Include="VirtoCommerce.InventoryModule.Core" Version="3.1003.0" />

--- a/src/VirtoCommerce.XCart.Core/VirtoCommerce.XCart.Core.csproj
+++ b/src/VirtoCommerce.XCart.Core/VirtoCommerce.XCart.Core.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="FluentValidation" Version="12.1.1" />
-    <PackageReference Include="VirtoCommerce.CartModule.Core" Version="3.1007.0" />
+    <PackageReference Include="VirtoCommerce.CartModule.Core" Version="3.1008.0-alpha.803-vcst-5332-customer-wishlist-sharing-scope" />
     <PackageReference Include="VirtoCommerce.CatalogModule.Core" Version="3.1029.0" />
     <PackageReference Include="VirtoCommerce.FileExperienceApi.Core" Version="3.1003.0" />
     <PackageReference Include="VirtoCommerce.InventoryModule.Core" Version="3.1003.0" />

--- a/src/VirtoCommerce.XCart.Data/Commands/BaseCommands/ScopedWishlistCommandHandlerBase.cs
+++ b/src/VirtoCommerce.XCart.Data/Commands/BaseCommands/ScopedWishlistCommandHandlerBase.cs
@@ -20,7 +20,15 @@ public abstract class ScopedWishlistCommandHandlerBase<TCommand> : CartCommandHa
 
     protected virtual Task UpdateScopeAsync(CartAggregate cartAggregate, TCommand request)
     {
-        if (request.Scope?.EqualsIgnoreCase(CartSharingScope.AnyoneAnonymous) == true)
+        if (!string.IsNullOrEmpty(request.SharedWithId))
+        {
+            // Targeted share (e.g. a Sales Rep publishing to a specific customer): persist the requested scope
+            // together with the target. Access defaults to Read; the visibility rules for the scope are enforced
+            // by the ICartSharingService implementation (a downstream module overrides it for its own scope).
+            _cartSharingService.EnsureSharingSettings(cartAggregate.Cart, request.SharingKey, request.Scope, CartSharingAccess.Read, request.SharedWithId);
+            _cartSharingService.SetOwner(cartAggregate.Cart, request.WishlistUserContext.CurrentUserId, request.WishlistUserContext.CurrentContact.Name, null);
+        }
+        else if (request.Scope?.EqualsIgnoreCase(CartSharingScope.AnyoneAnonymous) == true)
         {
             _cartSharingService.EnsureSharingSettings(cartAggregate.Cart, request.SharingKey, CartSharingScope.AnyoneAnonymous, CartSharingAccess.Read);
             _cartSharingService.SetOwner(cartAggregate.Cart, request.WishlistUserContext.CurrentUserId, request.WishlistUserContext.CurrentContact.Name, null);

--- a/src/VirtoCommerce.XCart.Data/Commands/BaseCommands/ScopedWishlistCommandHandlerBase.cs
+++ b/src/VirtoCommerce.XCart.Data/Commands/BaseCommands/ScopedWishlistCommandHandlerBase.cs
@@ -1,8 +1,8 @@
 using System.Threading.Tasks;
-using VirtoCommerce.CartModule.Core.Model;
 using VirtoCommerce.Platform.Core.Common;
 using VirtoCommerce.XCart.Core;
 using VirtoCommerce.XCart.Core.Commands.BaseCommands;
+using VirtoCommerce.XCart.Core.Models;
 using VirtoCommerce.XCart.Core.Services;
 
 namespace VirtoCommerce.XCart.Data.Commands.BaseCommands;
@@ -18,34 +18,24 @@ public abstract class ScopedWishlistCommandHandlerBase<TCommand> : CartCommandHa
         _cartSharingService = cartSharingService;
     }
 
-    protected virtual async Task UpdateScopeAsync(CartAggregate cartAggregate, TCommand request)
+    protected virtual Task UpdateScopeAsync(CartAggregate cartAggregate, TCommand request)
     {
-        // Authorize the requested scope/target before persisting it. The base pipeline permits nothing targeted;
-        // a downstream module (e.g. Sales Rep) enforces who may share with a given principal. Throws when denied.
-        await _cartSharingService.AuthorizeSharingAsync(request.Scope, request.SharedWithId, request.WishlistUserContext.CurrentUserId);
+        var context = CreateScopeContext(request);
 
-        if (!string.IsNullOrEmpty(request.SharedWithId))
-        {
-            // Targeted share (e.g. a Sales Rep publishing to a specific customer): persist the requested scope
-            // together with the target. Access defaults to Read; the visibility rules for the scope are enforced
-            // by the ICartSharingService implementation (a downstream module overrides it for its own scope).
-            _cartSharingService.EnsureSharingSettings(cartAggregate.Cart, request.SharingKey, request.Scope, CartSharingAccess.Read, request.SharedWithId);
-            _cartSharingService.SetOwner(cartAggregate.Cart, request.WishlistUserContext.CurrentUserId, request.WishlistUserContext.CurrentContact.Name, null);
-        }
-        else if (request.Scope?.EqualsIgnoreCase(CartSharingScope.AnyoneAnonymous) == true)
-        {
-            _cartSharingService.EnsureSharingSettings(cartAggregate.Cart, request.SharingKey, CartSharingScope.AnyoneAnonymous, CartSharingAccess.Read);
-            _cartSharingService.SetOwner(cartAggregate.Cart, request.WishlistUserContext.CurrentUserId, request.WishlistUserContext.CurrentContact.Name, null);
-        }
-        else if (request.Scope?.EqualsIgnoreCase(CartSharingScope.Organization) == true)
-        {
-            _cartSharingService.EnsureSharingSettings(cartAggregate.Cart, request.SharingKey, CartSharingScope.Organization, CartSharingAccess.Write);
-            _cartSharingService.SetOwner(cartAggregate.Cart, request.WishlistUserContext.CurrentUserId, request.WishlistUserContext.CurrentContact.Name, request.WishlistUserContext.CurrentOrganizationId);
-        }
-        else if (request.Scope?.EqualsIgnoreCase(CartSharingScope.Private) == true)
-        {
-            _cartSharingService.EnsureSharingSettings(cartAggregate.Cart, null, CartSharingScope.Private, CartSharingAccess.Write);
-            _cartSharingService.SetOwner(cartAggregate.Cart, request.WishlistUserContext.CurrentUserId, request.WishlistUserContext.CurrentContact.Name, null);
-        }
+        return _cartSharingService.UpdateScopeAsync(cartAggregate.Cart, context);
+    }
+
+    protected virtual WishlistScopeContext CreateScopeContext(TCommand request)
+    {
+        var context = AbstractTypeFactory<WishlistScopeContext>.TryCreateInstance();
+
+        context.Scope = request.Scope;
+        context.SharingKey = request.SharingKey;
+        context.SharedWithId = request.SharedWithId;
+        context.CurrentUserId = request.WishlistUserContext.CurrentUserId;
+        context.CustomerName = request.WishlistUserContext.CurrentContact.Name;
+        context.CurrentOrganizationId = request.WishlistUserContext.CurrentOrganizationId;
+
+        return context;
     }
 }

--- a/src/VirtoCommerce.XCart.Data/Commands/BaseCommands/ScopedWishlistCommandHandlerBase.cs
+++ b/src/VirtoCommerce.XCart.Data/Commands/BaseCommands/ScopedWishlistCommandHandlerBase.cs
@@ -18,8 +18,12 @@ public abstract class ScopedWishlistCommandHandlerBase<TCommand> : CartCommandHa
         _cartSharingService = cartSharingService;
     }
 
-    protected virtual Task UpdateScopeAsync(CartAggregate cartAggregate, TCommand request)
+    protected virtual async Task UpdateScopeAsync(CartAggregate cartAggregate, TCommand request)
     {
+        // Authorize the requested scope/target before persisting it. The base pipeline permits nothing targeted;
+        // a downstream module (e.g. Sales Rep) enforces who may share with a given principal. Throws when denied.
+        await _cartSharingService.AuthorizeSharingAsync(request.Scope, request.SharedWithId, request.WishlistUserContext.CurrentUserId);
+
         if (!string.IsNullOrEmpty(request.SharedWithId))
         {
             // Targeted share (e.g. a Sales Rep publishing to a specific customer): persist the requested scope
@@ -43,7 +47,5 @@ public abstract class ScopedWishlistCommandHandlerBase<TCommand> : CartCommandHa
             _cartSharingService.EnsureSharingSettings(cartAggregate.Cart, null, CartSharingScope.Private, CartSharingAccess.Write);
             _cartSharingService.SetOwner(cartAggregate.Cart, request.WishlistUserContext.CurrentUserId, request.WishlistUserContext.CurrentContact.Name, null);
         }
-
-        return Task.CompletedTask;
     }
 }

--- a/src/VirtoCommerce.XCart.Data/Services/CartSharingService.cs
+++ b/src/VirtoCommerce.XCart.Data/Services/CartSharingService.cs
@@ -98,7 +98,13 @@ public class CartSharingService(ICartAggregateRepository cartAggregateRepository
         return cart.OrganizationId;
     }
 
-    public virtual void EnsureSharingSettings(ShoppingCart cart, string sharingKey, string mode, string access, string sharedWithId = null)
+    [Obsolete("Use the overload with sharedWithId (null for the built-in non-targeted scopes).", DiagnosticId = "VC0015", UrlFormat = "https://docs.virtocommerce.org/products/products-virto3-versions")]
+    public virtual void EnsureSharingSettings(ShoppingCart cart, string sharingKey, string mode, string access)
+    {
+        EnsureSharingSettings(cart, sharingKey, mode, access, sharedWithId: null);
+    }
+
+    public virtual void EnsureSharingSettings(ShoppingCart cart, string sharingKey, string mode, string access, string sharedWithId)
     {
         if (cart.SharingSettings.IsNullOrEmpty())
         {
@@ -129,9 +135,6 @@ public class CartSharingService(ICartAggregateRepository cartAggregateRepository
 
     public virtual Task UpdateScopeAsync(ShoppingCart cart, WishlistScopeContext context)
     {
-        // A null/empty scope means "don't touch sharing" (e.g. a rename-only edit); an unrecognized scope (ApplyScope
-        // returned false) is rejected. The base pipeline has no authorization concern — a module that introduces an
-        // authorizable scope overrides this method to gate it before delegating to base.
         if (!string.IsNullOrEmpty(context.Scope) && !ApplyScope(cart, context))
         {
             throw new InvalidOperationException($"Unsupported sharing scope '{context.Scope}'.");
@@ -140,28 +143,25 @@ public class CartSharingService(ICartAggregateRepository cartAggregateRepository
         return Task.CompletedTask;
     }
 
-    // Applies a recognized scope to the cart (sharing setting + owner) and returns true; returns false for a scope
-    // this pipeline does not know, which makes UpdateScopeAsync throw. A module that adds a scope overrides this,
-    // handles its own scope, and delegates the rest to base.
     protected virtual bool ApplyScope(ShoppingCart cart, WishlistScopeContext context)
     {
         if (CartSharingScope.AnyoneAnonymous.EqualsIgnoreCase(context.Scope))
         {
-            EnsureSharingSettings(cart, context.SharingKey, CartSharingScope.AnyoneAnonymous, CartSharingAccess.Read);
+            EnsureSharingSettings(cart, context.SharingKey, CartSharingScope.AnyoneAnonymous, CartSharingAccess.Read, sharedWithId: null);
             SetOwner(cart, context.CurrentUserId, context.CustomerName, null);
             return true;
         }
 
         if (CartSharingScope.Organization.EqualsIgnoreCase(context.Scope))
         {
-            EnsureSharingSettings(cart, context.SharingKey, CartSharingScope.Organization, CartSharingAccess.Write);
+            EnsureSharingSettings(cart, context.SharingKey, CartSharingScope.Organization, CartSharingAccess.Write, sharedWithId: null);
             SetOwner(cart, context.CurrentUserId, context.CustomerName, context.CurrentOrganizationId);
             return true;
         }
 
         if (CartSharingScope.Private.EqualsIgnoreCase(context.Scope))
         {
-            EnsureSharingSettings(cart, null, CartSharingScope.Private, CartSharingAccess.Write);
+            EnsureSharingSettings(cart, null, CartSharingScope.Private, CartSharingAccess.Write, sharedWithId: null);
             SetOwner(cart, context.CurrentUserId, context.CustomerName, null);
             return true;
         }

--- a/src/VirtoCommerce.XCart.Data/Services/CartSharingService.cs
+++ b/src/VirtoCommerce.XCart.Data/Services/CartSharingService.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using VirtoCommerce.CartModule.Core.Model;
+using VirtoCommerce.XCart.Core.Models;
 using VirtoCommerce.CartModule.Core.Model.Search;
 using VirtoCommerce.Platform.Core.Common;
 using VirtoCommerce.XCart.Core;
@@ -99,8 +100,6 @@ public class CartSharingService(ICartAggregateRepository cartAggregateRepository
 
     public virtual void EnsureSharingSettings(ShoppingCart cart, string sharingKey, string mode, string access, string sharedWithId = null)
     {
-        ValidateSharingSettings(mode, sharedWithId);
-
         if (cart.SharingSettings.IsNullOrEmpty())
         {
             var sharingSetting = AbstractTypeFactory<CartSharingSetting>.TryCreateInstance();
@@ -128,35 +127,46 @@ public class CartSharingService(ICartAggregateRepository cartAggregateRepository
         }
     }
 
-    public virtual Task AuthorizeSharingAsync(string scope, string sharedWithId, string currentUserId)
+    public virtual Task UpdateScopeAsync(ShoppingCart cart, WishlistScopeContext context)
     {
-        // The base pipeline has no targeted scope, so there is nothing caller-specific to authorize here; the
-        // structural guard in ValidateSharingSettings already rejects any target. A module that introduces a
-        // targeted scope overrides this to enforce who may target whom.
+        // A null/empty scope means "don't touch sharing" (e.g. a rename-only edit); an unrecognized scope (ApplyScope
+        // returned false) is rejected. The base pipeline has no authorization concern — a module that introduces an
+        // authorizable scope overrides this method to gate it before delegating to base.
+        if (!string.IsNullOrEmpty(context.Scope) && !ApplyScope(cart, context))
+        {
+            throw new InvalidOperationException($"Unsupported sharing scope '{context.Scope}'.");
+        }
+
         return Task.CompletedTask;
     }
 
-    // Structural validity of a sharing setting the pipeline is about to persist. The built-in scopes are all
-    // non-targeted, so a target is never allowed and the scope must be one the pipeline supports; a module that
-    // adds a targeted scope overrides this to accept it.
-    protected virtual void ValidateSharingSettings(string scope, string sharedWithId)
+    // Applies a recognized scope to the cart (sharing setting + owner) and returns true; returns false for a scope
+    // this pipeline does not know, which makes UpdateScopeAsync throw. A module that adds a scope overrides this,
+    // handles its own scope, and delegates the rest to base.
+    protected virtual bool ApplyScope(ShoppingCart cart, WishlistScopeContext context)
     {
-        if (!string.IsNullOrEmpty(sharedWithId))
+        if (CartSharingScope.AnyoneAnonymous.EqualsIgnoreCase(context.Scope))
         {
-            throw new InvalidOperationException($"Sharing scope '{scope}' does not support a shared-with target.");
+            EnsureSharingSettings(cart, context.SharingKey, CartSharingScope.AnyoneAnonymous, CartSharingAccess.Read);
+            SetOwner(cart, context.CurrentUserId, context.CustomerName, null);
+            return true;
         }
 
-        if (!string.IsNullOrEmpty(scope) && !IsSupportedScope(scope))
+        if (CartSharingScope.Organization.EqualsIgnoreCase(context.Scope))
         {
-            throw new InvalidOperationException($"Unsupported sharing scope '{scope}'.");
+            EnsureSharingSettings(cart, context.SharingKey, CartSharingScope.Organization, CartSharingAccess.Write);
+            SetOwner(cart, context.CurrentUserId, context.CustomerName, context.CurrentOrganizationId);
+            return true;
         }
-    }
 
-    protected virtual bool IsSupportedScope(string scope)
-    {
-        return scope.EqualsIgnoreCase(CartSharingScope.Private)
-            || scope.EqualsIgnoreCase(CartSharingScope.AnyoneAnonymous)
-            || scope.EqualsIgnoreCase(CartSharingScope.Organization);
+        if (CartSharingScope.Private.EqualsIgnoreCase(context.Scope))
+        {
+            EnsureSharingSettings(cart, null, CartSharingScope.Private, CartSharingAccess.Write);
+            SetOwner(cart, context.CurrentUserId, context.CustomerName, null);
+            return true;
+        }
+
+        return false;
     }
 
     public virtual async Task<CartAggregate> GetWishlistBySharingKeyAsync(string sharingKey, IList<string> includeFields)

--- a/src/VirtoCommerce.XCart.Data/Services/CartSharingService.cs
+++ b/src/VirtoCommerce.XCart.Data/Services/CartSharingService.cs
@@ -96,7 +96,7 @@ public class CartSharingService(ICartAggregateRepository cartAggregateRepository
         return cart.OrganizationId;
     }
 
-    public virtual void EnsureSharingSettings(ShoppingCart cart, string sharingKey, string mode, string access)
+    public virtual void EnsureSharingSettings(ShoppingCart cart, string sharingKey, string mode, string access, string sharedWithId = null)
     {
         if (cart.SharingSettings.IsNullOrEmpty())
         {
@@ -106,6 +106,7 @@ public class CartSharingService(ICartAggregateRepository cartAggregateRepository
             sharingSetting.ShoppingCartId = cart.Id;
             sharingSetting.Scope = mode;
             sharingSetting.Access = access;
+            sharingSetting.SharedWithId = sharedWithId;
 
             cart.SharingSettings.Add(sharingSetting);
         }
@@ -120,6 +121,7 @@ public class CartSharingService(ICartAggregateRepository cartAggregateRepository
 
             sharingSetting.Scope = mode;
             sharingSetting.Access = access;
+            sharingSetting.SharedWithId = sharedWithId;
         }
     }
 

--- a/src/VirtoCommerce.XCart.Data/Services/CartSharingService.cs
+++ b/src/VirtoCommerce.XCart.Data/Services/CartSharingService.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -98,6 +99,8 @@ public class CartSharingService(ICartAggregateRepository cartAggregateRepository
 
     public virtual void EnsureSharingSettings(ShoppingCart cart, string sharingKey, string mode, string access, string sharedWithId = null)
     {
+        ValidateSharingSettings(mode, sharedWithId);
+
         if (cart.SharingSettings.IsNullOrEmpty())
         {
             var sharingSetting = AbstractTypeFactory<CartSharingSetting>.TryCreateInstance();
@@ -123,6 +126,37 @@ public class CartSharingService(ICartAggregateRepository cartAggregateRepository
             sharingSetting.Access = access;
             sharingSetting.SharedWithId = sharedWithId;
         }
+    }
+
+    public virtual Task AuthorizeSharingAsync(string scope, string sharedWithId, string currentUserId)
+    {
+        // The base pipeline has no targeted scope, so there is nothing caller-specific to authorize here; the
+        // structural guard in ValidateSharingSettings already rejects any target. A module that introduces a
+        // targeted scope overrides this to enforce who may target whom.
+        return Task.CompletedTask;
+    }
+
+    // Structural validity of a sharing setting the pipeline is about to persist. The built-in scopes are all
+    // non-targeted, so a target is never allowed and the scope must be one the pipeline supports; a module that
+    // adds a targeted scope overrides this to accept it.
+    protected virtual void ValidateSharingSettings(string scope, string sharedWithId)
+    {
+        if (!string.IsNullOrEmpty(sharedWithId))
+        {
+            throw new InvalidOperationException($"Sharing scope '{scope}' does not support a shared-with target.");
+        }
+
+        if (!string.IsNullOrEmpty(scope) && !IsSupportedScope(scope))
+        {
+            throw new InvalidOperationException($"Unsupported sharing scope '{scope}'.");
+        }
+    }
+
+    protected virtual bool IsSupportedScope(string scope)
+    {
+        return scope.EqualsIgnoreCase(CartSharingScope.Private)
+            || scope.EqualsIgnoreCase(CartSharingScope.AnyoneAnonymous)
+            || scope.EqualsIgnoreCase(CartSharingScope.Organization);
     }
 
     public virtual async Task<CartAggregate> GetWishlistBySharingKeyAsync(string sharingKey, IList<string> includeFields)

--- a/src/VirtoCommerce.XCart.Web/module.manifest
+++ b/src/VirtoCommerce.XCart.Web/module.manifest
@@ -5,7 +5,7 @@
   <version-tag></version-tag>
   <platformVersion>3.1048.0</platformVersion>
   <dependencies>
-    <dependency id="VirtoCommerce.Cart" version="3.1007.0" />
+    <dependency id="VirtoCommerce.Cart" version="3.1008.0-alpha.803-vcst-5332-customer-wishlist-sharing-scope" />
     <dependency id="VirtoCommerce.Catalog" version="3.1029.0" />
     <dependency id="VirtoCommerce.FileExperienceApi" version="3.1003.0" />
     <dependency id="VirtoCommerce.Inventory" version="3.1003.0" />

--- a/src/VirtoCommerce.XCart.Web/module.manifest
+++ b/src/VirtoCommerce.XCart.Web/module.manifest
@@ -5,7 +5,7 @@
   <version-tag></version-tag>
   <platformVersion>3.1048.0</platformVersion>
   <dependencies>
-    <dependency id="VirtoCommerce.Cart" version="3.1008.0-alpha.803-vcst-5332-customer-wishlist-sharing-scope" />
+    <dependency id="VirtoCommerce.Cart" version="3.1008.0" />
     <dependency id="VirtoCommerce.Catalog" version="3.1029.0" />
     <dependency id="VirtoCommerce.FileExperienceApi" version="3.1003.0" />
     <dependency id="VirtoCommerce.Inventory" version="3.1003.0" />


### PR DESCRIPTION
## Description

Makes the wishlist-sharing pipeline **extensible** so downstream modules can add new sharing scopes without forking X-Cart, and surfaces the new `CartSharingSetting.SharedWithId` (added in the Cart PR) on the GraphQL wishlist API. VCST-5332 (Sales Rep "publish list to a customer") is the first consumer; this PR contains only the reusable platform-level seam, no Sales-Rep specifics.

Previously the create/change-wishlist handlers applied the sharing scope inline with a hard-coded `if (private) … else if (organization) … else if (anonymous) …` chain in `ScopedWishlistCommandHandlerBase`. A new scope could not be added without editing that base handler. This PR moves that logic behind `ICartSharingService` as a template-method seam a subclass can extend for exactly one arm.

**Behavior**
- **`sharedWithId` on the API.** New nullable field on `SharingSettingType` (output), `InputCreateWishlistType`/`InputChangeWishlistType` (input) and the `ScopedWishlistCommand` — carried through to the persisted setting. `WishlistType.ResolveSharingSetting` now projects `SharedWithId` back onto the read model. Existing queries/mutations are unchanged when the field is omitted (defaults to `null`).
- **`WishlistScopeContext`** (new Core model) — the DTO the sharing write path takes instead of a command: `Scope`, `SharingKey`, `SharedWithId`, `CurrentUserId`, `CustomerName`, `CurrentOrganizationId`. Constructed via `AbstractTypeFactory`, so it is itself extensible.
- **`ICartSharingService.UpdateScopeAsync(cart, WishlistScopeContext)`** — the single entry point that applies a scope to a cart. `CartSharingService` implements it as: if the scope is non-empty and `ApplyScope` doesn't recognize it, throw `InvalidOperationException("Unsupported sharing scope …")`.
- **`protected virtual bool ApplyScope(cart, context)`** — the override seam. The base handles `AnyoneAnonymous`, `Organization`, `Private` (each `EnsureSharingSettings` + `SetOwner`) and returns `false` for anything else. A subclass overrides one arm and delegates the rest to `base.ApplyScope`.
- **`ScopedWishlistCommandHandlerBase`** is now thin: it builds the context via a `protected virtual WishlistScopeContext CreateScopeContext(TCommand request)` (overridable) and calls `UpdateScopeAsync` — the inline scope `if`-chain is gone.
- **`EnsureSharingSettings` gains a `sharedWithId` overload.** The pre-existing 4-arg signature is kept and marked `[Obsolete(DiagnosticId = "VC0015", …)]`, delegating to the new 5-arg overload with `sharedWithId: null` — no breaking change for current callers (VC0015 pattern for a changed public signature).
- **`module.manifest`** dependency on `VirtoCommerce.Cart` bumped to the version that ships `SharedWithId` (MatchVersions-consistent with the csproj `PackageReference`).

### Examples:

Create a wishlist targeting a specific principal (the `scope`/`sharedWithId` id space is defined by whichever module owns the scope):

```graphql
mutation {
  createWishlist(
    command: {
      storeId: "B2B-store"
      name: "Recommended for Q3"
      scope: "Organization"
      sharedWithId: null
    }
  ) {
    id
    scope
    sharedWithId
  }
}
```

Read it back — `sharedWithId` is now part of the sharing settings:

```graphql
query {
  cart(storeId: "B2B-store", cartType: "Wishlist", cartId: "…") {
    sharingSettings { id scope access sharedWithId isOwner }
  }
}
```

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-5332
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.XCart_3.1029.0-pr-136-9189.zip