### PR TITLE
VCST-5691: Create ProductPrice with AbstractTypeFactory

### DIFF
--- a/src/VirtoCommerce.XCart.Core/CartAggregate.cs
+++ b/src/VirtoCommerce.XCart.Core/CartAggregate.cs
@@ -376,7 +376,7 @@ namespace VirtoCommerce.XCart.Core
 
             if (newCartItem.IsWishlist && newCartItem.CartProduct.Price == null)
             {
-                newCartItem.CartProduct.Price = new ProductPrice(Currency);
+                newCartItem.CartProduct.Price = AbstractTypeFactory<ProductPrice>.TryCreateInstance(nameof(ProductPrice), Currency);
             }
 
             var lineItem = _mapper.Map<LineItem>(newCartItem.CartProduct, options =>
@@ -992,7 +992,7 @@ namespace VirtoCommerce.XCart.Core
             EnsureCartExists();
 
             var validationContext = await _cartValidationContextFactory.CreateValidationContextAsync(this);
-            
+
 #pragma warning disable VC0009 // Obsolete overload is intentionally kept as the virtual extension point
             return await ValidateAsync(validationContext, ruleSet);
 #pragma warning restore VC0009

--- a/src/VirtoCommerce.XCart.Core/Models/CartProduct.cs
+++ b/src/VirtoCommerce.XCart.Core/Models/CartProduct.cs
@@ -79,12 +79,10 @@ namespace VirtoCommerce.XCart.Core.Models
             AllPrices = prices.Where(x => x.ProductId == Id)
                               .Select(x =>
                               {
-                                  var productPrice = new ProductPrice(currency)
-                                  {
-                                      PricelistId = x.PricelistId,
-                                      ListPrice = new Money(x.List, currency),
-                                      MinQuantity = x.MinQuantity
-                                  };
+                                  var productPrice = AbstractTypeFactory<ProductPrice>.TryCreateInstance(nameof(ProductPrice), currency);
+                                  productPrice.PricelistId = x.PricelistId;
+                                  productPrice.ListPrice = new Money(x.List, currency);
+                                  productPrice.MinQuantity = x.MinQuantity;
                                   productPrice.SalePrice = x.Sale == null ? productPrice.ListPrice : new Money(x.Sale.GetValueOrDefault(), currency);
 
                                   return productPrice;

--- a/src/VirtoCommerce.XCart.Core/VirtoCommerce.XCart.Core.csproj
+++ b/src/VirtoCommerce.XCart.Core/VirtoCommerce.XCart.Core.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <IsPackable>True</IsPackable>
@@ -17,7 +17,7 @@
     <PackageReference Include="VirtoCommerce.PaymentModule.Core" Version="3.1004.0" />
     <PackageReference Include="VirtoCommerce.PricingModule.Core" Version="3.1003.0" />
     <PackageReference Include="VirtoCommerce.ShippingModule.Core" Version="3.1005.0" />
-    <PackageReference Include="VirtoCommerce.Xapi.Core" Version="3.1018.0-alpha.195-vcst-5691" />
+    <PackageReference Include="VirtoCommerce.Xapi.Core" Version="3.1018.0" />
     <PackageReference Include="VirtoCommerce.XCatalog.Core" Version="3.1007.0" />
   </ItemGroup>
 </Project>

--- a/src/VirtoCommerce.XCart.Core/VirtoCommerce.XCart.Core.csproj
+++ b/src/VirtoCommerce.XCart.Core/VirtoCommerce.XCart.Core.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="VirtoCommerce.PaymentModule.Core" Version="3.1004.0" />
     <PackageReference Include="VirtoCommerce.PricingModule.Core" Version="3.1003.0" />
     <PackageReference Include="VirtoCommerce.ShippingModule.Core" Version="3.1005.0" />
-    <PackageReference Include="VirtoCommerce.Xapi.Core" Version="3.1015.0" />
+    <PackageReference Include="VirtoCommerce.Xapi.Core" Version="3.1018.0-alpha.195-vcst-5691" />
     <PackageReference Include="VirtoCommerce.XCatalog.Core" Version="3.1007.0" />
   </ItemGroup>
 </Project>

--- a/src/VirtoCommerce.XCart.Web/module.manifest
+++ b/src/VirtoCommerce.XCart.Web/module.manifest
@@ -13,7 +13,7 @@
     <dependency id="VirtoCommerce.Payment" version="3.1004.0" />
     <dependency id="VirtoCommerce.Pricing" version="3.1003.0" />
     <dependency id="VirtoCommerce.Shipping" version="3.1005.0" />
-    <dependency id="VirtoCommerce.Xapi" version="3.1015.0" />
+    <dependency id="VirtoCommerce.Xapi" version="3.1018.0-alpha.195-vcst-5691" />
     <dependency id="VirtoCommerce.XCatalog" version="3.1007.0" />
   </dependencies>
 

--- a/src/VirtoCommerce.XCart.Web/module.manifest
+++ b/src/VirtoCommerce.XCart.Web/module.manifest
@@ -13,7 +13,7 @@
     <dependency id="VirtoCommerce.Payment" version="3.1004.0" />
     <dependency id="VirtoCommerce.Pricing" version="3.1003.0" />
     <dependency id="VirtoCommerce.Shipping" version="3.1005.0" />
-    <dependency id="VirtoCommerce.Xapi" version="3.1018.0-alpha.195-vcst-5691" />
+    <dependency id="VirtoCommerce.Xapi" version="3.1018.0" />
     <dependency id="VirtoCommerce.XCatalog" version="3.1007.0" />
   </dependencies>
 

--- a/tests/VirtoCommerce.XCart.Tests/Helpers/XCartMoqHelper.cs
+++ b/tests/VirtoCommerce.XCart.Tests/Helpers/XCartMoqHelper.cs
@@ -86,6 +86,8 @@ namespace VirtoCommerce.XCart.Tests.Helpers
 
             _fixture.Register(() =>
             {
+                AbstractTypeFactory<Xapi.Core.Models.ProductPrice>.RegisterType<Xapi.Core.Models.ProductPrice>();
+
                 var catalogProduct = _fixture.Create<CatalogProduct>();
 
                 catalogProduct.TrackInventory = true;


### PR DESCRIPTION
## Description

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-5691
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.XCart_3.1030.0-pr-137-f70e.zip

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical factory swap on cart price construction with default type unchanged; low scope aside from normal pricing-path sensitivity.
> 
> **Overview**
> **ProductPrice** instances are no longer created with `new ProductPrice(...)` in cart pricing flows. **`CartAggregate`** (wishlist items with missing price) and **`CartProduct.ApplyPrices`** now use **`AbstractTypeFactory<ProductPrice>.TryCreateInstance`**, so extensions can substitute custom price types.
> 
> **VirtoCommerce.Xapi** is bumped to **3.1018.0** in the core project and **module.manifest** to align with the factory API. Tests register **`Xapi.Core.Models.ProductPrice`** on the factory in **`XCartMoqHelper`** so fixtures keep working.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f70e242a65695a78139806eaaf9e0993b2d0eb02. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->